### PR TITLE
fix: add missing runtime dependencies for Docker builds

### DIFF
--- a/libs/kt-agents-core/pyproject.toml
+++ b/libs/kt-agents-core/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "kt-models",
     "kt-providers",
     "kt-config",
+    "langchain-core>=0.3.0",
     "langgraph>=1.0.8",
     "langchain-openai>=1.1.9",
 ]

--- a/libs/kt-db/pyproject.toml
+++ b/libs/kt-db/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "sqlalchemy>=2.0.46",
     "asyncpg>=0.31.0",
     "alembic>=1.18.4",
+    "fastapi-users[sqlalchemy]>=15.0.4",
 ]
 
 [build-system]

--- a/libs/kt-facts/pyproject.toml
+++ b/libs/kt-facts/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "kt-db",
     "kt-models",
+    "kt-providers",
     "metaphone>=0.6",
     "numpy>=2.4.2",
     "scipy>=1.17.1",
@@ -18,6 +19,7 @@ build-backend = "hatchling.build"
 [tool.uv.sources]
 kt-db = { workspace = true }
 kt-models = { workspace = true }
+kt-providers = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/libs/kt-hatchet/pyproject.toml
+++ b/libs/kt-hatchet/pyproject.toml
@@ -10,8 +10,11 @@ dependencies = [
     "kt-ontology",
     "kt-config",
     "kt-qdrant",
+    "kt-agents-core",
     "hatchet-sdk>=1.26.0",
     "python-dotenv>=1.0.0",
+    "langchain-core>=0.3.0",
+    "langgraph>=1.0.8",
 ]
 
 [build-system]
@@ -25,6 +28,7 @@ kt-providers = { workspace = true }
 kt-ontology = { workspace = true }
 kt-config = { workspace = true }
 kt-qdrant = { workspace = true }
+kt-agents-core = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/libs/kt-models/pyproject.toml
+++ b/libs/kt-models/pyproject.toml
@@ -5,9 +5,11 @@ description = "Knowledge Tree AI model gateway, embeddings, and LangChain adapte
 requires-python = ">=3.12"
 dependencies = [
     "kt-config",
+    "kt-db",
     "litellm>=1.81.11",
     "tiktoken>=0.12.0",
     "langchain-openai>=1.1.9",
+    "langsmith>=0.7.14",
 ]
 
 [build-system]
@@ -16,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 kt-config = { workspace = true }
+kt-db = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/libs/kt-ontology/pyproject.toml
+++ b/libs/kt-ontology/pyproject.toml
@@ -6,6 +6,8 @@ requires-python = ">=3.12"
 dependencies = [
     "kt-db",
     "kt-config",
+    "kt-graph",
+    "kt-models",
     "httpx>=0.28.1",
     "redis>=5.0.0",
 ]
@@ -17,6 +19,8 @@ build-backend = "hatchling.build"
 [tool.uv.sources]
 kt-db = { workspace = true }
 kt-config = { workspace = true }
+kt-graph = { workspace = true }
+kt-models = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/libs/kt-providers/pyproject.toml
+++ b/libs/kt-providers/pyproject.toml
@@ -5,9 +5,11 @@ description = "Knowledge Tree search providers and content fetcher"
 requires-python = ">=3.12"
 dependencies = [
     "kt-config",
+    "kt-agents-core",
     "httpx>=0.28.1",
     "trafilatura>=2.0.0",
     "pydantic>=2.12.5",
+    "structlog>=25.5.0",
 ]
 
 [build-system]
@@ -16,6 +18,7 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 kt-config = { workspace = true }
+kt-agents-core = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/services/worker-ingest/Dockerfile
+++ b/services/worker-ingest/Dockerfile
@@ -23,6 +23,9 @@ COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
 # Copy this service's source
 COPY services/worker-ingest/ services/worker-ingest/
 
+# Copy cross-dependency sources
+COPY services/worker-orchestrator/ services/worker-orchestrator/
+
 # Install dependencies
 RUN uv sync --frozen --no-dev --package kt-worker-ingest
 

--- a/services/worker-ingest/pyproject.toml
+++ b/services/worker-ingest/pyproject.toml
@@ -12,7 +12,10 @@ dependencies = [
     "kt-graph",
     "kt-facts",
     "kt-config",
+    "kt-worker-orchestrator",
     "pymupdf>=1.27.1",
+    "langchain-core>=0.3.0",
+    "langgraph>=1.0.8",
 ]
 
 [build-system]
@@ -28,6 +31,7 @@ kt-providers = { workspace = true }
 kt-graph = { workspace = true }
 kt-facts = { workspace = true }
 kt-config = { workspace = true }
+kt-worker-orchestrator = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/services/worker-nodes/pyproject.toml
+++ b/services/worker-nodes/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "kt-ontology",
     "kt-config",
     "kt-worker-orchestrator",
+    "langchain-core>=0.3.0",
+    "langgraph>=1.0.8",
 ]
 
 [build-system]

--- a/services/worker-orchestrator/Dockerfile
+++ b/services/worker-orchestrator/Dockerfile
@@ -23,6 +23,10 @@ COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
 # Copy this service's source
 COPY services/worker-orchestrator/ services/worker-orchestrator/
 
+# Copy cross-dependency sources
+COPY services/worker-nodes/ services/worker-nodes/
+COPY services/worker-query/ services/worker-query/
+
 # Install dependencies
 RUN uv sync --frozen --no-dev --package kt-worker-orchestrator
 

--- a/services/worker-orchestrator/pyproject.toml
+++ b/services/worker-orchestrator/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "kt-facts",
     "kt-ontology",
     "kt-config",
+    "kt-worker-nodes",
+    "kt-worker-query",
+    "langchain-core>=0.3.0",
+    "langgraph>=1.0.8",
 ]
 
 [build-system]
@@ -29,6 +33,8 @@ kt-graph = { workspace = true }
 kt-facts = { workspace = true }
 kt-ontology = { workspace = true }
 kt-config = { workspace = true }
+kt-worker-nodes = { workspace = true }
+kt-worker-query = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/services/worker-query/Dockerfile
+++ b/services/worker-query/Dockerfile
@@ -23,6 +23,9 @@ COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
 # Copy this service's source
 COPY services/worker-query/ services/worker-query/
 
+# Copy cross-dependency sources
+COPY services/worker-orchestrator/ services/worker-orchestrator/
+
 # Install dependencies
 RUN uv sync --frozen --no-dev --package kt-worker-query
 

--- a/services/worker-query/pyproject.toml
+++ b/services/worker-query/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "kt-providers",
     "kt-graph",
     "kt-config",
+    "kt-worker-orchestrator",
+    "langchain-core>=0.3.0",
+    "langgraph>=1.0.8",
 ]
 
 [build-system]
@@ -25,6 +28,7 @@ kt-models = { workspace = true }
 kt-providers = { workspace = true }
 kt-graph = { workspace = true }
 kt-config = { workspace = true }
+kt-worker-orchestrator = { workspace = true }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -1629,7 +1629,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-tree-workspace"
-version = "0.1.0"
+version = "0.1.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1667,6 +1667,7 @@ dependencies = [
     { name = "kt-graph" },
     { name = "kt-models" },
     { name = "kt-providers" },
+    { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
 ]
@@ -1677,6 +1678,7 @@ requires-dist = [
     { name = "kt-graph", editable = "libs/kt-graph" },
     { name = "kt-models", editable = "libs/kt-models" },
     { name = "kt-providers", editable = "libs/kt-providers" },
+    { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=1.1.9" },
     { name = "langgraph", specifier = ">=1.0.8" },
 ]
@@ -1760,6 +1762,7 @@ source = { editable = "libs/kt-db" }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "kt-config" },
     { name = "sqlalchemy" },
 ]
@@ -1768,6 +1771,7 @@ dependencies = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "fastapi-users", extras = ["sqlalchemy"], specifier = ">=15.0.4" },
     { name = "kt-config", editable = "libs/kt-config" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
 ]
@@ -1779,6 +1783,7 @@ source = { editable = "libs/kt-facts" }
 dependencies = [
     { name = "kt-db" },
     { name = "kt-models" },
+    { name = "kt-providers" },
     { name = "metaphone" },
     { name = "numpy" },
     { name = "scipy" },
@@ -1788,6 +1793,7 @@ dependencies = [
 requires-dist = [
     { name = "kt-db", editable = "libs/kt-db" },
     { name = "kt-models", editable = "libs/kt-models" },
+    { name = "kt-providers", editable = "libs/kt-providers" },
     { name = "metaphone", specifier = ">=0.6" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "scipy", specifier = ">=1.17.1" },
@@ -1816,24 +1822,30 @@ version = "0.1.0"
 source = { editable = "libs/kt-hatchet" }
 dependencies = [
     { name = "hatchet-sdk" },
+    { name = "kt-agents-core" },
     { name = "kt-config" },
     { name = "kt-db" },
     { name = "kt-models" },
     { name = "kt-ontology" },
     { name = "kt-providers" },
     { name = "kt-qdrant" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
     { name = "python-dotenv" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "hatchet-sdk", specifier = ">=1.26.0" },
+    { name = "kt-agents-core", editable = "libs/kt-agents-core" },
     { name = "kt-config", editable = "libs/kt-config" },
     { name = "kt-db", editable = "libs/kt-db" },
     { name = "kt-models", editable = "libs/kt-models" },
     { name = "kt-ontology", editable = "libs/kt-ontology" },
     { name = "kt-providers", editable = "libs/kt-providers" },
     { name = "kt-qdrant", editable = "libs/kt-qdrant" },
+    { name = "langchain-core", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=1.0.8" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
@@ -1870,7 +1882,9 @@ version = "0.1.0"
 source = { editable = "libs/kt-models" }
 dependencies = [
     { name = "kt-config" },
+    { name = "kt-db" },
     { name = "langchain-openai" },
+    { name = "langsmith" },
     { name = "litellm" },
     { name = "tiktoken" },
 ]
@@ -1878,7 +1892,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "kt-config", editable = "libs/kt-config" },
+    { name = "kt-db", editable = "libs/kt-db" },
     { name = "langchain-openai", specifier = ">=1.1.9" },
+    { name = "langsmith", specifier = ">=0.7.14" },
     { name = "litellm", specifier = ">=1.81.11" },
     { name = "tiktoken", specifier = ">=0.12.0" },
 ]
@@ -1891,6 +1907,8 @@ dependencies = [
     { name = "httpx" },
     { name = "kt-config" },
     { name = "kt-db" },
+    { name = "kt-graph" },
+    { name = "kt-models" },
     { name = "redis" },
 ]
 
@@ -1899,6 +1917,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kt-config", editable = "libs/kt-config" },
     { name = "kt-db", editable = "libs/kt-db" },
+    { name = "kt-graph", editable = "libs/kt-graph" },
+    { name = "kt-models", editable = "libs/kt-models" },
     { name = "redis", specifier = ">=5.0.0" },
 ]
 
@@ -1908,16 +1928,20 @@ version = "0.1.0"
 source = { editable = "libs/kt-providers" }
 dependencies = [
     { name = "httpx" },
+    { name = "kt-agents-core" },
     { name = "kt-config" },
     { name = "pydantic" },
+    { name = "structlog" },
     { name = "trafilatura" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "kt-agents-core", editable = "libs/kt-agents-core" },
     { name = "kt-config", editable = "libs/kt-config" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "structlog", specifier = ">=25.5.0" },
     { name = "trafilatura", specifier = ">=2.0.0" },
 ]
 
@@ -2001,6 +2025,9 @@ dependencies = [
     { name = "kt-hatchet" },
     { name = "kt-models" },
     { name = "kt-providers" },
+    { name = "kt-worker-orchestrator" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
     { name = "pymupdf" },
 ]
 
@@ -2014,6 +2041,9 @@ requires-dist = [
     { name = "kt-hatchet", editable = "libs/kt-hatchet" },
     { name = "kt-models", editable = "libs/kt-models" },
     { name = "kt-providers", editable = "libs/kt-providers" },
+    { name = "kt-worker-orchestrator", editable = "services/worker-orchestrator" },
+    { name = "langchain-core", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=1.0.8" },
     { name = "pymupdf", specifier = ">=1.27.1" },
 ]
 
@@ -2032,6 +2062,8 @@ dependencies = [
     { name = "kt-ontology" },
     { name = "kt-providers" },
     { name = "kt-worker-orchestrator" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
 ]
 
 [package.metadata]
@@ -2046,6 +2078,8 @@ requires-dist = [
     { name = "kt-ontology", editable = "libs/kt-ontology" },
     { name = "kt-providers", editable = "libs/kt-providers" },
     { name = "kt-worker-orchestrator", editable = "services/worker-orchestrator" },
+    { name = "langchain-core", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=1.0.8" },
 ]
 
 [[package]]
@@ -2062,6 +2096,10 @@ dependencies = [
     { name = "kt-models" },
     { name = "kt-ontology" },
     { name = "kt-providers" },
+    { name = "kt-worker-nodes" },
+    { name = "kt-worker-query" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
 ]
 
 [package.metadata]
@@ -2075,6 +2113,10 @@ requires-dist = [
     { name = "kt-models", editable = "libs/kt-models" },
     { name = "kt-ontology", editable = "libs/kt-ontology" },
     { name = "kt-providers", editable = "libs/kt-providers" },
+    { name = "kt-worker-nodes", editable = "services/worker-nodes" },
+    { name = "kt-worker-query", editable = "services/worker-query" },
+    { name = "langchain-core", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=1.0.8" },
 ]
 
 [[package]]
@@ -2089,6 +2131,9 @@ dependencies = [
     { name = "kt-hatchet" },
     { name = "kt-models" },
     { name = "kt-providers" },
+    { name = "kt-worker-orchestrator" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
 ]
 
 [package.metadata]
@@ -2100,6 +2145,9 @@ requires-dist = [
     { name = "kt-hatchet", editable = "libs/kt-hatchet" },
     { name = "kt-models", editable = "libs/kt-models" },
     { name = "kt-providers", editable = "libs/kt-providers" },
+    { name = "kt-worker-orchestrator", editable = "services/worker-orchestrator" },
+    { name = "langchain-core", specifier = ">=0.3.0" },
+    { name = "langgraph", specifier = ">=1.0.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Docker images fail at runtime with `ModuleNotFoundError` because several packages import modules that aren't declared in their `pyproject.toml`. These work in dev (shared venv with all transitive deps) but fail in Docker (isolated `--package` installs).

## Errors observed in dev cluster

- MCP: `ModuleNotFoundError: No module named 'fastapi_users'`
- Workers: `ModuleNotFoundError: No module named 'structlog'`
- Various: missing `langchain-core`, `langgraph`, `langsmith`

## Fix

Added all missing dependencies across 11 pyproject.toml files. Updated Dockerfiles for services with cross-service dependencies to copy the required source code.

See commit message for the full list of additions per package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)