### PR TITLE
fix(helm): configure runtime API URLs for frontends

### DIFF
--- a/helm/knowledge-tree/frontend/Dockerfile
+++ b/helm/knowledge-tree/frontend/Dockerfile
@@ -12,8 +12,8 @@ FROM base AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY frontend/ ./
-# NEXT_PUBLIC_* vars must be set at build time
-ARG NEXT_PUBLIC_API_URL=""
+# Build with placeholder — replaced at runtime via entrypoint
+ARG NEXT_PUBLIC_API_URL="__NEXT_PUBLIC_API_URL_PLACEHOLDER__"
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 RUN pnpm build
 
@@ -27,8 +27,21 @@ COPY --from=build /app/public ./public
 COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Entrypoint script to replace API URL placeholder at runtime
+RUN cat <<'SCRIPT' > /app/entrypoint.sh
+#!/bin/sh
+set -e
+if [ -n "$NEXT_PUBLIC_API_URL" ] && [ "$NEXT_PUBLIC_API_URL" != "__NEXT_PUBLIC_API_URL_PLACEHOLDER__" ]; then
+  echo "Replacing API URL placeholder with: $NEXT_PUBLIC_API_URL"
+  find /app/.next -name '*.js' -exec sed -i "s|__NEXT_PUBLIC_API_URL_PLACEHOLDER__|$NEXT_PUBLIC_API_URL|g" {} +
+  find /app -maxdepth 1 -name '*.js' -exec sed -i "s|__NEXT_PUBLIC_API_URL_PLACEHOLDER__|$NEXT_PUBLIC_API_URL|g" {} +
+fi
+exec node server.js
+SCRIPT
+RUN chmod +x /app/entrypoint.sh
+
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-CMD ["node", "server.js"]
+CMD ["/app/entrypoint.sh"]

--- a/helm/knowledge-tree/templates/frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/frontend-deployment.yaml
@@ -30,6 +30,10 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.frontend.port | quote }}
+            {{- if .Values.frontend.env.NEXT_PUBLIC_API_URL }}
+            - name: NEXT_PUBLIC_API_URL
+              value: {{ .Values.frontend.env.NEXT_PUBLIC_API_URL | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
@@ -31,10 +31,8 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.wikiFrontend.port | quote }}
-            {{- if .Values.wikiFrontend.env.PUBLIC_API_URL }}
-            - name: PUBLIC_API_URL
-              value: {{ .Values.wikiFrontend.env.PUBLIC_API_URL | quote }}
-            {{- end }}
+            - name: API_BASE_URL
+              value: "http://{{ include "knowledge-tree.fullname" . }}-api:{{ .Values.api.port }}"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Problem

The Next.js frontend calls `http://localhost:8000` because `NEXT_PUBLIC_API_URL` is baked in at build time as empty.

## Fix

### Frontend (Next.js — client-side)
- Dockerfile builds with a **placeholder** (`__NEXT_PUBLIC_API_URL_PLACEHOLDER__`)
- Entrypoint script replaces the placeholder in JS bundles at container startup using `NEXT_PUBLIC_API_URL` env var
- Helm deployment passes the env var from values (set to public DNS per environment)
- Browser makes API calls to the public endpoint (e.g., `https://api.openktree-dev.com`)

### Wiki-frontend (Astro — SSR)
- `API_BASE_URL` set to the in-cluster API service URL (`http://knowledge-tree-api:8000`)
- Astro reads `process.env` at runtime, no build-time baking needed
- Server-side fetch goes directly to the API pod (fast, no hairpin DNS)

### What goes where
| Component | API URL | Why |
|---|---|---|
| Frontend (browser JS) | `https://api.openktree-dev.com` | Public DNS, browser can't reach cluster IPs |
| Wiki-frontend (SSR) | `http://knowledge-tree-api:8000` | In-cluster, no TLS overhead |
| MCP, Workers | In-cluster via shared env | Already configured correctly |

🤖 Generated with [Claude Code](https://claude.com/claude-code)