### PR TITLE
fix(helm): update image names to openktree- prefix

### DIFF
--- a/helm/knowledge-tree/Chart.yaml
+++ b/helm/knowledge-tree/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - knowledge-graph
   - ai
   - research
-home: https://github.com/love/knowledge-tree
+home: https://github.com/openktree/knowledge-tree
 
 dependencies:
   - name: cloudnative-pg

--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Secret name — use existing or chart-managed
 
 {{/*
 Image helper — resolves <registry>/<repo>:<tag> with per-component override
-Args: dict with .root (context), .image (component image block), .defaultName (e.g. "kt-api")
+Args: dict with .root (context), .image (component image block), .defaultName (e.g. "openktree-api")
 */}}
 {{- define "knowledge-tree.image" -}}
 {{- $registry := .root.Values.global.imageRegistry -}}

--- a/helm/knowledge-tree/templates/api-deployment.yaml
+++ b/helm/knowledge-tree/templates/api-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: api
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.api.image "defaultName" "kt-api") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.api.image "defaultName" "openktree-api") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.api.port }}

--- a/helm/knowledge-tree/templates/frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/frontend-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       {{- end }}
       containers:
         - name: frontend
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.frontend.image "defaultName" "kt-frontend") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.frontend.image "defaultName" "openktree-frontend") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.frontend.port }}

--- a/helm/knowledge-tree/templates/mcp-deployment.yaml
+++ b/helm/knowledge-tree/templates/mcp-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           command: ['sh', '-c', 'until nc -z {{ include "knowledge-tree.graphDbHost" . }} 5432; do echo "waiting for graph-db..."; sleep 2; done']
       containers:
         - name: mcp
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.mcp.image "defaultName" "kt-mcp") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.mcp.image "defaultName" "openktree-mcp") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.mcp.port }}

--- a/helm/knowledge-tree/templates/migration-job.yaml
+++ b/helm/knowledge-tree/templates/migration-job.yaml
@@ -48,7 +48,7 @@ spec:
                   key: password
       containers:
         - name: migrate
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.api.image "defaultName" "kt-api") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.api.image "defaultName" "openktree-api") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command:
             - sh

--- a/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       containers:
         - name: wiki-frontend
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.wikiFrontend.image "defaultName" "kt-wiki-frontend") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.wikiFrontend.image "defaultName" "openktree-wiki-frontend") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.wikiFrontend.port }}

--- a/helm/knowledge-tree/templates/worker-conversations-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-conversations-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.conversations.image "defaultName" "kt-worker-conversations") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.conversations.image "defaultName" "openktree-worker-conversations") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/templates/worker-ingest-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-ingest-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.ingest.image "defaultName" "kt-worker-ingest") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.ingest.image "defaultName" "openktree-worker-ingest") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/templates/worker-nodes-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-nodes-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.nodes.image "defaultName" "kt-worker-nodes") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.nodes.image "defaultName" "openktree-worker-nodes") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/templates/worker-orchestrator-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-orchestrator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.orchestrator.image "defaultName" "kt-worker-orchestrator") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.orchestrator.image "defaultName" "openktree-worker-orchestrator") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/templates/worker-query-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-query-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.query.image "defaultName" "kt-worker-query") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.query.image "defaultName" "openktree-worker-query") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/templates/worker-search-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-search-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.search.image "defaultName" "kt-worker-search") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.search.image "defaultName" "openktree-worker-search") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/templates/worker-sync-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-sync-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
       containers:
         - name: worker
-          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.sync.image "defaultName" "kt-worker-sync") }}
+          image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.sync.image "defaultName" "openktree-worker-sync") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -4,7 +4,7 @@ cnpg-operator:
 
 # -- Global settings
 global:
-  imageRegistry: ""
+  imageRegistry: "ghcr.io/openktree/knowledge-tree"
   imageTag: "latest"
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []


### PR DESCRIPTION
Rename all Helm template defaultName values from kt- prefix to openktree- prefix to match GHCR image names. Set global.imageRegistry default to ghcr.io/openktree/knowledge-tree. Update Chart.yaml home URL to https://github.com/openktree/knowledge-tree.