### PR TITLE
fix(helm): fix hatchet token job and add token init container

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -218,3 +218,28 @@ Init container waiting for graph-db and Hatchet
   image: busybox:1.36
   command: ['sh', '-c', 'until nc -z {{ include "knowledge-tree.fullname" . }}-hatchet 7070; do echo "waiting for hatchet..."; sleep 2; done']
 {{- end }}
+
+{{/*
+Init container that blocks until the Hatchet client token is a valid JWT.
+On first install the token job may not have run yet; the init container will
+CrashLoopBackOff until the secret is patched, which is the k8s-native way
+to wait for a dependency.
+*/}}
+{{- define "knowledge-tree.initWaitForToken" -}}
+- name: wait-for-hatchet-token
+  image: busybox:1.36
+  env:
+    - name: HATCHET_CLIENT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "knowledge-tree.secretName" . }}
+          key: hatchet-client-token
+  command:
+    - sh
+    - -c
+    - |
+      case "$HATCHET_CLIENT_TOKEN" in
+        eyJ*) echo "Valid Hatchet client token found"; exit 0 ;;
+        *) echo "Waiting for Hatchet token job to generate a valid token..."; exit 1 ;;
+      esac
+{{- end }}

--- a/helm/knowledge-tree/templates/api-deployment.yaml
+++ b/helm/knowledge-tree/templates/api-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: api
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.api.image "defaultName" "openktree-api") }}

--- a/helm/knowledge-tree/templates/hatchet-token-job.yaml
+++ b/helm/knowledge-tree/templates/hatchet-token-job.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: post-install
     helm.sh/hook-weight: "5"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
@@ -109,8 +109,8 @@ spec:
             - name: HATCHET_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "knowledge-tree.secretName" . }}
-                  key: hatchet-db-password
+                  name: {{ default (printf "%s-credentials" (include "knowledge-tree.hatchetDbName" .)) .Values.hatchetDb.credentialsSecret }}
+                  key: password
             - name: DATABASE_URL
               value: "postgresql://hatchet:$(HATCHET_DB_PASSWORD)@{{ include "knowledge-tree.hatchetDbHost" . }}:5432/hatchet?sslmode=disable"
 {{- end }}

--- a/helm/knowledge-tree/templates/hatchet-token-rbac.yaml
+++ b/helm/knowledge-tree/templates/hatchet-token-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: post-install
     helm.sh/hook-weight: "4"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 ---
@@ -17,7 +17,7 @@ metadata:
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: post-install
     helm.sh/hook-weight: "4"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 rules:
@@ -36,7 +36,7 @@ metadata:
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook: post-install
     helm.sh/hook-weight: "4"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 subjects:

--- a/helm/knowledge-tree/templates/mcp-deployment.yaml
+++ b/helm/knowledge-tree/templates/mcp-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - name: wait-for-graph-db
           image: busybox:1.36
           command: ['sh', '-c', 'until nc -z {{ include "knowledge-tree.graphDbHost" . }} 5432; do echo "waiting for graph-db..."; sleep 2; done']
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: mcp
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.mcp.image "defaultName" "openktree-mcp") }}

--- a/helm/knowledge-tree/templates/worker-conversations-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-conversations-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.conversations.image "defaultName" "openktree-worker-conversations") }}

--- a/helm/knowledge-tree/templates/worker-ingest-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-ingest-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.ingest.image "defaultName" "openktree-worker-ingest") }}

--- a/helm/knowledge-tree/templates/worker-nodes-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-nodes-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.nodes.image "defaultName" "openktree-worker-nodes") }}

--- a/helm/knowledge-tree/templates/worker-orchestrator-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-orchestrator-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.orchestrator.image "defaultName" "openktree-worker-orchestrator") }}

--- a/helm/knowledge-tree/templates/worker-query-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-query-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.query.image "defaultName" "openktree-worker-query") }}

--- a/helm/knowledge-tree/templates/worker-search-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-search-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.search.image "defaultName" "openktree-worker-search") }}

--- a/helm/knowledge-tree/templates/worker-sync-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-sync-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       {{- end }}
       initContainers:
         {{- include "knowledge-tree.initWaitContainers" . | nindent 8 }}
+        {{- include "knowledge-tree.initWaitForToken" . | nindent 8 }}
       containers:
         - name: worker
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.workers.sync.image "defaultName" "openktree-worker-sync") }}


### PR DESCRIPTION
## Problem

1. Hatchet token job reads DB password from app secret (`knowledge-tree-secrets`) which no longer contains DB passwords (moved to CNPG secrets in #10)
2. Token job runs on every upgrade unnecessarily — token only needs generating once
3. Workers crash immediately if the token hasn't been generated yet, with no graceful retry

## Fix

### Token job
- Hook changed to `post-install` only (not `post-upgrade`) — token persists in the secret
- DB password now read from CNPG credential secret (`<cluster>-credentials`)

### Init container
- New `initWaitForToken` helper added to `_helpers.tpl`
- Checks if `hatchet-client-token` in the secret is a valid JWT (starts with `eyJ`)
- Added to all 9 service deployments as an init container
- Pods will restart until the token job patches the secret, then proceed normally

### Startup sequence
```
1. CNPG databases start → credentials secrets created
2. Hatchet starts (reads DB password from CNPG secret)
3. Token job runs (post-install) → generates JWT → patches app secret
4. Init containers detect valid JWT → services start
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)