### PR TITLE
fix(helm): use CNPG-generated secrets for DB passwords

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -140,13 +140,13 @@ Outputs a list of env var definitions.
 - name: GRAPH_DB_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "knowledge-tree.secretName" . }}
-      key: graph-db-password
+      name: {{ default (printf "%s-credentials" (include "knowledge-tree.graphDbName" .)) .Values.graphDb.credentialsSecret }}
+      key: password
 - name: WRITE_DB_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "knowledge-tree.secretName" . }}
-      key: write-db-password
+      name: {{ default (printf "%s-credentials" (include "knowledge-tree.writeDbName" .)) .Values.writeDb.credentialsSecret }}
+      key: password
 - name: HATCHET_CLIENT_TOKEN
   valueFrom:
     secretKeyRef:

--- a/helm/knowledge-tree/templates/hatchet-deployment.yaml
+++ b/helm/knowledge-tree/templates/hatchet-deployment.yaml
@@ -32,8 +32,8 @@ spec:
             - name: HATCHET_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "knowledge-tree.secretName" . }}
-                  key: hatchet-db-password
+                  name: {{ default (printf "%s-credentials" (include "knowledge-tree.hatchetDbName" .)) .Values.hatchetDb.credentialsSecret }}
+                  key: password
             - name: DATABASE_URL
               value: "postgresql://hatchet:$(HATCHET_DB_PASSWORD)@{{ include "knowledge-tree.hatchetDbHost" . }}:5432/hatchet?sslmode=disable"
             - name: SERVER_AUTH_COOKIE_DOMAIN

--- a/helm/knowledge-tree/templates/secret.yaml
+++ b/helm/knowledge-tree/templates/secret.yaml
@@ -7,9 +7,6 @@ metadata:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  graph-db-password: {{ .Values.secrets.graphDbPassword | quote }}
-  write-db-password: {{ .Values.secrets.writeDbPassword | quote }}
-  hatchet-db-password: {{ .Values.secrets.hatchetDbPassword | quote }}
   openrouter-api-key: {{ .Values.secrets.openrouterApiKey | quote }}
   openai-api-key: {{ .Values.secrets.openaiApiKey | quote }}
   brave-key: {{ .Values.secrets.braveKey | quote }}

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -34,6 +34,7 @@ secrets:
 # CloudNativePG Databases
 # =============================================================================
 graphDb:
+  credentialsSecret: ""  # if empty, uses CNPG-generated secret
   instances: 1
   image: ghcr.io/cloudnative-pg/postgresql:16.8
   storage:
@@ -51,6 +52,7 @@ graphDb:
       memory: 2Gi
 
 writeDb:
+  credentialsSecret: ""  # if empty, uses CNPG-generated secret
   instances: 1
   image: ghcr.io/cloudnative-pg/postgresql:16
   storage:
@@ -66,6 +68,7 @@ writeDb:
       memory: 2Gi
 
 hatchetDb:
+  credentialsSecret: ""  # if empty, uses CNPG-generated secret
   instances: 1
   image: ghcr.io/cloudnative-pg/postgresql:16
   storage:


### PR DESCRIPTION
## Problem

The Helm chart reads DB passwords from the app secret (`knowledge-tree-secrets`), requiring users to manually synchronize passwords between CNPG and the app secret. This is error-prone and unnecessary since CNPG auto-generates credentials.

## Fix

Read DB passwords directly from CNPG-generated credential secrets:
- `GRAPH_DB_PASSWORD` ← `<fullname>-graph-db-credentials` → `password`
- `WRITE_DB_PASSWORD` ← `<fullname>-write-db-credentials` → `password`
- `HATCHET_DB_PASSWORD` ← `<fullname>-hatchet-db-credentials` → `password`

The app secret (`knowledge-tree-secrets`) now only needs:
- `openrouter-api-key`, `openai-api-key`, `brave-key`, `serper-key`
- `jwt-secret-key`
- `google-oauth-client-id`, `google-oauth-client-secret`
- `hatchet-client-token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)