### PR TITLE
feat: add waitlist and invite system for closed registration

### DIFF
--- a/frontend/src/app/(auth)/register/invite/page.tsx
+++ b/frontend/src/app/(auth)/register/invite/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/auth";
+import { api } from "@/lib/api";
+
+export default function InviteRedemptionPage() {
+  const { login } = useAuth();
+  const router = useRouter();
+
+  // Step 1: validate invite
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [validating, setValidating] = useState(false);
+  const [validateError, setValidateError] = useState<string | null>(null);
+
+  // Step 2: register
+  const [validated, setValidated] = useState(false);
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [registering, setRegistering] = useState(false);
+  const [registerError, setRegisterError] = useState<string | null>(null);
+
+  async function handleValidate(e: React.FormEvent) {
+    e.preventDefault();
+    setValidateError(null);
+    setValidating(true);
+    try {
+      const result = await api.invites.validate(email, code);
+      if (result.valid) {
+        setEmail(result.email);
+        setValidated(true);
+      } else {
+        setValidateError(
+          "Invalid or expired invite code. Please check and try again.",
+        );
+      }
+    } catch (err) {
+      setValidateError(
+        err instanceof Error ? err.message : "Validation failed.",
+      );
+    } finally {
+      setValidating(false);
+    }
+  }
+
+  async function handleRegister(e: React.FormEvent) {
+    e.preventDefault();
+    setRegisterError(null);
+    setRegistering(true);
+    try {
+      await api.auth.register({
+        email,
+        password,
+        display_name: displayName || undefined,
+      });
+      await login(email, password);
+      router.push("/");
+    } catch (err) {
+      setRegisterError(
+        err instanceof Error ? err.message : "Registration failed.",
+      );
+    } finally {
+      setRegistering(false);
+    }
+  }
+
+  if (!validated) {
+    return (
+      <>
+        <h1 className="mb-6 text-xl font-semibold">Redeem invite</h1>
+        <form onSubmit={handleValidate} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <label htmlFor="inv-email" className="text-sm font-medium">
+              Email
+            </label>
+            <input
+              id="inv-email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label htmlFor="inv-code" className="text-sm font-medium">
+              Invite code
+            </label>
+            <input
+              id="inv-code"
+              type="text"
+              required
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              className="rounded-md border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          {validateError && (
+            <p className="text-sm text-red-500">{validateError}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={validating}
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {validating ? "Validating..." : "Validate invite"}
+          </button>
+
+          <div className="flex flex-col gap-2 items-center text-center">
+            <a
+              href="/register"
+              className="text-sm underline hover:text-foreground"
+            >
+              Back to registration
+            </a>
+            <a
+              href="/login"
+              className="text-sm underline hover:text-foreground"
+            >
+              Back to sign in
+            </a>
+          </div>
+        </form>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="mb-6 text-xl font-semibold">Create your account</h1>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Invite validated for <span className="font-medium">{email}</span>
+      </p>
+
+      <form onSubmit={handleRegister} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="reg-email" className="text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="reg-email"
+            type="email"
+            value={email}
+            readOnly
+            className="rounded-md border border-border bg-muted px-3 py-2 text-sm cursor-not-allowed"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="reg-name" className="text-sm font-medium">
+            Display name (optional)
+          </label>
+          <input
+            id="reg-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="reg-password" className="text-sm font-medium">
+            Password
+          </label>
+          <input
+            id="reg-password"
+            type="password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+
+        {registerError && (
+          <p className="text-sm text-red-500">{registerError}</p>
+        )}
+
+        <button
+          type="submit"
+          disabled={registering}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {registering ? "Creating account..." : "Create account"}
+        </button>
+      </form>
+    </>
+  );
+}

--- a/frontend/src/app/members/page.tsx
+++ b/frontend/src/app/members/page.tsx
@@ -4,14 +4,34 @@ import { useCallback, useEffect, useState } from "react";
 import { api } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/contexts/auth";
-import type { MemberResponse } from "@/types";
+import type {
+  MemberResponse,
+  WaitlistEntryResponse,
+  InviteResponse,
+} from "@/types";
 
 export default function MembersPage() {
   const { user } = useAuth();
   const [members, setMembers] = useState<MemberResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState<string | null>(null);
+
+  // Waitlist state
+  const [waitlist, setWaitlist] = useState<WaitlistEntryResponse[]>([]);
+  const [waitlistLoading, setWaitlistLoading] = useState(true);
+  const [reviewingId, setReviewingId] = useState<string | null>(null);
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+
+  // Invites state
+  const [invites, setInvites] = useState<InviteResponse[]>([]);
+  const [invitesLoading, setInvitesLoading] = useState(true);
+  const [creatingInvite, setCreatingInvite] = useState(false);
+  const [newInviteEmail, setNewInviteEmail] = useState("");
+  const [newInviteDays, setNewInviteDays] = useState(7);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const fetchMembers = useCallback(async () => {
     try {
@@ -24,9 +44,33 @@ export default function MembersPage() {
     }
   }, []);
 
+  const fetchWaitlist = useCallback(async () => {
+    try {
+      const data = await api.waitlist.list();
+      setWaitlist(data);
+    } catch {
+      // ignore
+    } finally {
+      setWaitlistLoading(false);
+    }
+  }, []);
+
+  const fetchInvites = useCallback(async () => {
+    try {
+      const data = await api.invites.list();
+      setInvites(data);
+    } catch {
+      // ignore
+    } finally {
+      setInvitesLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     fetchMembers();
-  }, [fetchMembers]);
+    fetchWaitlist();
+    fetchInvites();
+  }, [fetchMembers, fetchWaitlist, fetchInvites]);
 
   const toggleRole = async (member: MemberResponse) => {
     if (member.id === user?.id) return;
@@ -52,69 +96,364 @@ export default function MembersPage() {
     }
   };
 
+  const handleReview = async (entryId: string, status: "approved" | "rejected") => {
+    setReviewingId(entryId);
+    setInviteCode(null);
+    try {
+      const result = await api.waitlist.review(entryId, { status });
+      setWaitlist((prev) =>
+        prev.map((e) => (e.id === entryId ? result.entry : e)),
+      );
+      if (result.invite) {
+        setInviteCode(result.invite.code);
+        fetchInvites();
+      }
+    } catch {
+      // ignore
+    } finally {
+      setReviewingId(null);
+    }
+  };
+
+  const handleCreateInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreatingInvite(true);
+    try {
+      await api.invites.create({
+        email: newInviteEmail,
+        expires_in_days: newInviteDays,
+      });
+      setNewInviteEmail("");
+      setNewInviteDays(7);
+      setShowCreateForm(false);
+      fetchInvites();
+    } catch {
+      // ignore
+    } finally {
+      setCreatingInvite(false);
+    }
+  };
+
+  const handleRevokeInvite = async (inviteId: string) => {
+    if (!window.confirm("Revoke this invite?")) return;
+    try {
+      await api.invites.revoke(inviteId);
+      fetchInvites();
+    } catch {
+      // ignore
+    }
+  };
+
+  const copyCode = (code: string, id: string) => {
+    navigator.clipboard.writeText(code);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
   if (loading) {
     return (
       <div className="p-6">
-        <p className="text-sm text-muted-foreground">Loading members...</p>
+        <p className="text-sm text-muted-foreground">Loading...</p>
       </div>
     );
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-6 py-10">
+    <div className="max-w-4xl mx-auto px-6 py-10">
       <h1 className="text-xl font-semibold mb-6">Members</h1>
 
-      <div className="rounded-xl border border-border bg-card overflow-hidden">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border bg-muted/50">
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Email</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Name</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Role</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">BYOK</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Joined</th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {members.map((m) => (
-              <tr key={m.id} className="border-b border-border last:border-0">
-                <td className="px-4 py-3 break-all">{m.email}</td>
-                <td className="px-4 py-3">{m.display_name ?? "\u2014"}</td>
-                <td className="px-4 py-3">
-                  <Badge variant={m.is_superuser ? "default" : "secondary"}>
-                    {m.is_superuser ? "Admin" : "User"}
-                  </Badge>
-                </td>
-                <td className="px-4 py-3">
-                  {m.has_byok ? (
-                    <span className="text-green-600 text-xs">Active</span>
-                  ) : (
-                    <span className="text-muted-foreground text-xs">\u2014</span>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  {new Date(m.created_at).toLocaleDateString()}
-                </td>
-                <td className="px-4 py-3 text-right">
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={m.id === user?.id || updating === m.id}
-                    onClick={() => toggleRole(m)}
-                  >
-                    {updating === m.id
-                      ? "..."
-                      : m.is_superuser
-                        ? "Demote"
-                        : "Promote"}
-                  </Button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <Tabs defaultValue="members">
+        <TabsList>
+          <TabsTrigger value="members">Members</TabsTrigger>
+          <TabsTrigger value="waitlist">
+            Waitlist
+            {waitlist.filter((e) => e.status === "pending").length > 0 && (
+              <Badge variant="secondary" className="ml-2">
+                {waitlist.filter((e) => e.status === "pending").length}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="invites">Invites</TabsTrigger>
+        </TabsList>
+
+        {/* ── Members ─────────────────────────────────────────── */}
+        <TabsContent value="members">
+          <div className="rounded-xl border border-border bg-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/50">
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">Email</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">Name</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">Role</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">BYOK</th>
+                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">Joined</th>
+                  <th className="text-right px-4 py-3 font-medium text-muted-foreground">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {members.map((m) => (
+                  <tr key={m.id} className="border-b border-border last:border-0">
+                    <td className="px-4 py-3 break-all">{m.email}</td>
+                    <td className="px-4 py-3">{m.display_name ?? "\u2014"}</td>
+                    <td className="px-4 py-3">
+                      <Badge variant={m.is_superuser ? "default" : "secondary"}>
+                        {m.is_superuser ? "Admin" : "User"}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3">
+                      {m.has_byok ? (
+                        <span className="text-green-600 text-xs">Active</span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">{"\u2014"}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {new Date(m.created_at).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={m.id === user?.id || updating === m.id}
+                        onClick={() => toggleRole(m)}
+                      >
+                        {updating === m.id
+                          ? "..."
+                          : m.is_superuser
+                            ? "Demote"
+                            : "Promote"}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </TabsContent>
+
+        {/* ── Waitlist ────────────────────────────────────────── */}
+        <TabsContent value="waitlist">
+          {inviteCode && (
+            <div className="mb-4 rounded-lg border border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950 p-4">
+              <p className="text-sm font-medium mb-1">Invite code generated:</p>
+              <div className="flex items-center gap-2">
+                <code className="text-xs bg-background border border-border rounded px-2 py-1 font-mono break-all">
+                  {inviteCode}
+                </code>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => copyCode(inviteCode, "banner")}
+                >
+                  {copiedId === "banner" ? "Copied" : "Copy"}
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                Share this code with the approved user.
+              </p>
+            </div>
+          )}
+
+          {waitlistLoading ? (
+            <p className="text-sm text-muted-foreground">Loading waitlist...</p>
+          ) : waitlist.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No waitlist entries.</p>
+          ) : (
+            <div className="rounded-xl border border-border bg-card overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Email</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Name</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Message</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Status</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Submitted</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {waitlist.map((entry) => (
+                    <tr key={entry.id} className="border-b border-border last:border-0">
+                      <td className="px-4 py-3 break-all">{entry.email}</td>
+                      <td className="px-4 py-3">{entry.display_name ?? "\u2014"}</td>
+                      <td className="px-4 py-3 max-w-xs truncate" title={entry.message ?? undefined}>
+                        {entry.message ?? "\u2014"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge
+                          variant={
+                            entry.status === "approved"
+                              ? "default"
+                              : entry.status === "rejected"
+                                ? "destructive"
+                                : "secondary"
+                          }
+                        >
+                          {entry.status}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {new Date(entry.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {entry.status === "pending" ? (
+                          <div className="flex gap-1 justify-end">
+                            <Button
+                              size="sm"
+                              variant="default"
+                              disabled={reviewingId === entry.id}
+                              onClick={() => handleReview(entry.id, "approved")}
+                            >
+                              {reviewingId === entry.id ? "..." : "Approve"}
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={reviewingId === entry.id}
+                              onClick={() => handleReview(entry.id, "rejected")}
+                            >
+                              Reject
+                            </Button>
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">{"\u2014"}</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </TabsContent>
+
+        {/* ── Invites ─────────────────────────────────────────── */}
+        <TabsContent value="invites">
+          <div className="mb-4">
+            {showCreateForm ? (
+              <form onSubmit={handleCreateInvite} className="flex items-end gap-3">
+                <div className="flex flex-col gap-1">
+                  <label htmlFor="inv-email" className="text-xs font-medium text-muted-foreground">
+                    Email
+                  </label>
+                  <input
+                    id="inv-email"
+                    type="email"
+                    required
+                    value={newInviteEmail}
+                    onChange={(e) => setNewInviteEmail(e.target.value)}
+                    className="rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label htmlFor="inv-days" className="text-xs font-medium text-muted-foreground">
+                    Expires in (days)
+                  </label>
+                  <input
+                    id="inv-days"
+                    type="number"
+                    min={1}
+                    max={365}
+                    value={newInviteDays}
+                    onChange={(e) => setNewInviteDays(Number(e.target.value))}
+                    className="w-20 rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                </div>
+                <Button type="submit" size="sm" disabled={creatingInvite}>
+                  {creatingInvite ? "Creating..." : "Create"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setShowCreateForm(false)}
+                >
+                  Cancel
+                </Button>
+              </form>
+            ) : (
+              <Button size="sm" onClick={() => setShowCreateForm(true)}>
+                Create invite
+              </Button>
+            )}
+          </div>
+
+          {invitesLoading ? (
+            <p className="text-sm text-muted-foreground">Loading invites...</p>
+          ) : invites.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No invites yet.</p>
+          ) : (
+            <div className="rounded-xl border border-border bg-card overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Email</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Code</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Expires</th>
+                    <th className="text-left px-4 py-3 font-medium text-muted-foreground">Status</th>
+                    <th className="text-right px-4 py-3 font-medium text-muted-foreground">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {invites.map((inv) => {
+                    const isExpired = new Date(inv.expires_at) < new Date();
+                    const isRedeemed = !!inv.redeemed_at;
+                    return (
+                      <tr key={inv.id} className="border-b border-border last:border-0">
+                        <td className="px-4 py-3 break-all">{inv.email}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-1">
+                            <code className="text-xs font-mono truncate max-w-[120px]" title={inv.code}>
+                              {inv.code.slice(0, 12)}...
+                            </code>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="h-6 px-1 text-xs"
+                              onClick={() => copyCode(inv.code, inv.id)}
+                            >
+                              {copiedId === inv.id ? "Copied" : "Copy"}
+                            </Button>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-muted-foreground">
+                          {new Date(inv.expires_at).toLocaleDateString()}
+                        </td>
+                        <td className="px-4 py-3">
+                          <Badge
+                            variant={
+                              isRedeemed
+                                ? "default"
+                                : isExpired
+                                  ? "destructive"
+                                  : "secondary"
+                            }
+                          >
+                            {isRedeemed ? "Redeemed" : isExpired ? "Expired" : "Pending"}
+                          </Badge>
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          {!isRedeemed && !isExpired ? (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => handleRevokeInvite(inv.id)}
+                            >
+                              Revoke
+                            </Button>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">{"\u2014"}</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/auth";
 import { api } from "@/lib/api";
+import { WaitlistForm } from "@/components/auth/WaitlistForm";
 
 export function RegisterForm() {
   const { login } = useAuth();
@@ -35,14 +36,7 @@ export function RegisterForm() {
   }
 
   if (registrationClosed) {
-    return (
-      <div className="flex flex-col gap-4 items-center text-center">
-        <p className="text-sm text-muted-foreground">{registrationClosed}</p>
-        <a href="/login" className="text-sm underline hover:text-foreground">
-          Back to sign in
-        </a>
-      </div>
-    );
+    return <WaitlistForm closedMessage={registrationClosed} />;
   }
 
   async function handleSubmit(e: React.FormEvent) {

--- a/frontend/src/components/auth/WaitlistForm.tsx
+++ b/frontend/src/components/auth/WaitlistForm.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+
+interface WaitlistFormProps {
+  closedMessage: string;
+}
+
+export function WaitlistForm({ closedMessage }: WaitlistFormProps) {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      await api.waitlist.submit({
+        email,
+        display_name: displayName || undefined,
+        message: message || undefined,
+      });
+      setSubmitted(true);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to submit request.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="flex flex-col gap-4 items-center text-center">
+        <p className="text-sm text-muted-foreground">
+          Your request has been submitted. You will receive an invite code when
+          approved.
+        </p>
+        <a
+          href="/register/invite"
+          className="text-sm underline hover:text-foreground"
+        >
+          Already have an invite code?
+        </a>
+        <a href="/login" className="text-sm underline hover:text-foreground">
+          Back to sign in
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground text-center">
+        {closedMessage}
+      </p>
+      <p className="text-sm text-muted-foreground text-center">
+        Request access by filling out the form below.
+      </p>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="wl-email" className="text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="wl-email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="wl-name" className="text-sm font-medium">
+            Display name (optional)
+          </label>
+          <input
+            id="wl-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="wl-message" className="text-sm font-medium">
+            Why do you want access? (optional)
+          </label>
+          <textarea
+            id="wl-message"
+            rows={3}
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+          />
+        </div>
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {loading ? "Submitting..." : "Request access"}
+        </button>
+      </form>
+
+      <div className="flex flex-col gap-2 items-center text-center">
+        <a
+          href="/register/invite"
+          className="text-sm underline hover:text-foreground"
+        >
+          Already have an invite code?
+        </a>
+        <a href="/login" className="text-sm underline hover:text-foreground">
+          Back to sign in
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,6 +70,13 @@ import type {
   SystemSettingsResponse,
   UpdateSystemSettingsRequest,
   RegistrationStatusResponse,
+  WaitlistSubmitRequest,
+  WaitlistSubmitResponse,
+  WaitlistEntryResponse,
+  WaitlistReviewResponse,
+  InviteCreateRequest,
+  InviteResponse,
+  InviteValidateResponse,
   CreateSynthesisRequest,
   CreateSuperSynthesisRequest,
   SynthesisDocumentResponse,
@@ -1033,6 +1040,69 @@ export const api = {
           method: "PATCH",
           body: JSON.stringify(data),
         },
+      );
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // Waitlist
+  // -------------------------------------------------------------------------
+  waitlist: {
+    submit(data: WaitlistSubmitRequest): Promise<WaitlistSubmitResponse> {
+      return request<WaitlistSubmitResponse>("/waitlist", {
+        method: "POST",
+        body: JSON.stringify(data),
+      });
+    },
+
+    list(status?: string): Promise<WaitlistEntryResponse[]> {
+      const qs = status ? `?status=${encodeURIComponent(status)}` : "";
+      return request<WaitlistEntryResponse[]>(`/waitlist${qs}`);
+    },
+
+    review(
+      entryId: string,
+      data: { status: string; expires_in_days?: number },
+    ): Promise<WaitlistReviewResponse> {
+      return request<WaitlistReviewResponse>(
+        `/waitlist/${encodeURIComponent(entryId)}`,
+        {
+          method: "PATCH",
+          body: JSON.stringify(data),
+        },
+      );
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // Invites
+  // -------------------------------------------------------------------------
+  invites: {
+    create(data: InviteCreateRequest): Promise<InviteResponse> {
+      return request<InviteResponse>("/invites", {
+        method: "POST",
+        body: JSON.stringify(data),
+      });
+    },
+
+    list(): Promise<InviteResponse[]> {
+      return request<InviteResponse[]>("/invites");
+    },
+
+    validate(
+      email: string,
+      code: string,
+    ): Promise<InviteValidateResponse> {
+      return request<InviteValidateResponse>("/invites/validate", {
+        method: "POST",
+        body: JSON.stringify({ email, code }),
+      });
+    },
+
+    revoke(inviteId: string): Promise<void> {
+      return request<void>(
+        `/invites/${encodeURIComponent(inviteId)}`,
+        { method: "DELETE" },
       );
     },
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1018,7 +1018,73 @@ export interface UpdateSystemSettingsRequest {
 
 export interface RegistrationStatusResponse {
   registration_open: boolean;
+  waitlist_enabled?: boolean;
   reason?: string;
+}
+
+// ── Waitlist ────────────────────────────────────────────────────────────
+
+export interface WaitlistSubmitRequest {
+  email: string;
+  display_name?: string;
+  message?: string;
+}
+
+export interface WaitlistSubmitResponse {
+  status: string;
+}
+
+export interface WaitlistEntryResponse {
+  id: string;
+  email: string;
+  display_name: string | null;
+  message: string | null;
+  status: string;
+  reviewed_at: string | null;
+  created_at: string;
+}
+
+// ── Invites ─────────────────────────────────────────────────────────────
+
+export interface InviteCreateRequest {
+  email: string;
+  expires_in_days?: number;
+}
+
+export interface InviteResponse {
+  id: string;
+  email: string;
+  code: string;
+  expires_at: string;
+  redeemed_at: string | null;
+  created_at: string;
+}
+
+export interface InviteValidateRequest {
+  email: string;
+  code: string;
+}
+
+export interface InviteValidateResponse {
+  valid: boolean;
+  email: string;
+}
+
+export interface InviteInfo {
+  id: string;
+  email: string;
+  code: string;
+  expires_at: string;
+}
+
+export interface WaitlistReviewRequest {
+  status: string;
+  expires_in_days?: number;
+}
+
+export interface WaitlistReviewResponse {
+  entry: WaitlistEntryResponse;
+  invite: InviteInfo | null;
 }
 
 // ── Seeds ──────────────────────────────────────────────────────────────

--- a/libs/kt-db/alembic/versions/zzaf_add_waitlist_and_invites.py
+++ b/libs/kt-db/alembic/versions/zzaf_add_waitlist_and_invites.py
@@ -1,0 +1,61 @@
+"""Add waitlist_entries and invites tables.
+
+Revision ID: zzaf
+Revises: zzae
+Create Date: 2026-03-27
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "zzaf"
+down_revision = "zzae"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "waitlist_entries",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("email", sa.String(320), nullable=False, index=True),
+        sa.Column("display_name", sa.String(200), nullable=True),
+        sa.Column("message", sa.Text, nullable=True),
+        sa.Column("status", sa.String(20), server_default="pending", nullable=False),
+        sa.Column("reviewed_at", sa.DateTime, nullable=True),
+        sa.Column(
+            "reviewed_by",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "invites",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("email", sa.String(320), nullable=False, index=True),
+        sa.Column("code", sa.String(64), nullable=False, unique=True, index=True),
+        sa.Column(
+            "created_by",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime, nullable=False),
+        sa.Column("redeemed_at", sa.DateTime, nullable=True),
+        sa.Column(
+            "redeemed_by",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("invites")
+    op.drop_table("waitlist_entries")

--- a/libs/kt-db/src/kt_db/models.py
+++ b/libs/kt-db/src/kt_db/models.py
@@ -508,6 +508,42 @@ class SystemSetting(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow, onupdate=_utcnow)
 
 
+class WaitlistEntry(Base):
+    """Request from a prospective user to join when registration is closed."""
+
+    __tablename__ = "waitlist_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(320), nullable=False, index=True)
+    display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default="pending", server_default="pending")
+    reviewed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    reviewed_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+
+class Invite(Base):
+    """Admin-generated invite allowing a specific email to register."""
+
+    __tablename__ = "invites"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(320), nullable=False, index=True)
+    code: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    redeemed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    redeemed_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+
 class ApiToken(Base):
     """User-generated long-lived API tokens (for API/MCP access)."""
 

--- a/libs/kt-db/src/kt_db/repositories/invites.py
+++ b/libs/kt-db/src/kt_db/repositories/invites.py
@@ -1,0 +1,94 @@
+"""Repository for admin-generated invites."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_db.models import Invite
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class InviteRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        email: str,
+        code: str,
+        created_by: uuid.UUID,
+        expires_at: datetime,
+    ) -> Invite:
+        invite = Invite(
+            id=uuid.uuid4(),
+            email=email.strip().lower(),
+            code=code,
+            created_by=created_by,
+            expires_at=expires_at,
+        )
+        self._session.add(invite)
+        await self._session.flush()
+        return invite
+
+    async def list_all(
+        self,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[Invite], int]:
+        from sqlalchemy import func
+
+        total = (await self._session.execute(select(func.count()).select_from(Invite))).scalar_one()
+        rows = (
+            (await self._session.execute(select(Invite).order_by(Invite.created_at.desc()).offset(offset).limit(limit)))
+            .scalars()
+            .all()
+        )
+        return list(rows), total
+
+    async def get_by_code(self, code: str) -> Invite | None:
+        result = await self._session.execute(select(Invite).where(Invite.code == code))
+        return result.scalar_one_or_none()
+
+    async def get_valid_for_email(self, email: str, code: str) -> Invite | None:
+        """Find a valid (non-expired, non-redeemed) invite matching email + code."""
+        result = await self._session.execute(
+            select(Invite).where(
+                Invite.email == email.strip().lower(),
+                Invite.code == code,
+                Invite.redeemed_at.is_(None),
+                Invite.expires_at > _utcnow(),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_any_valid_for_email(self, email: str) -> Invite | None:
+        """Find any valid (non-expired, non-redeemed) invite for an email."""
+        result = await self._session.execute(
+            select(Invite)
+            .where(
+                Invite.email == email.strip().lower(),
+                Invite.redeemed_at.is_(None),
+                Invite.expires_at > _utcnow(),
+            )
+            .order_by(Invite.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def redeem(self, invite_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        await self._session.execute(
+            update(Invite).where(Invite.id == invite_id).values(redeemed_at=_utcnow(), redeemed_by=user_id)
+        )
+        await self._session.flush()
+
+    async def delete(self, invite_id: uuid.UUID) -> bool:
+        result = await self._session.execute(delete(Invite).where(Invite.id == invite_id, Invite.redeemed_at.is_(None)))
+        await self._session.flush()
+        return result.rowcount > 0

--- a/libs/kt-db/src/kt_db/repositories/waitlist.py
+++ b/libs/kt-db/src/kt_db/repositories/waitlist.py
@@ -1,0 +1,86 @@
+"""Repository for waitlist entries."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_db.models import WaitlistEntry
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class WaitlistRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        email: str,
+        display_name: str | None = None,
+        message: str | None = None,
+    ) -> WaitlistEntry:
+        entry = WaitlistEntry(
+            id=uuid.uuid4(),
+            email=email.strip().lower(),
+            display_name=display_name,
+            message=message,
+            status="pending",
+        )
+        self._session.add(entry)
+        await self._session.flush()
+        return entry
+
+    async def list_all(
+        self,
+        offset: int = 0,
+        limit: int = 50,
+        status_filter: str | None = None,
+    ) -> tuple[list[WaitlistEntry], int]:
+        base = select(WaitlistEntry)
+        count_q = select(func.count()).select_from(WaitlistEntry)
+        if status_filter:
+            base = base.where(WaitlistEntry.status == status_filter)
+            count_q = count_q.where(WaitlistEntry.status == status_filter)
+
+        total = (await self._session.execute(count_q)).scalar_one()
+        rows = (
+            (await self._session.execute(base.order_by(WaitlistEntry.created_at).offset(offset).limit(limit)))
+            .scalars()
+            .all()
+        )
+        return list(rows), total
+
+    async def get_by_id(self, entry_id: uuid.UUID) -> WaitlistEntry | None:
+        result = await self._session.execute(select(WaitlistEntry).where(WaitlistEntry.id == entry_id))
+        return result.scalar_one_or_none()
+
+    async def update_status(
+        self,
+        entry_id: uuid.UUID,
+        status: str,
+        reviewed_by: uuid.UUID,
+    ) -> WaitlistEntry | None:
+        await self._session.execute(
+            update(WaitlistEntry)
+            .where(WaitlistEntry.id == entry_id)
+            .values(status=status, reviewed_at=_utcnow(), reviewed_by=reviewed_by)
+        )
+        await self._session.flush()
+        return await self.get_by_id(entry_id)
+
+    async def exists_pending(self, email: str) -> bool:
+        result = await self._session.execute(
+            select(func.count())
+            .select_from(WaitlistEntry)
+            .where(
+                WaitlistEntry.email == email.strip().lower(),
+                WaitlistEntry.status == "pending",
+            )
+        )
+        return (result.scalar_one() or 0) > 0

--- a/services/api/src/kt_api/auth/manager.py
+++ b/services/api/src/kt_api/auth/manager.py
@@ -39,20 +39,40 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         if user_count > 0:
             settings = get_settings()
-            if settings.disable_self_registration:
-                raise HTTPException(status_code=403, detail="Registration is disabled by the administrator.")
+            registration_disabled = settings.disable_self_registration
+            if not registration_disabled:
+                repo = SystemSettingsRepository(session)
+                registration_disabled = await repo.get_bool("disable_self_registration")
 
-            repo = SystemSettingsRepository(session)
-            if await repo.get_bool("disable_self_registration"):
-                raise HTTPException(status_code=403, detail="Registration is disabled by the administrator.")
+            if registration_disabled:
+                # Allow registration if the user has a valid invite
+                from kt_db.repositories.invites import InviteRepository
+
+                invite_repo = InviteRepository(session)
+                invite = await invite_repo.get_any_valid_for_email(user_create.email)
+                if invite is None:
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Registration is disabled by the administrator.",
+                    )
 
         return await super().create(user_create, safe=safe, request=request)
 
     async def on_after_register(self, user: User, request=None) -> None:  # type: ignore[override]
         logger.info("New user registered: %s (%s)", user.email, user.id)
 
-        # Auto-promote the first registered user to admin
         session = self.user_db.session
+
+        # Mark any matching invite as redeemed
+        from kt_db.repositories.invites import InviteRepository
+
+        invite_repo = InviteRepository(session)
+        invite = await invite_repo.get_any_valid_for_email(user.email)
+        if invite is not None:
+            await invite_repo.redeem(invite.id, user.id)
+            logger.info("Invite %s redeemed by user %s", invite.id, user.email)
+
+        # Auto-promote the first registered user to admin
         result = await session.execute(select(func.count()).select_from(User))
         user_count = result.scalar_one()
         if user_count == 1:

--- a/services/api/src/kt_api/auth/router.py
+++ b/services/api/src/kt_api/auth/router.py
@@ -187,6 +187,7 @@ async def api_key_status(
 
 class RegistrationStatusResponse(BaseModel):
     registration_open: bool
+    waitlist_enabled: bool = False
     reason: str | None = None
 
 
@@ -199,6 +200,7 @@ async def registration_status(
     if settings.disable_self_registration:
         return RegistrationStatusResponse(
             registration_open=False,
+            waitlist_enabled=True,
             reason="Registration is disabled by the administrator.",
         )
 
@@ -206,6 +208,7 @@ async def registration_status(
     if await repo.get_bool("disable_self_registration"):
         return RegistrationStatusResponse(
             registration_open=False,
+            waitlist_enabled=True,
             reason="Registration is disabled by the administrator.",
         )
 

--- a/services/api/src/kt_api/invites.py
+++ b/services/api/src/kt_api/invites.py
@@ -1,0 +1,131 @@
+"""Invite endpoints — admin management + public validation."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_api.auth.tokens import require_admin
+from kt_api.dependencies import get_db_session
+from kt_db.models import User
+from kt_db.repositories.invites import InviteRepository
+
+router = APIRouter(prefix="/api/v1/invites", tags=["invites"])
+
+
+# ---------- Schemas ----------
+
+
+class InviteCreateRequest(BaseModel):
+    email: str
+    expires_in_days: int = 7
+
+
+class InviteResponse(BaseModel):
+    id: str
+    email: str
+    code: str
+    expires_at: datetime
+    redeemed_at: datetime | None
+    created_at: datetime
+
+
+class InviteValidateRequest(BaseModel):
+    email: str
+    code: str
+
+
+class InviteValidateResponse(BaseModel):
+    valid: bool
+    email: str
+
+
+# ---------- Helpers ----------
+
+
+def _invite_response(inv: object) -> InviteResponse:
+    from kt_db.models import Invite
+
+    i: Invite = inv  # type: ignore[assignment]
+    return InviteResponse(
+        id=str(i.id),
+        email=i.email,
+        code=i.code,
+        expires_at=i.expires_at,
+        redeemed_at=i.redeemed_at,
+        created_at=i.created_at,
+    )
+
+
+# ---------- Admin ----------
+
+
+@router.post("", response_model=InviteResponse, status_code=201)
+async def create_invite(
+    body: InviteCreateRequest,
+    admin: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> InviteResponse:
+    """Admin: generate a new invite for a specific email."""
+    repo = InviteRepository(session)
+    code = secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    invite = await repo.create(
+        email=body.email,
+        code=code,
+        created_by=admin.id,
+        expires_at=now + timedelta(days=body.expires_in_days),
+    )
+    await session.commit()
+    return _invite_response(invite)
+
+
+@router.get("", response_model=list[InviteResponse])
+async def list_invites(
+    _admin: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[InviteResponse]:
+    """Admin: list all invites."""
+    repo = InviteRepository(session)
+    invites, _ = await repo.list_all()
+    return [_invite_response(i) for i in invites]
+
+
+@router.delete("/{invite_id}", status_code=204)
+async def revoke_invite(
+    invite_id: str,
+    _admin: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Admin: revoke an unredeemed invite."""
+    try:
+        iid = uuid.UUID(invite_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid invite ID.")
+
+    repo = InviteRepository(session)
+    deleted = await repo.delete(iid)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Invite not found or already redeemed.")
+    await session.commit()
+
+
+# ---------- Public ----------
+
+
+@router.post("/validate", response_model=InviteValidateResponse)
+async def validate_invite(
+    body: InviteValidateRequest,
+    session: AsyncSession = Depends(get_db_session),
+) -> InviteValidateResponse:
+    """Public: validate an invite code for an email. Does NOT redeem it."""
+    repo = InviteRepository(session)
+    invite = await repo.get_valid_for_email(body.email, body.code)
+    if invite is None:
+        return InviteValidateResponse(valid=False, email=body.email.strip().lower())
+    return InviteValidateResponse(valid=True, email=invite.email)

--- a/services/api/src/kt_api/router.py
+++ b/services/api/src/kt_api/router.py
@@ -15,6 +15,7 @@ from kt_api.facts import router as facts_router
 from kt_api.graph import router as graph_router
 from kt_api.graph_builder import router as graph_builder_router
 from kt_api.import_router import router as import_router
+from kt_api.invites import router as invites_router
 from kt_api.members import router as members_router
 from kt_api.nodes import router as nodes_router
 from kt_api.prompt_transparency import router as prompts_router
@@ -24,6 +25,7 @@ from kt_api.sources import router as sources_router
 from kt_api.syntheses import router as syntheses_router
 from kt_api.system_settings import router as system_settings_router
 from kt_api.usage import router as usage_router
+from kt_api.waitlist import router as waitlist_router
 
 _auth_dep = [Depends(require_auth)]
 
@@ -48,5 +50,8 @@ api_router.include_router(usage_router, dependencies=_auth_dep)
 api_router.include_router(members_router, dependencies=_auth_dep)
 api_router.include_router(syntheses_router, dependencies=_auth_dep)
 api_router.include_router(system_settings_router, dependencies=_auth_dep)
+# Waitlist + invites: public + admin (auth enforced per-endpoint)
+api_router.include_router(waitlist_router)
+api_router.include_router(invites_router)
 # Prompt transparency is public — supports research credibility
 api_router.include_router(prompts_router)

--- a/services/api/src/kt_api/waitlist.py
+++ b/services/api/src/kt_api/waitlist.py
@@ -1,0 +1,170 @@
+"""Waitlist endpoints — public submission + admin management."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_api.auth.tokens import require_admin
+from kt_api.dependencies import get_db_session
+from kt_config.settings import get_settings
+from kt_db.models import User
+from kt_db.repositories.invites import InviteRepository
+from kt_db.repositories.system_settings import SystemSettingsRepository
+from kt_db.repositories.waitlist import WaitlistRepository
+
+router = APIRouter(prefix="/api/v1/waitlist", tags=["waitlist"])
+
+
+# ---------- Schemas ----------
+
+
+class WaitlistSubmitRequest(BaseModel):
+    email: str
+    display_name: str | None = None
+    message: str | None = None
+
+
+class WaitlistSubmitResponse(BaseModel):
+    status: str
+
+
+class WaitlistEntryResponse(BaseModel):
+    id: str
+    email: str
+    display_name: str | None
+    message: str | None
+    status: str
+    reviewed_at: datetime | None
+    created_at: datetime
+
+
+class InviteInfo(BaseModel):
+    id: str
+    email: str
+    code: str
+    expires_at: datetime
+
+
+class WaitlistReviewRequest(BaseModel):
+    status: str  # "approved" | "rejected"
+    expires_in_days: int = 7
+
+
+class WaitlistReviewResponse(BaseModel):
+    entry: WaitlistEntryResponse
+    invite: InviteInfo | None = None
+
+
+# ---------- Public ----------
+
+
+def _entry_response(e: object) -> WaitlistEntryResponse:
+    from kt_db.models import WaitlistEntry
+
+    entry: WaitlistEntry = e  # type: ignore[assignment]
+    return WaitlistEntryResponse(
+        id=str(entry.id),
+        email=entry.email,
+        display_name=entry.display_name,
+        message=entry.message,
+        status=entry.status,
+        reviewed_at=entry.reviewed_at,
+        created_at=entry.created_at,
+    )
+
+
+@router.post("", response_model=WaitlistSubmitResponse)
+async def submit_waitlist(
+    body: WaitlistSubmitRequest,
+    session: AsyncSession = Depends(get_db_session),
+) -> WaitlistSubmitResponse:
+    """Public: submit a waitlist request (only when registration is disabled)."""
+    # Verify registration is actually disabled
+    settings = get_settings()
+    registration_disabled = settings.disable_self_registration
+    if not registration_disabled:
+        repo = SystemSettingsRepository(session)
+        registration_disabled = await repo.get_bool("disable_self_registration")
+    if not registration_disabled:
+        raise HTTPException(status_code=400, detail="Registration is open — please register directly.")
+
+    waitlist_repo = WaitlistRepository(session)
+    if await waitlist_repo.exists_pending(body.email):
+        raise HTTPException(status_code=409, detail="A pending request already exists for this email.")
+
+    await waitlist_repo.create(
+        email=body.email,
+        display_name=body.display_name,
+        message=body.message,
+    )
+    await session.commit()
+    return WaitlistSubmitResponse(status="submitted")
+
+
+# ---------- Admin ----------
+
+
+@router.get("", response_model=list[WaitlistEntryResponse])
+async def list_waitlist(
+    status: str | None = Query(None),
+    _admin: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[WaitlistEntryResponse]:
+    """Admin: list waitlist entries with optional status filter."""
+    repo = WaitlistRepository(session)
+    entries, _ = await repo.list_all(status_filter=status)
+    return [_entry_response(e) for e in entries]
+
+
+@router.patch("/{entry_id}", response_model=WaitlistReviewResponse)
+async def review_waitlist_entry(
+    entry_id: str,
+    body: WaitlistReviewRequest,
+    admin: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> WaitlistReviewResponse:
+    """Admin: approve or reject a waitlist entry. Approve auto-creates an invite."""
+    if body.status not in ("approved", "rejected"):
+        raise HTTPException(status_code=400, detail="Status must be 'approved' or 'rejected'.")
+
+    try:
+        eid = uuid.UUID(entry_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid entry ID.")
+
+    repo = WaitlistRepository(session)
+    entry = await repo.get_by_id(eid)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Waitlist entry not found.")
+    if entry.status != "pending":
+        raise HTTPException(status_code=400, detail="Entry has already been reviewed.")
+
+    updated = await repo.update_status(eid, body.status, admin.id)
+    assert updated is not None
+
+    invite_info: InviteInfo | None = None
+    if body.status == "approved":
+        invite_repo = InviteRepository(session)
+        code = secrets.token_urlsafe(32)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        invite = await invite_repo.create(
+            email=updated.email,
+            code=code,
+            created_by=admin.id,
+            expires_at=now + timedelta(days=body.expires_in_days),
+        )
+        invite_info = InviteInfo(
+            id=str(invite.id),
+            email=invite.email,
+            code=invite.code,
+            expires_at=invite.expires_at,
+        )
+
+    await session.commit()
+    return WaitlistReviewResponse(entry=_entry_response(updated), invite=invite_info)

--- a/services/api/tests/integration/test_waitlist_invites.py
+++ b/services/api/tests/integration/test_waitlist_invites.py
@@ -1,0 +1,270 @@
+"""Integration tests for waitlist and invite endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from unittest.mock import patch
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from kt_api.dependencies import get_db_session
+from kt_api.main import create_app
+from kt_db.models import User
+
+# The SKIP_AUTH stub user UUID
+STUB_USER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def wi_session_factory(engine):
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
+async def _ensure_stub_user(wi_session_factory):
+    """Ensure the SKIP_AUTH stub user exists in the DB for FK constraints."""
+    async with wi_session_factory() as session:
+        from sqlalchemy import select
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+        existing = await session.execute(select(User).where(User.id == STUB_USER_ID))
+        if existing.scalar_one_or_none() is None:
+            stmt = (
+                pg_insert(User)
+                .values(
+                    id=STUB_USER_ID,
+                    email="test@example.com",
+                    hashed_password="stub",
+                    is_active=True,
+                    is_superuser=True,
+                    is_verified=True,
+                )
+                .on_conflict_do_nothing()
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def wi_app(wi_session_factory, _ensure_stub_user):
+    application = create_app()
+
+    async def override_get_db_session() -> AsyncGenerator[AsyncSession, None]:
+        async with wi_session_factory() as session:
+            yield session
+
+    application.dependency_overrides[get_db_session] = override_get_db_session
+    return application
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def wi_client(wi_app):
+    transport = ASGITransport(app=wi_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ── Waitlist ──────────────────────────────────────────────────────
+
+
+async def test_waitlist_submit_rejected_when_registration_open(wi_client: AsyncClient):
+    """Waitlist submission should fail when registration is open."""
+    resp = await wi_client.post(
+        "/api/v1/waitlist",
+        json={"email": "test@example.com"},
+    )
+    # Registration is open by default (SKIP_AUTH mode), so waitlist should reject
+    assert resp.status_code == 400
+    assert "register directly" in resp.json()["detail"].lower()
+
+
+async def test_waitlist_submit_succeeds_when_registration_disabled(wi_client: AsyncClient):
+    """Waitlist submission should succeed when registration is disabled."""
+    with patch("kt_api.waitlist.get_settings") as mock_settings:
+        mock_settings.return_value.disable_self_registration = True
+        resp = await wi_client.post(
+            "/api/v1/waitlist",
+            json={
+                "email": "waitlist@example.com",
+                "display_name": "Test User",
+                "message": "I want access please",
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "submitted"
+
+
+async def test_waitlist_duplicate_pending_rejected(wi_client: AsyncClient):
+    """Duplicate pending waitlist entry should be rejected."""
+    email = f"dup-{uuid.uuid4().hex[:6]}@example.com"
+    with patch("kt_api.waitlist.get_settings") as mock_settings:
+        mock_settings.return_value.disable_self_registration = True
+        # First submission
+        resp = await wi_client.post("/api/v1/waitlist", json={"email": email})
+        assert resp.status_code == 200
+        # Second submission — should fail
+        resp = await wi_client.post("/api/v1/waitlist", json={"email": email})
+        assert resp.status_code == 409
+
+
+async def test_waitlist_list_requires_admin(wi_client: AsyncClient):
+    """GET /waitlist requires admin auth (SKIP_AUTH gives admin)."""
+    resp = await wi_client.get("/api/v1/waitlist")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+async def test_waitlist_review_approve_creates_invite(wi_client: AsyncClient):
+    """Approving a waitlist entry should auto-create an invite."""
+    email = f"approve-{uuid.uuid4().hex[:6]}@example.com"
+    # Create entry
+    with patch("kt_api.waitlist.get_settings") as mock_settings:
+        mock_settings.return_value.disable_self_registration = True
+        resp = await wi_client.post(
+            "/api/v1/waitlist",
+            json={"email": email, "display_name": "Approvee"},
+        )
+    assert resp.status_code == 200
+
+    # List and find entry
+    resp = await wi_client.get("/api/v1/waitlist?status=pending")
+    entries = resp.json()
+    entry = next((e for e in entries if e["email"] == email), None)
+    assert entry is not None
+
+    # Approve
+    resp = await wi_client.patch(
+        f"/api/v1/waitlist/{entry['id']}",
+        json={"status": "approved"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entry"]["status"] == "approved"
+    assert data["invite"] is not None
+    assert data["invite"]["email"] == email
+    assert len(data["invite"]["code"]) > 0
+
+
+async def test_waitlist_review_reject(wi_client: AsyncClient):
+    """Rejecting a waitlist entry should not create an invite."""
+    email = f"reject-{uuid.uuid4().hex[:6]}@example.com"
+    with patch("kt_api.waitlist.get_settings") as mock_settings:
+        mock_settings.return_value.disable_self_registration = True
+        resp = await wi_client.post("/api/v1/waitlist", json={"email": email})
+    assert resp.status_code == 200
+
+    resp = await wi_client.get("/api/v1/waitlist?status=pending")
+    entry = next((e for e in resp.json() if e["email"] == email), None)
+    assert entry is not None
+
+    resp = await wi_client.patch(
+        f"/api/v1/waitlist/{entry['id']}",
+        json={"status": "rejected"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["entry"]["status"] == "rejected"
+    assert data["invite"] is None
+
+
+# ── Invites ───────────────────────────────────────────────────────
+
+
+async def test_invite_create(wi_client: AsyncClient):
+    """Admin should be able to create an invite."""
+    resp = await wi_client.post(
+        "/api/v1/invites",
+        json={"email": "invited@example.com", "expires_in_days": 7},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["email"] == "invited@example.com"
+    assert len(data["code"]) > 0
+    assert data["redeemed_at"] is None
+
+
+async def test_invite_list(wi_client: AsyncClient):
+    """Admin should be able to list invites."""
+    resp = await wi_client.get("/api/v1/invites")
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+async def test_invite_validate_valid(wi_client: AsyncClient):
+    """Validating a correct email+code should return valid=True."""
+    # Create invite
+    resp = await wi_client.post(
+        "/api/v1/invites",
+        json={"email": f"valid-{uuid.uuid4().hex[:6]}@example.com"},
+    )
+    invite = resp.json()
+
+    # Validate
+    resp = await wi_client.post(
+        "/api/v1/invites/validate",
+        json={"email": invite["email"], "code": invite["code"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is True
+
+
+async def test_invite_validate_wrong_code(wi_client: AsyncClient):
+    """Validating with a wrong code should return valid=False."""
+    resp = await wi_client.post(
+        "/api/v1/invites/validate",
+        json={"email": "nobody@example.com", "code": "wrong-code"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is False
+
+
+async def test_invite_validate_wrong_email(wi_client: AsyncClient):
+    """Validating with a wrong email should return valid=False."""
+    # Create invite for one email
+    resp = await wi_client.post(
+        "/api/v1/invites",
+        json={"email": f"real-{uuid.uuid4().hex[:6]}@example.com"},
+    )
+    invite = resp.json()
+
+    # Try to validate with different email
+    resp = await wi_client.post(
+        "/api/v1/invites/validate",
+        json={"email": "other@example.com", "code": invite["code"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is False
+
+
+async def test_invite_revoke(wi_client: AsyncClient):
+    """Admin should be able to revoke an unredeemed invite."""
+    resp = await wi_client.post(
+        "/api/v1/invites",
+        json={"email": f"revoke-{uuid.uuid4().hex[:6]}@example.com"},
+    )
+    invite = resp.json()
+
+    # Revoke
+    resp = await wi_client.delete(f"/api/v1/invites/{invite['id']}")
+    assert resp.status_code == 204
+
+    # Validate should now fail
+    resp = await wi_client.post(
+        "/api/v1/invites/validate",
+        json={"email": invite["email"], "code": invite["code"]},
+    )
+    assert resp.json()["valid"] is False
+
+
+# ── Registration status ──────────────────────────────────────────
+
+
+async def test_registration_status_includes_waitlist_enabled(wi_client: AsyncClient):
+    """Registration status should include waitlist_enabled field."""
+    resp = await wi_client.get("/api/v1/auth/registration-status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "waitlist_enabled" in data


### PR DESCRIPTION
## Summary

- **Waitlist**: When self-registration is disabled, users see a waitlist form (email, name, reason) instead of a dead-end message. Admins review entries in the Members page.
- **Invites**: Admins can generate time-limited, single-use invite codes bound to a specific email. Approving a waitlist entry auto-generates an invite. Users redeem invite codes at `/register/invite` to register even when registration is closed.
- **Registration bypass**: `UserManager.create` checks for valid invites before blocking registration; `on_after_register` marks the invite as redeemed.

### Backend
- New `WaitlistEntry` and `Invite` DB models + Alembic migration `zzaf`
- `WaitlistRepository` and `InviteRepository` in `kt_db`
- Public endpoints: `POST /waitlist`, `POST /invites/validate`
- Admin endpoints: `GET /waitlist`, `PATCH /waitlist/{id}`, `POST /invites`, `GET /invites`, `DELETE /invites/{id}`
- Updated `RegistrationStatusResponse` with `waitlist_enabled` field

### Frontend
- `WaitlistForm` component replaces static "registration closed" message
- Invite redemption page at `/register/invite` (two-step: validate code → register)
- Members page extended with **Waitlist** and **Invites** tabs (approve/reject, create/revoke/copy codes)
- TypeScript types and API client methods for all new endpoints

## Test plan
- [x] 13 new integration tests covering waitlist submit, duplicate rejection, admin list/approve/reject, invite create/list/validate/revoke, and registration status
- [x] All 85 existing API tests still pass
- [x] Frontend lint, type-check, and 123 tests all pass
- [ ] Manual: disable self-registration → visit /register → submit waitlist → admin approves → share code → user redeems at /register/invite → registers successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)