### PR TITLE
fix: fix system settings timezone error and CORS for credentials

### DIFF
--- a/helm/knowledge-tree/templates/api-deployment.yaml
+++ b/helm/knowledge-tree/templates/api-deployment.yaml
@@ -32,6 +32,10 @@ spec:
               protocol: TCP
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}
+            {{- if .Values.api.corsOrigins }}
+            - name: CORS_ORIGINS
+              value: {{ .Values.api.corsOrigins | quote }}
+            {{- end }}
           volumeMounts:
             {{- include "knowledge-tree.configVolumeMount" . | nindent 12 }}
           livenessProbe:

--- a/libs/kt-db/src/kt_db/repositories/system_settings.py
+++ b/libs/kt-db/src/kt_db/repositories/system_settings.py
@@ -12,7 +12,7 @@ from kt_db.models import SystemSetting
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class SystemSettingsRepository:

--- a/services/api/src/kt_api/main.py
+++ b/services/api/src/kt_api/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -12,6 +13,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from kt_api.router import api_router
 
 logger = logging.getLogger(__name__)
+
+
+def _get_cors_origins() -> list[str]:
+    origins = os.environ.get("CORS_ORIGINS", "")
+    if origins:
+        return [o.strip() for o in origins.split(",") if o.strip()]
+    return ["*"]
+
 
 # Suppress noisy LiteLLM debug output ("Provider List: ..." on every call)
 logging.getLogger("LiteLLM").setLevel(logging.WARNING)
@@ -60,9 +69,10 @@ def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(title="Knowledge Tree", version="0.1.0", lifespan=lifespan)
 
+    origins = _get_cors_origins()
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/uv.lock
+++ b/uv.lock
@@ -1629,7 +1629,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-tree-workspace"
-version = "0.1.7"
+version = "0.2.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Problems

### 1. System settings PATCH returns 500
```
asyncpg.exceptions.DataError: can't subtract offset-naive and offset-aware datetimes
```
The `_utcnow()` helper returns a timezone-aware datetime but the DB column is `TIMESTAMP WITHOUT TIME ZONE`.

### 2. CORS blocks cross-origin requests
```
Access to fetch at 'https://api.openktree-dev.com/api/v1/system-settings' from origin
'https://research.openktree-dev.com' has been blocked by CORS policy
```
`allow_origins=["*"]` with `allow_credentials=True` is rejected by browsers — explicit origins are required.

## Fix

- Strip tzinfo from `_utcnow()` to produce a naive UTC datetime matching the column type
- Add `CORS_ORIGINS` env var — comma-separated list of allowed origins (falls back to `*` for backwards compat)
- Add `api.corsOrigins` to Helm values

Dev overlay should set:
```yaml
api:
  corsOrigins: "https://research.openktree-dev.com,https://wiki.openktree-dev.com"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)