### PR TITLE
fix(docker): update Dockerfiles for renamed worker services

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -12,13 +12,12 @@ COPY libs/ libs/
 COPY services/api/pyproject.toml services/api/pyproject.toml
 COPY services/mcp/pyproject.toml services/mcp/pyproject.toml
 COPY services/worker-all/pyproject.toml services/worker-all/pyproject.toml
-COPY services/worker-conversations/pyproject.toml services/worker-conversations/pyproject.toml
+COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-ingest/pyproject.toml services/worker-ingest/pyproject.toml
 COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
-COPY services/worker-orchestrator/pyproject.toml services/worker-orchestrator/pyproject.toml
-COPY services/worker-query/pyproject.toml services/worker-query/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/api/ services/api/

--- a/services/mcp/Dockerfile
+++ b/services/mcp/Dockerfile
@@ -12,13 +12,12 @@ COPY libs/ libs/
 COPY services/api/pyproject.toml services/api/pyproject.toml
 COPY services/mcp/pyproject.toml services/mcp/pyproject.toml
 COPY services/worker-all/pyproject.toml services/worker-all/pyproject.toml
-COPY services/worker-conversations/pyproject.toml services/worker-conversations/pyproject.toml
+COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-ingest/pyproject.toml services/worker-ingest/pyproject.toml
 COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
-COPY services/worker-orchestrator/pyproject.toml services/worker-orchestrator/pyproject.toml
-COPY services/worker-query/pyproject.toml services/worker-query/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/mcp/ services/mcp/

--- a/services/worker-bottomup/Dockerfile
+++ b/services/worker-bottomup/Dockerfile
@@ -17,6 +17,7 @@ COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
 COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/worker-bottomup/ services/worker-bottomup/

--- a/services/worker-ingest/Dockerfile
+++ b/services/worker-ingest/Dockerfile
@@ -12,13 +12,12 @@ COPY libs/ libs/
 COPY services/api/pyproject.toml services/api/pyproject.toml
 COPY services/mcp/pyproject.toml services/mcp/pyproject.toml
 COPY services/worker-all/pyproject.toml services/worker-all/pyproject.toml
-COPY services/worker-conversations/pyproject.toml services/worker-conversations/pyproject.toml
+COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-ingest/pyproject.toml services/worker-ingest/pyproject.toml
 COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
-COPY services/worker-orchestrator/pyproject.toml services/worker-orchestrator/pyproject.toml
-COPY services/worker-query/pyproject.toml services/worker-query/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/worker-ingest/ services/worker-ingest/

--- a/services/worker-nodes/Dockerfile
+++ b/services/worker-nodes/Dockerfile
@@ -12,13 +12,12 @@ COPY libs/ libs/
 COPY services/api/pyproject.toml services/api/pyproject.toml
 COPY services/mcp/pyproject.toml services/mcp/pyproject.toml
 COPY services/worker-all/pyproject.toml services/worker-all/pyproject.toml
-COPY services/worker-conversations/pyproject.toml services/worker-conversations/pyproject.toml
+COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-ingest/pyproject.toml services/worker-ingest/pyproject.toml
 COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
-COPY services/worker-orchestrator/pyproject.toml services/worker-orchestrator/pyproject.toml
-COPY services/worker-query/pyproject.toml services/worker-query/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/worker-nodes/ services/worker-nodes/

--- a/services/worker-search/Dockerfile
+++ b/services/worker-search/Dockerfile
@@ -12,13 +12,12 @@ COPY libs/ libs/
 COPY services/api/pyproject.toml services/api/pyproject.toml
 COPY services/mcp/pyproject.toml services/mcp/pyproject.toml
 COPY services/worker-all/pyproject.toml services/worker-all/pyproject.toml
-COPY services/worker-conversations/pyproject.toml services/worker-conversations/pyproject.toml
+COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-ingest/pyproject.toml services/worker-ingest/pyproject.toml
 COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
-COPY services/worker-orchestrator/pyproject.toml services/worker-orchestrator/pyproject.toml
-COPY services/worker-query/pyproject.toml services/worker-query/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/worker-search/ services/worker-search/

--- a/services/worker-sync/Dockerfile
+++ b/services/worker-sync/Dockerfile
@@ -12,13 +12,12 @@ COPY libs/ libs/
 COPY services/api/pyproject.toml services/api/pyproject.toml
 COPY services/mcp/pyproject.toml services/mcp/pyproject.toml
 COPY services/worker-all/pyproject.toml services/worker-all/pyproject.toml
-COPY services/worker-conversations/pyproject.toml services/worker-conversations/pyproject.toml
+COPY services/worker-bottomup/pyproject.toml services/worker-bottomup/pyproject.toml
 COPY services/worker-ingest/pyproject.toml services/worker-ingest/pyproject.toml
 COPY services/worker-nodes/pyproject.toml services/worker-nodes/pyproject.toml
-COPY services/worker-orchestrator/pyproject.toml services/worker-orchestrator/pyproject.toml
-COPY services/worker-query/pyproject.toml services/worker-query/pyproject.toml
 COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
+COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
 # Copy this service's source
 COPY services/worker-sync/ services/worker-sync/


### PR DESCRIPTION
## Summary
- Remove references to deleted services (`worker-conversations`, `worker-orchestrator`, `worker-query`) from all 6 existing Dockerfiles
- Add `worker-bottomup` and `worker-synthesis` to the workspace member list in all Dockerfiles
- Add missing `worker-synthesis` entry to `worker-bottomup/Dockerfile`

This fixes all Docker build failures since v0.4.0 (when PR #39 replaced orchestrator/query with synthesis agents).

## Test plan
- [ ] Merge and verify the Build & Push workflow succeeds for all backend services
- [ ] Verify Docker images are pushed to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)