### PR TITLE
fix(ci): use correct env var NEW_VERSION in build_command

### DIFF
--- a/helm/knowledge-tree/Chart.yaml
+++ b/helm/knowledge-tree/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: knowledge-tree
 description: Knowledge Tree - AI knowledge integration system
 type: application
-version: 
-appVersion: ""
+version: 0.4.1
+appVersion: "0.4.1"
 keywords:
   - knowledge-graph
   - ai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ commit_message = "chore(release): v{version}"
 tag_format = "v{version}"
 major_on_zero = false
 allow_zero_version = true
-build_command = "sed -i \"s/^version: .*/version: ${version}/;s/^appVersion: .*/appVersion: \\\"${version}\\\"/\" helm/knowledge-tree/Chart.yaml && git add helm/knowledge-tree/Chart.yaml"
+build_command = "sed -i \"s/^version: .*/version: ${NEW_VERSION}/;s/^appVersion: .*/appVersion: \\\"${NEW_VERSION}\\\"/\" helm/knowledge-tree/Chart.yaml && git add helm/knowledge-tree/Chart.yaml"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "perf"]


### PR DESCRIPTION
## Summary
- Fixes `build_command` to use `$NEW_VERSION` (the env var python-semantic-release actually sets) instead of `$version` (which was unset, blanking Chart.yaml)
- Restores Chart.yaml version/appVersion to 0.4.1 (was blanked by the broken build_command in v0.4.1)

## Test plan
- [ ] Merge and verify the release workflow creates v0.4.2 with correct Chart.yaml version/appVersion values
- [ ] Confirm `version:` and `appVersion:` in Chart.yaml match the released version

🤖 Generated with [Claude Code](https://claude.com/claude-code)