### PR TITLE
fix(ci): reset version to 0.1.0 and fix Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         service:
           - api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,1 @@
 # CHANGELOG
-
-<!-- version list -->
-
-## v1.0.0 (2026-03-23)
-
-- Initial Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "knowledge-tree-workspace"
-version = "1.0.0"
+version = "0.1.0"
 description = "Knowledge Tree monorepo workspace"
 requires-python = ">=3.12"
 

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -14,7 +14,7 @@ COPY libs/ libs/
 COPY services/api/ services/api/
 
 # Install dependencies
-RUN cd services/api && uv sync --frozen --no-dev
+RUN cd services/api && uv sync --frozen --no-dev --package kt-api
 
 EXPOSE 8000
 

--- a/services/mcp/Dockerfile
+++ b/services/mcp/Dockerfile
@@ -14,7 +14,7 @@ COPY libs/ libs/
 COPY services/mcp/ services/mcp/
 
 # Install dependencies
-RUN cd services/mcp && uv sync --frozen --no-dev
+RUN cd services/mcp && uv sync --frozen --no-dev --package kt-mcp
 
 EXPOSE 8001
 

--- a/services/worker-conversations/Dockerfile
+++ b/services/worker-conversations/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-conversations/ services/worker-conversations/
 
-RUN cd services/worker-conversations && uv sync --frozen --no-dev
+RUN cd services/worker-conversations && uv sync --frozen --no-dev --package kt-worker-conversations
 
 CMD ["uv", "run", "--project", "services/worker-conversations", "-m", "kt_worker_conv"]

--- a/services/worker-ingest/Dockerfile
+++ b/services/worker-ingest/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-ingest/ services/worker-ingest/
 
-RUN cd services/worker-ingest && uv sync --frozen --no-dev
+RUN cd services/worker-ingest && uv sync --frozen --no-dev --package kt-worker-ingest
 
 CMD ["uv", "run", "--project", "services/worker-ingest", "-m", "kt_worker_ingest"]

--- a/services/worker-nodes/Dockerfile
+++ b/services/worker-nodes/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-nodes/ services/worker-nodes/
 
-RUN cd services/worker-nodes && uv sync --frozen --no-dev
+RUN cd services/worker-nodes && uv sync --frozen --no-dev --package kt-worker-nodes
 
 CMD ["uv", "run", "--project", "services/worker-nodes", "-m", "kt_worker_nodes"]

--- a/services/worker-orchestrator/Dockerfile
+++ b/services/worker-orchestrator/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-orchestrator/ services/worker-orchestrator/
 
-RUN cd services/worker-orchestrator && uv sync --frozen --no-dev
+RUN cd services/worker-orchestrator && uv sync --frozen --no-dev --package kt-worker-orchestrator
 
 CMD ["uv", "run", "--project", "services/worker-orchestrator", "-m", "kt_worker_orchestrator"]

--- a/services/worker-query/Dockerfile
+++ b/services/worker-query/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-query/ services/worker-query/
 
-RUN cd services/worker-query && uv sync --frozen --no-dev
+RUN cd services/worker-query && uv sync --frozen --no-dev --package kt-worker-query
 
 CMD ["uv", "run", "--project", "services/worker-query", "-m", "kt_worker_query"]

--- a/services/worker-search/Dockerfile
+++ b/services/worker-search/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-search/ services/worker-search/
 
-RUN cd services/worker-search && uv sync --frozen --no-dev
+RUN cd services/worker-search && uv sync --frozen --no-dev --package kt-worker-search
 
 CMD ["uv", "run", "--project", "services/worker-search", "-m", "kt_worker_search"]

--- a/services/worker-sync/Dockerfile
+++ b/services/worker-sync/Dockerfile
@@ -8,6 +8,6 @@ COPY pyproject.toml uv.lock ./
 COPY libs/ libs/
 COPY services/worker-sync/ services/worker-sync/
 
-RUN cd services/worker-sync && uv sync --frozen --no-dev
+RUN cd services/worker-sync && uv sync --frozen --no-dev --package kt-worker-sync
 
 CMD ["uv", "run", "--project", "services/worker-sync", "-m", "kt_worker_sync"]


### PR DESCRIPTION
## Summary

Fixes two issues from the initial release:

### 1. Version reset: v1.0.0 → v0.1.0

Semantic-release treated the initial release as a major bump (1.0.0) despite `major_on_zero = false`. This happened because there were no prior tags, so it defaulted to a major release.

- Reset `pyproject.toml` version to `0.1.0`
- Deleted the `v1.0.0` release and tag
- Reset `CHANGELOG.md`

After merge, a `v0.1.0` tag will be created manually as the baseline for future semantic-release runs.

### 2. Docker build failures

All 9 backend service builds failed with:
```
error: Failed to determine installation plan
  Caused by: Distribution not found at: file:///app/services/worker-conversations
```

Each Dockerfile copies only `libs/` and its own service, but `uv sync --frozen` tries to resolve ALL workspace members from `uv.lock`. 

**Fix:** Use `--package <name>` flag so uv only installs the target package and its dependencies:
```dockerfile
RUN uv sync --frozen --no-dev --package kt-api
```

### 3. Build matrix fail-fast disabled

Added `fail-fast: false` so one service's build failure doesn't cancel all other builds.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] After merge, manually create `v0.1.0` tag to trigger build pipeline
- [ ] All 11 Docker images build and push successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)