### PR TITLE
fix(ci): use semantic-release build_command for Chart.yaml sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,22 +38,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: semantic-release version --push --tag --changelog --vcs-release
-
-      - name: Sync Chart.yaml version
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          CHART_VERSION=$(grep '^version:' helm/knowledge-tree/Chart.yaml | awk '{print $2}')
-          if [ "$VERSION" != "$CHART_VERSION" ]; then
-            sed -i "s/^version: .*/version: ${VERSION}/" helm/knowledge-tree/Chart.yaml
-            sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" helm/knowledge-tree/Chart.yaml
-            git config user.name "semantic-release"
-            git config user.email "semantic-release@users.noreply.github.com"
-            git add helm/knowledge-tree/Chart.yaml
-            git commit --amend --no-edit
-            git push --force-with-lease origin main
-            # Move the tag to the amended commit so it stays in main's history
-            git tag -f "v${VERSION}"
-            git push --force origin "v${VERSION}"
-          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ commit_message = "chore(release): v{version}"
 tag_format = "v{version}"
 major_on_zero = false
 allow_zero_version = true
+build_command = "sed -i \"s/^version: .*/version: ${version}/;s/^appVersion: .*/appVersion: \\\"${version}\\\"/\" helm/knowledge-tree/Chart.yaml && git add helm/knowledge-tree/Chart.yaml"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf"]


### PR DESCRIPTION
## Summary
- Moves Helm Chart.yaml version sync from a post-push amend+force-push step into semantic-release's `build_command`, which runs before the release commit is created
- Eliminates the `git commit --amend` + `git push --force-with-lease` pattern that failed with "stale info" when the local tracking ref was outdated after semantic-release's push
- Chart.yaml is now updated and staged as part of the release commit itself — no separate step needed

## Test plan
- [ ] Merge a `feat` or `fix` commit to main and verify the release workflow succeeds
- [ ] Confirm Chart.yaml version and appVersion are updated in the release commit
- [ ] Verify the git tag points to a commit that includes the Chart.yaml changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)