### PR TITLE
fix(ci): re-tag after Chart.yaml sync to prevent orphaned release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,7 @@ jobs:
             git add helm/knowledge-tree/Chart.yaml
             git commit --amend --no-edit
             git push --force-with-lease origin main
+            # Move the tag to the amended commit so it stays in main's history
+            git tag -f "v${VERSION}"
+            git push --force origin "v${VERSION}"
           fi


### PR DESCRIPTION
## Summary

Fixes the Sync Chart.yaml version step in release.yml to re-tag after the amend+force-push, preventing the release tag from being orphaned.

## Root cause

The step amends the release commit and force-pushes to main, but the tag still points to the original (now-orphaned) commit. Subsequent semantic-release runs see the tag exists but can't find releasable commits since the tag isn't in main's ancestry:

```
No release will be made, 0.2.12 has already been released!
```

This broke all releases since v0.2.12 — PRs #35 and #36 are merged but not deployed.

## Fix

Added two lines after the force push to move the tag to the amended commit:
```yaml
git tag -f "v${VERSION}"
git push --force origin "v${VERSION}"
```

## Manual step required after merge

Re-point the orphaned v0.2.12 tag to the correct commit on main:
```bash
git tag -f v0.2.12 38a0906
git push --force origin v0.2.12
```

This unblocks the next release (v0.2.13) which will include PRs #35 and #36.