### PR TITLE
fix(helm): restore corrupted subchart versions, fix Chart.yaml sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: semantic-release version --push --tag --changelog --vcs-release
+
+      - name: Sync Chart.yaml version
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          CHART_VERSION=$(grep '^version:' helm/knowledge-tree/Chart.yaml | awk '{print $2}')
+          if [ "$VERSION" != "$CHART_VERSION" ]; then
+            sed -i "s/^version: .*/version: ${VERSION}/" helm/knowledge-tree/Chart.yaml
+            sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" helm/knowledge-tree/Chart.yaml
+            git config user.name "semantic-release"
+            git config user.email "semantic-release@users.noreply.github.com"
+            git add helm/knowledge-tree/Chart.yaml
+            git commit --amend --no-edit
+            git push --force-with-lease origin main
+          fi

--- a/helm/knowledge-tree/Chart.yaml
+++ b/helm/knowledge-tree/Chart.yaml
@@ -12,9 +12,9 @@ home: https://github.com/openktree/knowledge-tree
 
 dependencies:
   - name: cloudnative-pg
-    version: "0.2.11"
+    version: "0.23.0"
     repository: "https://cloudnative-pg.github.io/charts"
     condition: cnpg-operator.enabled
   - name: qdrant
-    version: "0.2.11"
+    version: "1.17.0"
     repository: "https://qdrant.github.io/qdrant-helm/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,6 @@ dev-dependencies = [
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-version_variables = [
-    "helm/knowledge-tree/Chart.yaml:version",
-    "helm/knowledge-tree/Chart.yaml:appVersion",
-]
 branch = "main"
 commit_message = "chore(release): v{version}"
 tag_format = "v{version}"


### PR DESCRIPTION
## Summary

**URGENT:** `version_variables` replaced ALL `version:` fields in Chart.yaml, corrupting subchart dependency versions:
- `cloudnative-pg: "0.23.0"` → `"0.2.11"` 
- `qdrant: "1.17.0"` → `"0.2.11"`

This PR:
1. Restores correct subchart versions
2. Removes `version_variables` from semantic-release config
3. Adds a targeted `sed` step in the release workflow that only bumps top-level `version` and `appVersion`

## Test plan

- [x] Chart.yaml subchart versions restored
- [ ] Next release bumps only top-level version/appVersion
- [ ] Helm upgrade succeeds with correct subchart versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)