### PR TITLE
fix(helm): make hatchet token job a regular resource

### DIFF
--- a/helm/knowledge-tree/templates/hatchet-token-job.yaml
+++ b/helm/knowledge-tree/templates/hatchet-token-job.yaml
@@ -5,10 +5,7 @@ metadata:
   name: {{ include "knowledge-tree.fullname" . }}-hatchet-token
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "5"
-    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+  annotations: {}
 spec:
   backoffLimit: {{ .Values.hatchet.tokenJob.backoffLimit }}
   activeDeadlineSeconds: 300

--- a/helm/knowledge-tree/templates/hatchet-token-rbac.yaml
+++ b/helm/knowledge-tree/templates/hatchet-token-rbac.yaml
@@ -5,10 +5,6 @@ metadata:
   name: {{ include "knowledge-tree.fullname" . }}-hatchet-token
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "4"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -16,10 +12,6 @@ metadata:
   name: {{ include "knowledge-tree.fullname" . }}-hatchet-token
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "4"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -35,10 +27,6 @@ metadata:
   name: {{ include "knowledge-tree.fullname" . }}-hatchet-token
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "4"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
 subjects:
   - kind: ServiceAccount
     name: {{ include "knowledge-tree.fullname" . }}-hatchet-token


### PR DESCRIPTION
## Problem

The hatchet token job was a `post-install` Helm hook, creating a deadlock:
1. Helm waits for all pods to be ready before running post-install hooks
2. Workers wait for a valid hatchet token (init container)
3. Token job (post-install hook) never runs because workers aren't ready
4. Timeout → install fails

## Fix

Remove all `helm.sh/hook` annotations. The token job and its RBAC are now regular resources deployed alongside everything else.

**Startup sequence:**
```
Helm deploys all resources simultaneously
  → DBs start (CNPG)
  → Hatchet starts (waits for hatchet-db)
  → Token job starts (init container waits for Hatchet)
  → Token job generates JWT, patches secret, restarts workers
  → Workers' init containers detect valid JWT → start
```

No deadlock — everything is self-resolving via init containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)