### PR TITLE
feat(api): add native Hatchet progress tracking endpoints

### DIFF
--- a/frontend/src/components/synthesis/CreateSynthesisDialog.tsx
+++ b/frontend/src/components/synthesis/CreateSynthesisDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Loader2, FileText, Layers, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +27,7 @@ import {
   listSyntheses,
 } from "@/lib/api";
 import { formatSynthesisConcept } from "./utils";
+import { SynthesisProgress } from "./SynthesisProgress";
 import type { SynthesisListItem } from "@/types";
 
 type SynthesisMode = "synthesis" | "super";
@@ -48,6 +49,7 @@ export function CreateSynthesisDialog({
   const [scopeCount, setScopeCount] = useState(5);
   const [visibility, setVisibility] = useState("public");
   const [creating, setCreating] = useState(false);
+  const [workflowRunId, setWorkflowRunId] = useState<string | null>(null);
 
   // Existing syntheses for super-synthesis inclusion
   const [existingSyntheses, setExistingSyntheses] = useState<
@@ -82,24 +84,22 @@ export function CreateSynthesisDialog({
     if (!topic.trim()) return;
     setCreating(true);
     try {
+      let result;
       if (mode === "super") {
-        await createSuperSynthesis({
+        result = await createSuperSynthesis({
           topic: topic.trim(),
           existing_synthesis_ids: Array.from(selectedExisting),
           scope_count: scopeCount,
           visibility,
         });
       } else {
-        await createSynthesis({
+        result = await createSynthesis({
           topic: topic.trim(),
           exploration_budget: budget,
           visibility,
         });
       }
-      onOpenChange(false);
-      setTopic("");
-      setSelectedExisting(new Set());
-      onCreated();
+      setWorkflowRunId(result.workflow_run_id);
     } catch (err) {
       console.error("Failed to create synthesis:", err);
     } finally {
@@ -107,15 +107,35 @@ export function CreateSynthesisDialog({
     }
   };
 
+  const handleProgressComplete = useCallback(() => {
+    onOpenChange(false);
+    setWorkflowRunId(null);
+    setTopic("");
+    setSelectedExisting(new Set());
+    onCreated();
+  }, [onOpenChange, onCreated]);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>New Synthesis</DialogTitle>
+          <DialogTitle>{workflowRunId ? "Synthesis Progress" : "New Synthesis"}</DialogTitle>
           <DialogDescription>
-            Create a research document from the knowledge graph.
+            {workflowRunId
+              ? "Your synthesis is being generated."
+              : "Create a research document from the knowledge graph."}
           </DialogDescription>
         </DialogHeader>
+
+        {workflowRunId ? (
+          <div className="py-4">
+            <SynthesisProgress
+              workflowRunId={workflowRunId}
+              onComplete={handleProgressComplete}
+            />
+          </div>
+        ) : (
+        <>
         <div className="space-y-4 py-4">
           {/* Mode selector */}
           <div className="space-y-2">
@@ -309,6 +329,8 @@ export function CreateSynthesisDialog({
             {mode === "super" ? "Create Super-Synthesis" : "Create Synthesis"}
           </Button>
         </DialogFooter>
+        </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/synthesis/SynthesisProgress.tsx
+++ b/frontend/src/components/synthesis/SynthesisProgress.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Loader2, CheckCircle2, XCircle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getWorkflowProgress } from "@/lib/api";
+import type { PipelineTaskItem } from "@/types";
+
+interface SynthesisProgressProps {
+  workflowRunId: string;
+  onComplete: () => void;
+}
+
+type OverallStatus = "running" | "completed" | "failed";
+
+function taskStatusIcon(status: string) {
+  const upper = status.toUpperCase();
+  if (upper === "SUCCEEDED" || upper === "COMPLETED")
+    return <CheckCircle2 className="size-4 text-green-500 shrink-0" />;
+  if (upper === "FAILED" || upper === "CANCELLED" || upper === "TIMED_OUT")
+    return <XCircle className="size-4 text-red-500 shrink-0" />;
+  if (upper === "RUNNING")
+    return <Loader2 className="size-4 animate-spin text-blue-500 shrink-0" />;
+  return <div className="size-4 rounded-full border-2 border-muted-foreground/30 shrink-0" />;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = ms / 1000;
+  if (secs < 60) return `${secs.toFixed(1)}s`;
+  const mins = Math.floor(secs / 60);
+  const remSecs = Math.round(secs % 60);
+  return `${mins}m${remSecs}s`;
+}
+
+export function SynthesisProgress({ workflowRunId, onComplete }: SynthesisProgressProps) {
+  const [status, setStatus] = useState<OverallStatus>("running");
+  const [tasks, setTasks] = useState<PipelineTaskItem[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchProgress = async () => {
+      try {
+        const progress = await getWorkflowProgress(workflowRunId);
+        if (cancelled) return;
+        setTasks(progress.tasks);
+
+        if (progress.status === "completed") {
+          setStatus("completed");
+          onComplete();
+        } else if (progress.status === "failed") {
+          setStatus("failed");
+        }
+      } catch {
+        // Ignore transient errors, keep polling
+      }
+    };
+
+    fetchProgress();
+
+    if (status === "running") {
+      const timer = setInterval(fetchProgress, 3000);
+      return () => { cancelled = true; clearInterval(timer); };
+    }
+
+    return () => { cancelled = true; };
+  }, [workflowRunId, status, onComplete]);
+
+  const completed = tasks.filter(
+    (t) => t.status === "SUCCEEDED" || t.status === "COMPLETED"
+  ).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        {status === "running" ? (
+          <Loader2 className="size-5 animate-spin text-blue-500" />
+        ) : status === "completed" ? (
+          <CheckCircle2 className="size-5 text-green-500" />
+        ) : (
+          <XCircle className="size-5 text-red-500" />
+        )}
+        <span className="font-medium">
+          {status === "running"
+            ? "Synthesizing..."
+            : status === "completed"
+              ? "Synthesis Complete"
+              : "Synthesis Failed"}
+        </span>
+        {tasks.length > 0 && (
+          <Badge variant="outline" className="ml-auto text-xs tabular-nums">
+            {completed} / {tasks.length}
+          </Badge>
+        )}
+      </div>
+
+      {tasks.length > 0 && (
+        <>
+          <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
+            <div
+              className="h-full bg-primary transition-all duration-500 rounded-full"
+              style={{ width: `${tasks.length > 0 ? (completed / tasks.length) * 100 : 0}%` }}
+            />
+          </div>
+
+          <div className="max-h-48 overflow-y-auto space-y-1">
+            {tasks.map((task) => (
+              <div
+                key={task.task_id}
+                className="flex items-center gap-2 px-2 py-1.5 text-sm"
+              >
+                {taskStatusIcon(task.status)}
+                <span className="flex-1 truncate">{task.display_name}</span>
+                {task.duration_ms != null && (
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {formatDuration(task.duration_ms)}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {status === "completed" && (
+        <Button variant="outline" className="w-full" onClick={onComplete}>
+          Done
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -76,6 +76,7 @@ import type {
   PaginatedSynthesesResponse,
   SentenceFactLink,
   SynthesisNodeResponse,
+  PipelineSnapshotResponse,
 } from "@/types";
 
 const BASE_URL =
@@ -1146,6 +1147,12 @@ export async function createSuperSynthesis(data: CreateSuperSynthesisRequest) {
   return request<{ status: string; workflow_run_id: string; topic: string }>(
     "/super-syntheses",
     { method: "POST", body: JSON.stringify(data) }
+  );
+}
+
+export async function getWorkflowProgress(workflowRunId: string) {
+  return request<PipelineSnapshotResponse>(
+    `/workflows/${encodeURIComponent(workflowRunId)}/progress`
   );
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -875,6 +875,13 @@ export interface PipelineTaskItem {
   children: PipelineTaskItem[];
 }
 
+export interface PipelineSnapshotResponse {
+  message_id: string;
+  workflow_run_id: string | null;
+  status: string; // "pending" | "running" | "completed" | "failed"
+  tasks: PipelineTaskItem[];
+}
+
 export interface ProgressResponse {
   message_id: string;
   status: string; // "pending" | "running" | "completed" | "failed"

--- a/libs/kt-hatchet/src/kt_hatchet/client.py
+++ b/libs/kt-hatchet/src/kt_hatchet/client.py
@@ -27,6 +27,25 @@ def get_hatchet() -> Hatchet:
     return Hatchet()
 
 
+async def get_workflow_run_details(workflow_run_id: str) -> object:
+    """Fetch full workflow run details (status + task tree) from Hatchet.
+
+    Returns a ``V1WorkflowRunDetails`` object with ``.run`` (status, timestamps),
+    ``.tasks`` (list of ``V1TaskSummary``), and ``.task_events``.
+
+    Raises ``RuntimeError`` if the Hatchet API is unreachable.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    h = get_hatchet()
+    try:
+        return await h.runs.aio_get(workflow_run_id)
+    except Exception as exc:
+        logger.warning("Failed to fetch workflow run %s: %s", workflow_run_id, exc)
+        raise RuntimeError(f"Failed to fetch workflow run '{workflow_run_id}': {exc}") from exc
+
+
 async def dispatch_workflow(
     workflow_name: str,
     input: dict,

--- a/libs/kt-hatchet/src/kt_hatchet/progress.py
+++ b/libs/kt-hatchet/src/kt_hatchet/progress.py
@@ -1,0 +1,64 @@
+"""Map Hatchet SDK workflow run details to progress dicts.
+
+These functions transform Hatchet's native ``V1WorkflowRunDetails`` and
+``V1TaskSummary`` objects into plain dicts that the API layer converts
+to Pydantic response models (``PipelineTaskItem``, ``ProgressResponse``).
+
+This module lives in ``kt-hatchet`` (not in the API service) because it
+needs knowledge of Hatchet SDK types, but returns plain dicts so that
+libs never import from services.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def map_task_summary(task: Any) -> dict[str, Any]:
+    """Map a Hatchet ``V1TaskSummary`` to a ``PipelineTaskItem``-shaped dict.
+
+    The dict keys match the ``PipelineTaskItem`` Pydantic model fields.
+    """
+    status_str: str = task.status.value  # e.g. "COMPLETED", "RUNNING"
+    if status_str == "COMPLETED":
+        status_str = "SUCCEEDED"  # Frontend expects "SUCCEEDED"
+
+    started_at: str | None = None
+    if task.started_at is not None:
+        started_at = task.started_at.isoformat()
+
+    children: list[dict[str, Any]] = []
+    if task.children:
+        children = [map_task_summary(c) for c in task.children]
+
+    return {
+        "task_id": task.task_external_id,
+        "display_name": task.display_name,
+        "status": status_str,
+        "duration_ms": task.duration,
+        "started_at": started_at,
+        "children": children,
+        "wave_number": None,
+        "node_type": None,
+    }
+
+
+def map_run_status(details: Any) -> str:
+    """Map ``V1WorkflowRunDetails.run.status`` to a progress status string.
+
+    Returns one of: ``"pending"``, ``"running"``, ``"completed"``, ``"failed"``.
+    """
+    status_value: str = details.run.status.value
+    if status_value == "QUEUED":
+        return "pending"
+    if status_value == "RUNNING":
+        return "running"
+    if status_value == "COMPLETED":
+        return "completed"
+    # FAILED, CANCELLED
+    return "failed"
+
+
+def map_run_error(details: Any) -> str | None:
+    """Extract error message from a workflow run, if any."""
+    return details.run.error_message

--- a/libs/kt-hatchet/tests/test_progress.py
+++ b/libs/kt-hatchet/tests/test_progress.py
@@ -1,0 +1,155 @@
+"""Unit tests for kt_hatchet.progress mapping functions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kt_hatchet.progress import map_run_error, map_run_status, map_task_summary
+
+
+def _make_status(value: str) -> SimpleNamespace:
+    """Create a mock V1TaskStatus enum member."""
+    return SimpleNamespace(value=value)
+
+
+def _make_task(
+    *,
+    task_external_id: str = "abc-123",
+    display_name: str = "create_node",
+    status: str = "RUNNING",
+    duration: int | None = None,
+    started_at: object | None = None,
+    children: list | None = None,
+) -> SimpleNamespace:
+    """Create a mock V1TaskSummary."""
+    return SimpleNamespace(
+        task_external_id=task_external_id,
+        display_name=display_name,
+        status=_make_status(status),
+        duration=duration,
+        started_at=started_at,
+        children=children,
+    )
+
+
+def _make_details(
+    run_status: str = "RUNNING",
+    error_message: str | None = None,
+    tasks: list | None = None,
+) -> SimpleNamespace:
+    """Create a mock V1WorkflowRunDetails."""
+    return SimpleNamespace(
+        run=SimpleNamespace(
+            status=_make_status(run_status),
+            error_message=error_message,
+        ),
+        tasks=tasks or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# map_task_summary
+# ---------------------------------------------------------------------------
+
+
+class TestMapTaskSummary:
+    def test_basic_running_task(self) -> None:
+        task = _make_task(status="RUNNING", display_name="dimensions")
+        result = map_task_summary(task)
+        assert result["task_id"] == "abc-123"
+        assert result["display_name"] == "dimensions"
+        assert result["status"] == "RUNNING"
+        assert result["duration_ms"] is None
+        assert result["started_at"] is None
+        assert result["children"] == []
+
+    def test_completed_maps_to_succeeded(self) -> None:
+        task = _make_task(status="COMPLETED", duration=1500)
+        result = map_task_summary(task)
+        assert result["status"] == "SUCCEEDED"
+        assert result["duration_ms"] == 1500
+
+    def test_failed_status_preserved(self) -> None:
+        task = _make_task(status="FAILED")
+        result = map_task_summary(task)
+        assert result["status"] == "FAILED"
+
+    def test_queued_status_preserved(self) -> None:
+        task = _make_task(status="QUEUED")
+        result = map_task_summary(task)
+        assert result["status"] == "QUEUED"
+
+    def test_cancelled_status_preserved(self) -> None:
+        task = _make_task(status="CANCELLED")
+        result = map_task_summary(task)
+        assert result["status"] == "CANCELLED"
+
+    def test_started_at_formatted(self) -> None:
+        from datetime import datetime, timezone
+
+        dt = datetime(2026, 3, 27, 12, 0, 0, tzinfo=timezone.utc)
+        task = _make_task(started_at=dt)
+        result = map_task_summary(task)
+        assert result["started_at"] == "2026-03-27T12:00:00+00:00"
+
+    def test_children_recursively_mapped(self) -> None:
+        child = _make_task(
+            task_external_id="child-1",
+            display_name="child_task",
+            status="COMPLETED",
+            duration=500,
+        )
+        parent = _make_task(
+            task_external_id="parent-1",
+            display_name="parent_task",
+            status="RUNNING",
+            children=[child],
+        )
+        result = map_task_summary(parent)
+        assert len(result["children"]) == 1
+        assert result["children"][0]["task_id"] == "child-1"
+        assert result["children"][0]["status"] == "SUCCEEDED"
+
+    def test_wave_number_and_node_type_default_none(self) -> None:
+        task = _make_task()
+        result = map_task_summary(task)
+        assert result["wave_number"] is None
+        assert result["node_type"] is None
+
+
+# ---------------------------------------------------------------------------
+# map_run_status
+# ---------------------------------------------------------------------------
+
+
+class TestMapRunStatus:
+    @pytest.mark.parametrize(
+        ("hatchet_status", "expected"),
+        [
+            ("QUEUED", "pending"),
+            ("RUNNING", "running"),
+            ("COMPLETED", "completed"),
+            ("FAILED", "failed"),
+            ("CANCELLED", "failed"),
+        ],
+    )
+    def test_status_mapping(self, hatchet_status: str, expected: str) -> None:
+        details = _make_details(run_status=hatchet_status)
+        assert map_run_status(details) == expected
+
+
+# ---------------------------------------------------------------------------
+# map_run_error
+# ---------------------------------------------------------------------------
+
+
+class TestMapRunError:
+    def test_no_error(self) -> None:
+        details = _make_details(error_message=None)
+        assert map_run_error(details) is None
+
+    def test_with_error(self) -> None:
+        details = _make_details(error_message="task timed out")
+        assert map_run_error(details) == "task timed out"

--- a/services/api/src/kt_api/progress.py
+++ b/services/api/src/kt_api/progress.py
@@ -1,0 +1,157 @@
+"""Progress and report endpoints for workflow tracking.
+
+These endpoints provide real-time progress feedback for research and
+synthesis workflows by querying Hatchet's native run/task status API.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_api.dependencies import get_db_session
+from kt_api.schemas import (
+    PipelineSnapshotResponse,
+    PipelineTaskItem,
+    ProgressResponse,
+    ResearchReportResponse,
+)
+from kt_db.repositories.conversations import ConversationRepository
+from kt_db.repositories.research_reports import ResearchReportRepository
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["progress"])
+
+
+def _build_task_items(details: object) -> list[PipelineTaskItem]:
+    """Convert Hatchet V1WorkflowRunDetails.tasks to PipelineTaskItem list."""
+    from kt_hatchet.progress import map_task_summary
+
+    tasks: list = getattr(details, "tasks", []) or []
+    return [PipelineTaskItem(**map_task_summary(t)) for t in tasks]
+
+
+@router.get(
+    "/conversations/{conversation_id}/messages/{message_id}/progress",
+    response_model=ProgressResponse,
+)
+async def get_message_progress(
+    conversation_id: str,
+    message_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> ProgressResponse:
+    """Get live progress for a workflow attached to a conversation message.
+
+    Merges database message state with Hatchet task tree status.
+    """
+    conv_repo = ConversationRepository(session)
+    msg = await conv_repo.get_message(uuid.UUID(message_id))
+    if msg is None:
+        raise HTTPException(status_code=404, detail="Message not found")
+    if str(msg.conversation_id) != conversation_id:
+        raise HTTPException(status_code=404, detail="Message not found in this conversation")
+
+    # Base response from DB fields
+    status = msg.status or "completed"
+    error: str | None = msg.error
+    task_items: list[PipelineTaskItem] = []
+
+    # Query Hatchet for live task tree if we have a workflow run ID
+    if msg.workflow_run_id:
+        try:
+            from kt_hatchet.client import get_workflow_run_details
+            from kt_hatchet.progress import map_run_error, map_run_status
+
+            details = await get_workflow_run_details(msg.workflow_run_id)
+            status = map_run_status(details)
+            error = error or map_run_error(details)
+            task_items = _build_task_items(details)
+        except RuntimeError:
+            logger.debug(
+                "Hatchet unavailable for run %s, falling back to DB status",
+                msg.workflow_run_id,
+            )
+
+    return ProgressResponse(
+        message_id=str(msg.id),
+        status=status,
+        content=msg.content or "",
+        error=error,
+        subgraph=None,
+        nav_budget=msg.nav_budget,
+        explore_budget=msg.explore_budget,
+        nav_used=msg.nav_used,
+        explore_used=msg.explore_used,
+        visited_nodes=msg.visited_nodes,
+        created_nodes=msg.created_nodes,
+        created_edges=msg.created_edges,
+        tasks=task_items,
+    )
+
+
+@router.get(
+    "/conversations/{conversation_id}/messages/{message_id}/report",
+    response_model=ResearchReportResponse,
+)
+async def get_message_report(
+    conversation_id: str,
+    message_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> ResearchReportResponse:
+    """Get the persisted research report for a completed workflow."""
+    report_repo = ResearchReportRepository(session)
+    report = await report_repo.get_by_message_id(uuid.UUID(message_id))
+    if report is None:
+        raise HTTPException(status_code=404, detail="Report not found")
+    if str(report.conversation_id) != conversation_id:
+        raise HTTPException(status_code=404, detail="Report not found in this conversation")
+
+    return ResearchReportResponse(
+        message_id=str(report.message_id),
+        nodes_created=report.nodes_created,
+        edges_created=report.edges_created,
+        waves_completed=report.waves_completed,
+        explore_budget=report.explore_budget,
+        explore_used=report.explore_used,
+        nav_budget=report.nav_budget,
+        nav_used=report.nav_used,
+        scope_summaries=report.scope_summaries or [],
+        super_sources=report.super_sources,
+        total_prompt_tokens=report.total_prompt_tokens,
+        total_completion_tokens=report.total_completion_tokens,
+        total_cost_usd=report.total_cost_usd,
+        created_at=report.created_at,
+    )
+
+
+@router.get(
+    "/workflows/{workflow_run_id}/progress",
+    response_model=PipelineSnapshotResponse,
+)
+async def get_workflow_progress(
+    workflow_run_id: str,
+) -> PipelineSnapshotResponse:
+    """Get live task progress for any workflow run by its Hatchet run ID.
+
+    Useful for synthesis and other workflows not tied to a conversation message.
+    """
+    try:
+        from kt_hatchet.client import get_workflow_run_details
+        from kt_hatchet.progress import map_run_status
+
+        details = await get_workflow_run_details(workflow_run_id)
+        return PipelineSnapshotResponse(
+            message_id="",
+            workflow_run_id=workflow_run_id,
+            status=map_run_status(details),
+            tasks=_build_task_items(details),
+        )
+    except RuntimeError:
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to fetch workflow status from Hatchet",
+        )

--- a/services/api/src/kt_api/router.py
+++ b/services/api/src/kt_api/router.py
@@ -17,6 +17,7 @@ from kt_api.graph_builder import router as graph_builder_router
 from kt_api.import_router import router as import_router
 from kt_api.members import router as members_router
 from kt_api.nodes import router as nodes_router
+from kt_api.progress import router as progress_router
 from kt_api.prompt_transparency import router as prompts_router
 from kt_api.research import router as research_router
 from kt_api.seeds import router as seeds_router
@@ -47,6 +48,7 @@ api_router.include_router(graph_builder_router, dependencies=_auth_dep)
 api_router.include_router(usage_router, dependencies=_auth_dep)
 api_router.include_router(members_router, dependencies=_auth_dep)
 api_router.include_router(syntheses_router, dependencies=_auth_dep)
+api_router.include_router(progress_router, dependencies=_auth_dep)
 api_router.include_router(system_settings_router, dependencies=_auth_dep)
 # Prompt transparency is public — supports research credibility
 api_router.include_router(prompts_router)

--- a/services/api/tests/integration/test_progress.py
+++ b/services/api/tests/integration/test_progress.py
@@ -1,0 +1,278 @@
+"""Integration tests for progress and report endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from kt_api.dependencies import get_db_session
+from kt_api.main import create_app
+from kt_db.models import Conversation, ConversationMessage, ResearchReport
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def session_factory(engine):
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def app(session_factory):
+    application = create_app()
+
+    async def override_get_db_session() -> AsyncGenerator[AsyncSession, None]:
+        async with session_factory() as session:
+            yield session
+
+    application.dependency_overrides[get_db_session] = override_get_db_session
+    return application
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture()
+async def conversation_with_message(session_factory):
+    """Create a conversation with an assistant message that has a workflow_run_id."""
+    async with session_factory() as session:
+        async with session.begin():
+            conv = Conversation(id=uuid.uuid4(), title="test", mode="research")
+            session.add(conv)
+            await session.flush()
+
+            msg = ConversationMessage(
+                id=uuid.uuid4(),
+                conversation_id=conv.id,
+                turn_number=1,
+                role="assistant",
+                content="",
+                status="running",
+                workflow_run_id="hatchet-run-123",
+                explore_budget=50,
+            )
+            session.add(msg)
+            await session.flush()
+
+        yield conv, msg
+
+
+@pytest_asyncio.fixture()
+async def conversation_with_report(session_factory):
+    """Create a conversation with a completed message and a research report."""
+    async with session_factory() as session:
+        async with session.begin():
+            conv = Conversation(id=uuid.uuid4(), title="test report", mode="research")
+            session.add(conv)
+            await session.flush()
+
+            msg = ConversationMessage(
+                id=uuid.uuid4(),
+                conversation_id=conv.id,
+                turn_number=1,
+                role="assistant",
+                content="done",
+                status="completed",
+                workflow_run_id="hatchet-run-456",
+            )
+            session.add(msg)
+            await session.flush()
+
+            report = ResearchReport(
+                id=uuid.uuid4(),
+                message_id=msg.id,
+                conversation_id=conv.id,
+                nodes_created=5,
+                edges_created=3,
+                waves_completed=2,
+                explore_budget=50,
+                explore_used=30,
+                nav_budget=10,
+                nav_used=8,
+                scope_summaries=["Explored topic A"],
+                total_prompt_tokens=1000,
+                total_completion_tokens=500,
+                total_cost_usd=0.05,
+            )
+            session.add(report)
+            await session.flush()
+
+        yield conv, msg
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hatchet_details(
+    run_status: str = "RUNNING",
+    tasks: list | None = None,
+    error_message: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        run=SimpleNamespace(
+            status=SimpleNamespace(value=run_status),
+            error_message=error_message,
+        ),
+        tasks=tasks or [],
+    )
+
+
+def _make_hatchet_task(
+    task_external_id: str = "task-1",
+    display_name: str = "create_node",
+    status: str = "RUNNING",
+    duration: int | None = None,
+    started_at: object | None = None,
+    children: list | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        task_external_id=task_external_id,
+        display_name=display_name,
+        status=SimpleNamespace(value=status),
+        duration=duration,
+        started_at=started_at,
+        children=children,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations/{id}/messages/{msgId}/progress
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessageProgress:
+    async def test_returns_progress_with_hatchet_tasks(self, client: AsyncClient, conversation_with_message):
+        conv, msg = conversation_with_message
+        hatchet_details = _make_hatchet_details(
+            run_status="RUNNING",
+            tasks=[
+                _make_hatchet_task(status="COMPLETED", display_name="create_node", duration=1200),
+                _make_hatchet_task(task_external_id="task-2", status="RUNNING", display_name="dimensions"),
+            ],
+        )
+
+        with patch(
+            "kt_hatchet.client.get_workflow_run_details",
+            new_callable=AsyncMock,
+            return_value=hatchet_details,
+        ):
+            resp = await client.get(f"/api/v1/conversations/{conv.id}/messages/{msg.id}/progress")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "running"
+        assert data["message_id"] == str(msg.id)
+        assert data["explore_budget"] == 50
+        assert len(data["tasks"]) == 2
+        assert data["tasks"][0]["status"] == "SUCCEEDED"
+        assert data["tasks"][0]["display_name"] == "create_node"
+        assert data["tasks"][0]["duration_ms"] == 1200
+        assert data["tasks"][1]["status"] == "RUNNING"
+
+    async def test_fallback_to_db_when_hatchet_unavailable(self, client: AsyncClient, conversation_with_message):
+        conv, msg = conversation_with_message
+
+        with patch(
+            "kt_hatchet.client.get_workflow_run_details",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Hatchet down"),
+        ):
+            resp = await client.get(f"/api/v1/conversations/{conv.id}/messages/{msg.id}/progress")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "running"  # Falls back to DB status
+        assert data["tasks"] == []
+
+    async def test_not_found_for_nonexistent_message(self, client: AsyncClient):
+        fake_conv = str(uuid.uuid4())
+        fake_msg = str(uuid.uuid4())
+        resp = await client.get(f"/api/v1/conversations/{fake_conv}/messages/{fake_msg}/progress")
+        assert resp.status_code == 404
+
+    async def test_not_found_for_wrong_conversation(self, client: AsyncClient, conversation_with_message):
+        _, msg = conversation_with_message
+        wrong_conv = str(uuid.uuid4())
+        resp = await client.get(f"/api/v1/conversations/{wrong_conv}/messages/{msg.id}/progress")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations/{id}/messages/{msgId}/report
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessageReport:
+    async def test_returns_report(self, client: AsyncClient, conversation_with_report):
+        conv, msg = conversation_with_report
+        resp = await client.get(f"/api/v1/conversations/{conv.id}/messages/{msg.id}/report")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["message_id"] == str(msg.id)
+        assert data["nodes_created"] == 5
+        assert data["edges_created"] == 3
+        assert data["waves_completed"] == 2
+        assert data["explore_budget"] == 50
+        assert data["explore_used"] == 30
+        assert data["scope_summaries"] == ["Explored topic A"]
+        assert data["total_cost_usd"] == pytest.approx(0.05)
+
+    async def test_not_found_for_nonexistent_report(self, client: AsyncClient):
+        fake_conv = str(uuid.uuid4())
+        fake_msg = str(uuid.uuid4())
+        resp = await client.get(f"/api/v1/conversations/{fake_conv}/messages/{fake_msg}/report")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /workflows/{workflow_run_id}/progress
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkflowProgress:
+    async def test_returns_workflow_progress(self, client: AsyncClient):
+        hatchet_details = _make_hatchet_details(
+            run_status="COMPLETED",
+            tasks=[
+                _make_hatchet_task(status="COMPLETED", display_name="synthesize", duration=5000),
+            ],
+        )
+
+        with patch(
+            "kt_hatchet.client.get_workflow_run_details",
+            new_callable=AsyncMock,
+            return_value=hatchet_details,
+        ):
+            resp = await client.get("/api/v1/workflows/run-789/progress")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "completed"
+        assert data["workflow_run_id"] == "run-789"
+        assert len(data["tasks"]) == 1
+        assert data["tasks"][0]["status"] == "SUCCEEDED"
+
+    async def test_502_when_hatchet_unavailable(self, client: AsyncClient):
+        with patch(
+            "kt_hatchet.client.get_workflow_run_details",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Hatchet down"),
+        ):
+            resp = await client.get("/api/v1/workflows/run-bad/progress")
+
+        assert resp.status_code == 502


### PR DESCRIPTION
## Summary

- Implement the missing `GET /progress` and `GET /report` endpoints that the frontend already polls, using Hatchet's native `runs.aio_get()` to query real workflow task statuses instead of custom streaming
- Add `GET /workflows/{id}/progress` generic endpoint for synthesis workflow tracking
- Add `SynthesisProgress` component with live task tree + progress bar in the create dialog
- Graceful fallback to DB-only status when Hatchet is unavailable

## Test plan

- [x] 15 unit tests for V1TaskSummary -> PipelineTaskItem mapping functions
- [x] 8 integration tests for progress/report/workflow endpoints (mocked Hatchet)
- [x] Frontend lint, type-check, and 123 tests all pass
- [ ] Manual: trigger bottom-up research, observe ResearchBuildProgress showing live task statuses
- [ ] Manual: create synthesis, observe SynthesisProgress in dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)