### PR TITLE
fix(api): inline _conversation_to_response after conversations module removal

### DIFF
--- a/services/api/src/kt_api/export.py
+++ b/services/api/src/kt_api/export.py
@@ -170,7 +170,7 @@ async def _fetch_embeddings(
 
 
 def _conv_to_response(conv: object) -> ConversationResponse:
-    from kt_api.conversations import _conversation_to_response
+    from kt_api.research import _conversation_to_response
 
     return _conversation_to_response(conv)
 

--- a/services/api/src/kt_api/research.py
+++ b/services/api/src/kt_api/research.py
@@ -28,6 +28,7 @@ from kt_api.schemas import (
     BottomUpProposedPerspective,
     BottomUpSourceUrl,
     ChunkInfoResponse,
+    ConversationMessageResponse,
     ConversationResponse,
     IngestBuildRequest,
     IngestBuildResponse,
@@ -40,6 +41,7 @@ from kt_api.schemas import (
     ProposedNodeAmbiguityResponse,
     ResearchSeedResponse,
     ResearchSummaryResponse,
+    SubgraphResponse,
 )
 from kt_config.settings import get_settings
 from kt_db.models import User
@@ -79,11 +81,42 @@ def _resolve_mime(upload: UploadFile) -> str | None:
     return None
 
 
+def _message_to_response(msg: Any) -> ConversationMessageResponse:
+    """Convert a ConversationMessage ORM model to response schema."""
+    subgraph = None
+    if msg.subgraph:
+        subgraph = SubgraphResponse(**msg.subgraph)
+    return ConversationMessageResponse(
+        id=str(msg.id),
+        turn_number=msg.turn_number,
+        role=msg.role,
+        content=msg.content,
+        nav_budget=msg.nav_budget,
+        explore_budget=msg.explore_budget,
+        nav_used=msg.nav_used,
+        explore_used=msg.explore_used,
+        visited_nodes=msg.visited_nodes,
+        created_nodes=msg.created_nodes,
+        created_edges=msg.created_edges,
+        subgraph=subgraph,
+        status=msg.status,
+        error=msg.error,
+        workflow_run_id=getattr(msg, "workflow_run_id", None),
+        created_at=msg.created_at,
+    )
+
+
 def _conversation_to_response(conv: Any, messages: list[Any] | None = None) -> ConversationResponse:
     """Convert a Conversation ORM model to response schema."""
-    from kt_api.conversations import _conversation_to_response as _orig
-
-    return _orig(conv, messages)
+    msgs = messages if messages is not None else getattr(conv, "messages", [])
+    return ConversationResponse(
+        id=str(conv.id),
+        title=conv.title,
+        mode=getattr(conv, "mode", "research"),
+        messages=[_message_to_response(m) for m in msgs],
+        created_at=conv.created_at,
+        updated_at=conv.updated_at,
+    )
 
 
 # ── Endpoints ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Inlines `_conversation_to_response` and `_message_to_response` in `research.py` after `conversations.py` was removed in PR #39
- Fixes `export.py` to import from `research` instead of deleted `conversations` module
- Fixes 500 error on `POST /api/v1/research/bottom-up/prepare`

## Test plan
- [x] All 72 API tests pass locally
- [ ] CI checks pass
- [ ] `POST /api/v1/research/bottom-up/prepare` returns 200 in dev cluster after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)