### PR TITLE
fix(helm): add pod affinity to token job for shared RWO PVC

### DIFF
--- a/helm/knowledge-tree/templates/hatchet-token-job.yaml
+++ b/helm/knowledge-tree/templates/hatchet-token-job.yaml
@@ -17,6 +17,13 @@ spec:
     spec:
       serviceAccountName: {{ include "knowledge-tree.fullname" . }}-hatchet-token
       restartPolicy: OnFailure
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "knowledge-tree.componentSelectorLabels" (dict "root" . "component" "hatchet") | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
       volumes:
         - name: hatchet-config
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary

- Add `podAffinity` to the Hatchet token job so it schedules on the same node as the Hatchet StatefulSet pod

The shared config PVC uses `ReadWriteOnce` access mode, which means it can only be attached to one node. Without affinity, the token job pod may land on a different node and fail with `Multi-Attach error`.

Follows up on #28.

## Test plan

- [x] `helm template` renders affinity block correctly
- [ ] Token job pod schedules on same node as `knowledge-tree-hatchet-0`
- [ ] Token generates successfully and patches the secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)