### PR TITLE
feat(frontend): add incremental refresh to node rebuild menu

### DIFF
--- a/frontend/src/components/node/NodeDetailPanel.tsx
+++ b/frontend/src/components/node/NodeDetailPanel.tsx
@@ -175,6 +175,9 @@ export default function NodeDetailPanel({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="start">
+                    <DropdownMenuItem onClick={() => rebuildNode("incremental", "all")}>
+                      Incremental Refresh
+                    </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => rebuildNode("full", "all")}>
                       Full Rebuild
                     </DropdownMenuItem>
@@ -248,7 +251,7 @@ export default function NodeDetailPanel({
                     variant="outline"
                     size="sm"
                     className="mt-1.5 h-6 text-xs gap-1 border-amber-300 text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300"
-                    onClick={() => rebuildNode("full", "all")}
+                    onClick={() => rebuildNode("incremental", "all")}
                     disabled={isRebuilding}
                   >
                     <Sparkles className={cn("h-3 w-3", isRebuilding && "animate-spin")} />


### PR DESCRIPTION
## Summary
- Add "Incremental Refresh" option to the node rebuild dropdown in `NodeDetailPanel`. This uses `mode: "incremental"` which generates only new dimension batches from facts accumulated since the last build, without wiping existing dimensions.
- Change the stub/partial "Build Node" button from `full` to `incremental` mode, matching the auto-build pipeline behavior.

## Context
The backend already supports `mode: "incremental"` in `rebuild_node`, but the frontend only exposed `full` mode. Incremental is the appropriate default for routine refreshes and first-time stub builds.

## Test plan
- [ ] Verify "Incremental Refresh" appears as first item in rebuild dropdown
- [ ] Verify clicking it dispatches with `mode=incremental, scope=all`
- [ ] Verify "Build Node" button on stub nodes dispatches incremental mode
- [ ] Verify existing Full Rebuild / Rebuild Dimensions / Rebuild Edges still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)