### PR TITLE
fix(helm): use version_variables for Chart.yaml version bumping

### DIFF
--- a/helm/knowledge-tree/Chart.yaml
+++ b/helm/knowledge-tree/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knowledge-tree
 description: Knowledge Tree - AI knowledge integration system
 type: application
-version: 0.2.6
-appVersion: "0.2.6"
+version: 0.2.10
+appVersion: "0.2.10"
 keywords:
   - knowledge-graph
   - ai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ dev-dependencies = [
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-version_pattern = [
-    'helm/knowledge-tree/Chart.yaml:^version: (?P<version>.+)',
-    'helm/knowledge-tree/Chart.yaml:^appVersion: "(?P<version>.+)"',
+version_variables = [
+    "helm/knowledge-tree/Chart.yaml:version",
+    "helm/knowledge-tree/Chart.yaml:appVersion",
 ]
 branch = "main"
 commit_message = "chore(release): v{version}"


### PR DESCRIPTION
## Summary

The `version_pattern` config key doesn't exist in python-semantic-release. Chart.yaml has been stuck at `0.2.6` while pyproject.toml advanced to `0.2.10`.

Fix: use `version_variables` (the correct config key for non-TOML files) and sync Chart.yaml to current version `0.2.10`.

Ref: [python-semantic-release docs](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html)

## Test plan

- [ ] Next release bumps both `pyproject.toml` and `Chart.yaml`
- [ ] Flux picks up new chart version and triggers pod rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)