### PR TITLE
feat(helm): add hatchet UI port and configurable admin credentials

### DIFF
--- a/helm/knowledge-tree/templates/hatchet-deployment.yaml
+++ b/helm/knowledge-tree/templates/hatchet-deployment.yaml
@@ -54,6 +54,18 @@ spec:
               value: {{ default (printf "http://%s-hatchet:8080" (include "knowledge-tree.fullname" .)) .Values.hatchet.serverUrl | quote }}
             - name: SERVER_AUTH_SET_EMAIL_VERIFIED
               value: "t"
+            - name: ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "knowledge-tree.secretName" . }}
+                  key: hatchet-admin-email
+                  optional: true
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "knowledge-tree.secretName" . }}
+                  key: hatchet-admin-password
+                  optional: true
             - name: SERVER_FLUSH_PERIOD_MILLISECONDS
               value: "250"
           livenessProbe:

--- a/helm/knowledge-tree/templates/hatchet-service.yaml
+++ b/helm/knowledge-tree/templates/hatchet-service.yaml
@@ -15,5 +15,9 @@ spec:
       targetPort: 7070
       name: grpc
       protocol: TCP
+    - port: 8888
+      targetPort: 8888
+      name: ui
+      protocol: TCP
   selector:
     {{- include "knowledge-tree.componentSelectorLabels" (dict "root" . "component" "hatchet") | nindent 4 }}

--- a/helm/knowledge-tree/templates/secret.yaml
+++ b/helm/knowledge-tree/templates/secret.yaml
@@ -15,4 +15,6 @@ stringData:
   google-oauth-client-id: {{ .Values.secrets.googleOauthClientId | quote }}
   google-oauth-client-secret: {{ .Values.secrets.googleOauthClientSecret | quote }}
   hatchet-client-token: {{ .Values.secrets.hatchetClientToken | quote }}
+  hatchet-admin-email: {{ .Values.secrets.hatchetAdminEmail | quote }}
+  hatchet-admin-password: {{ .Values.secrets.hatchetAdminPassword | quote }}
 {{- end }}

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -27,8 +27,12 @@ secrets:
   googleOauthClientId: ""
   googleOauthClientSecret: ""
 
-  # Leave empty to auto-generate via Helm hook job
+  # Leave empty to auto-generate via token job
   hatchetClientToken: ""
+
+  # Hatchet admin credentials (used for initial seed)
+  hatchetAdminEmail: "admin@example.com"
+  hatchetAdminPassword: "Admin123!!"
 
 # =============================================================================
 # CloudNativePG Databases


### PR DESCRIPTION
## Changes

These were part of PR #14's force push but didn't make it into the merge.

### 1. Hatchet service UI port
Add port 8888 to the hatchet service — this is where the UI is served (8080 is the API).

### 2. Configurable admin credentials
Add `ADMIN_EMAIL` and `ADMIN_PASSWORD` env vars to hatchet deployment, read from the app secret:
- `hatchet-admin-email` (default: `admin@example.com`)
- `hatchet-admin-password` (default: `Admin123!!`)

Both are `optional: true` so existing secrets without these keys still work.

When using `existingSecret`, add these keys to your secret for custom admin credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)