### PR TITLE
fix(helm): fix DB connection — env var ordering for $(VAR) substitution

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -125,6 +125,16 @@ Shared environment variables for all Python services.
 Outputs a list of env var definitions.
 */}}
 {{- define "knowledge-tree.sharedEnv" -}}
+- name: GRAPH_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (printf "%s-credentials" (include "knowledge-tree.graphDbName" .)) .Values.graphDb.credentialsSecret }}
+      key: password
+- name: WRITE_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ default (printf "%s-credentials" (include "knowledge-tree.writeDbName" .)) .Values.writeDb.credentialsSecret }}
+      key: password
 - name: DATABASE_URL
   value: "postgresql+asyncpg://kt:$(GRAPH_DB_PASSWORD)@{{ include "knowledge-tree.graphDbHost" . }}:5432/knowledge_tree"
 - name: WRITE_DATABASE_URL
@@ -137,16 +147,6 @@ Outputs a list of env var definitions.
   value: "{{ include "knowledge-tree.fullname" . }}-hatchet:7070"
 - name: HATCHET_CLIENT_TLS_STRATEGY
   value: "none"
-- name: GRAPH_DB_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ default (printf "%s-credentials" (include "knowledge-tree.graphDbName" .)) .Values.graphDb.credentialsSecret }}
-      key: password
-- name: WRITE_DB_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ default (printf "%s-credentials" (include "knowledge-tree.writeDbName" .)) .Values.writeDb.credentialsSecret }}
-      key: password
 - name: HATCHET_CLIENT_TOKEN
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Problem

API and all workers fail to connect to databases:
```
asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "kt"
```

The `DATABASE_URL` env var contains the literal string `$(GRAPH_DB_PASSWORD)` instead of the actual password.

## Root cause

Kubernetes `$(VAR)` substitution requires the referenced variable to be defined **before** the variable that uses it in the `env` list. The Helm template had:

```yaml
- name: DATABASE_URL                    # line 1: uses $(GRAPH_DB_PASSWORD)
  value: "...://kt:$(GRAPH_DB_PASSWORD)@..."
- name: GRAPH_DB_PASSWORD               # line 10: defined too late!
  valueFrom: ...
```

## Fix

Move `GRAPH_DB_PASSWORD` and `WRITE_DB_PASSWORD` to the top of the shared env block, before `DATABASE_URL` and `WRITE_DATABASE_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)