### PR TITLE
fix(helm): persist Hatchet config to PVC — fixes token invalidation on restart

### DIFF
--- a/helm/knowledge-tree/templates/hatchet-deployment.yaml
+++ b/helm/knowledge-tree/templates/hatchet-deployment.yaml
@@ -28,6 +28,9 @@ spec:
             - containerPort: 7070
               name: grpc
               protocol: TCP
+            - containerPort: 8888
+              name: ui
+              protocol: TCP
           env:
             - name: HATCHET_DB_PASSWORD
               valueFrom:
@@ -68,6 +71,9 @@ spec:
                   optional: true
             - name: SERVER_FLUSH_PERIOD_MILLISECONDS
               value: "250"
+          volumeMounts:
+            - name: hatchet-config
+              mountPath: /config
           livenessProbe:
             httpGet:
               path: /api/live
@@ -82,3 +88,22 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.hatchet.resources | nindent 12 }}
+      volumes:
+        - name: hatchet-config
+          persistentVolumeClaim:
+            claimName: {{ include "knowledge-tree.fullname" . }}-hatchet-config
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "knowledge-tree.fullname" . }}-hatchet-config
+  labels:
+    {{- include "knowledge-tree.componentLabels" (dict "root" . "component" "hatchet") | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
## Problem

Every time the Hatchet pod restarts, it generates **new JWT signing keys**, invalidating all existing worker tokens. Workers get `UNAUTHENTICATED: invalid auth token` and enter CrashLoopBackOff, requiring manual token regeneration.

## Root cause

Hatchet-lite stores its generated config (JWT keysets, cookie secrets, master encryption key) in `/config/server.yaml` inside the container's ephemeral filesystem. Pod restart = new keys = all tokens invalid.

## Fix

Mount a 100Mi PVC at `/config` so `server.yaml` persists across restarts. Keys are generated once on first boot and reused on subsequent starts.

The PVC has `helm.sh/resource-policy: keep` so it's never deleted by Helm.

After this fix:
- Hatchet pod restarts → same keys → tokens remain valid → workers stay healthy
- No more manual `just hatchet-token` after every deployment
- Token job (#19) can also be re-enabled since it will share the same keys

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)