### PR TITLE
fix(kt-facts): improve seed dedup LLM prompt and stop disambiguation cascade

### DIFF
--- a/libs/kt-facts/src/kt_facts/processing/seed_dedup.py
+++ b/libs/kt-facts/src/kt_facts/processing/seed_dedup.py
@@ -255,12 +255,13 @@ async def deduplicate_seed(
                         model_gateway=model_gateway,
                     )
                     if not confirmed:
-                        # LLM says different — create embedding-ambiguity routes
-                        await _create_embedding_disambiguation(
-                            seed_key,
-                            match.seed_key,
+                        # LLM says different — just skip. Disambiguation trees
+                        # are reserved for genuine homonyms detected by fact
+                        # clustering in seed_disambiguation.py.
+                        logger.info(
+                            "LLM merge gate rejected: '%s' vs '%s' — keeping separate",
+                            name,
                             matched_seed.name,
-                            write_seed_repo,
                         )
                         continue  # try next candidate
 
@@ -580,16 +581,30 @@ async def _llm_confirm_merge(
     facts_a_str = "\n".join(f"  - {f}" for f in incoming_facts_text) if incoming_facts_text else "  (no facts yet)"
     facts_b_str = "\n".join(f"  - {f}" for f in candidate_facts_text) if candidate_facts_text else "  (no facts yet)"
 
+    # Compute string similarity to give LLM context on how close the names are
+    d = edit_distance(incoming_name.lower(), candidate_name.lower())
+    max_len = max(len(incoming_name), len(candidate_name))
+    string_sim_pct = int((1.0 - d / max_len) * 100) if max_len else 100
+
     prompt = (
-        "Are these two knowledge-graph seeds the SAME concept/entity?\n"
-        "Be STRICT — only confirm for synonyms, abbreviations, or "
-        "different-specificity names for the same thing. "
-        "Related-but-distinct concepts = NOT same.\n\n"
+        "Two knowledge-graph seeds matched by high embedding similarity. "
+        f"Their names are {string_sim_pct}% identical by edit distance. "
+        "Determine whether they refer to the SAME concept/entity.\n\n"
+        "MERGE (same_entity=true) when:\n"
+        '- Singular/plural forms ("neural network" / "neural networks")\n'
+        '- Synonyms or abbreviations ("LLM" / "large language model")\n'
+        '- Grammatical variants ("photosynthesis" / "photosynthetic process")\n'
+        '- Same concept at different specificity ("ML" / "machine learning")\n\n'
+        "DO NOT MERGE (same_entity=false) when:\n"
+        "- Distinct processes sharing terminology "
+        '("light-dependent reactions" / "light-independent reactions")\n'
+        '- Different subdisciplines ("deep learning" / "reinforcement learning")\n'
+        '- Different entities with the same name ("Mercury" planet vs element)\n\n'
         f'Seed A: "{incoming_name}"\n'
         f"Facts:\n{facts_a_str}\n\n"
         f'Seed B: "{candidate_name}"\n'
         f"Facts:\n{facts_b_str}\n\n"
-        'JSON: {"same_entity": bool, "preferred_name": "more specific name or null"}'
+        'JSON: {"same_entity": bool, "preferred_name": "more canonical form or null"}'
     )
 
     try:

--- a/libs/kt-facts/tests/test_seed_dedup.py
+++ b/libs/kt-facts/tests/test_seed_dedup.py
@@ -1144,8 +1144,8 @@ class TestLLMConfirmMerge:
         # LLM SHOULD have been called (academic initials guard blocks auto-merge)
         model_gw.generate_json.assert_called_once()
 
-    async def test_llm_rejects_creates_anchor(self):
-        """LLM says different → existing becomes disambiguation anchor."""
+    async def test_llm_rejects_skips_without_disambiguation(self):
+        """LLM says different → seeds kept separate, no disambiguation tree."""
         repo = make_seed_repo_mock()
         existing = make_seed(
             "concept:light-dependent-reactions",
@@ -1192,8 +1192,9 @@ class TestLLMConfirmMerge:
         )
         # Should NOT have merged
         repo.merge_seeds.assert_not_called()
-        # Should have created disambiguation (split_seed called)
-        repo.split_seed.assert_called_once()
+        # Should NOT create disambiguation tree — just skip
+        repo.split_seed.assert_not_called()
+        repo.create_route.assert_not_called()
 
     async def test_llm_unavailable_auto_merges(self):
         """Without model_gateway, Signal 1 auto-merges (backward compat)."""


### PR DESCRIPTION
## Summary

- **Rewrote the LLM merge gate prompt** in `_llm_confirm_merge()` — the old prompt said "Be STRICT" which biased the LLM toward rejecting valid merges (e.g., singular/plural pairs like "large language model" vs "large language models"). The new prompt provides explicit MERGE/DO NOT MERGE categories with concrete examples and includes string similarity percentage to anchor the decision.
- **Stopped creating disambiguation trees on LLM rejection** — when the LLM said "not same", the system called `_create_embedding_disambiguation()` which converted seeds into ambiguous parents with routing children. This cascaded (`:disambig:disambig:disambig`...), producing 79 routes across 4 levels for what should be a single concept. Now LLM rejection just skips the candidate. Genuine homonym disambiguation is handled by fact clustering in `seed_disambiguation.py`.

## Investigation

Queried the write-db and found:
- `concept:large-language-model` (ambiguous, 156 facts) and `concept:large-language-models` (ambiguous, 1349 facts) both exist as separate seeds
- 79 embedding disambiguation routes across 4 levels deep, all `ambiguity_type=embedding`
- The cascade happened because each new related seed hit the disambiguation tree and created another layer

## Test plan

- [x] Updated `test_llm_rejects_creates_anchor` → `test_llm_rejects_skips_without_disambiguation` to verify seeds are kept separate without creating disambiguation trees
- [x] All 336 kt-facts unit tests pass
- [ ] Monitor LLM merge gate logs after deployment to verify improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)