### PR TITLE
fix(api): correct workflow dispatch names to match registered names

### DIFF
--- a/services/api/src/kt_api/edges.py
+++ b/services/api/src/kt_api/edges.py
@@ -178,7 +178,7 @@ async def enrich_edge(
     from kt_hatchet.client import dispatch_workflow
 
     api_key = require_api_key(user)
-    await dispatch_workflow("enrich_edge_task", {"edge_id": edge_id, "api_key": api_key})
+    await dispatch_workflow("enrich_edge", {"edge_id": edge_id, "api_key": api_key})
     return {"status": "started", "edge_id": edge_id}
 
 

--- a/services/api/src/kt_api/graph_builder.py
+++ b/services/api/src/kt_api/graph_builder.py
@@ -23,5 +23,5 @@ async def auto_build_graph() -> dict[str, str]:
     """
     from kt_hatchet.client import dispatch_workflow
 
-    run_id = await dispatch_workflow("auto_build_task", {})
+    run_id = await dispatch_workflow("auto_build_graph", {})
     return {"status": "started", "workflow_run_id": run_id}

--- a/services/api/src/kt_api/nodes.py
+++ b/services/api/src/kt_api/nodes.py
@@ -616,7 +616,7 @@ async def rebuild_node(
     scope = (body or {}).get("scope", "all")
     api_key = require_api_key(user)
     await dispatch_workflow(
-        "rebuild_node_task",
+        "rebuild_node",
         {
             "node_id": node_id,
             "mode": mode,
@@ -818,7 +818,7 @@ async def enrich_node(
 
     from kt_hatchet.client import dispatch_workflow
 
-    await dispatch_workflow("rebuild_node_task", {"node_id": node_id, "mode": "full", "scope": "all"})
+    await dispatch_workflow("rebuild_node", {"node_id": node_id, "mode": "full", "scope": "all"})
     return {"status": "started", "node_id": node_id}
 
 
@@ -852,7 +852,7 @@ async def quick_add_node(
         from kt_hatchet.client import dispatch_workflow
 
         await dispatch_workflow(
-            "rebuild_node_task",
+            "rebuild_node",
             {
                 "node_id": str(match.id),
                 "mode": "full",
@@ -887,7 +887,7 @@ async def quick_add_node(
         await ws.commit()
 
     run_id = await dispatch_workflow(
-        "node_pipeline_wf",
+        "node_pipeline",
         {
             "scope_id": scope_id,
             "concept": concept,
@@ -1062,7 +1062,7 @@ async def quick_add_perspective(
 
         await asyncio.gather(
             dispatch_workflow(
-                "node_pipeline_wf",
+                "node_pipeline",
                 {
                     "scope_id": scope_id,
                     "concept": body.thesis,
@@ -1073,7 +1073,7 @@ async def quick_add_perspective(
                 },
             ),
             dispatch_workflow(
-                "node_pipeline_wf",
+                "node_pipeline",
                 {
                     "scope_id": scope_id,
                     "concept": body.antithesis,
@@ -1129,7 +1129,7 @@ async def regenerate_composite(
 
     from kt_hatchet.client import dispatch_workflow
 
-    await dispatch_workflow("regenerate_composite_task", {"node_id": node_id})
+    await dispatch_workflow("regenerate_composite", {"node_id": node_id})
     return {"status": "started", "node_id": node_id}
 
 

--- a/services/api/src/kt_api/research.py
+++ b/services/api/src/kt_api/research.py
@@ -350,7 +350,7 @@ async def confirm_ingest(
 
     api_key = require_api_key(user)
     run_id = await dispatch_workflow(
-        "ingest_confirm_wf",
+        "ingest_confirm",
         {
             "nav_budget": body.nav_budget,
             "selected_chunks": body.selected_chunks,
@@ -493,7 +493,7 @@ async def decompose_ingest(
 
     api_key = require_api_key(user)
     run_id = await dispatch_workflow(
-        "ingest_decompose_wf",
+        "ingest_decompose",
         {
             "conversation_id": conversation_id,
             "message_id": str(assistant_msg.id),
@@ -659,7 +659,7 @@ async def build_ingest(
 
     api_key = require_api_key(user)
     run_id = await dispatch_workflow(
-        "ingest_build_wf",
+        "ingest_build",
         IngestBuildInput(
             selected_nodes=confirmed_nodes,
             conversation_id=str(conv_uuid),
@@ -725,7 +725,7 @@ async def bottom_up_prepare(
 
     api_key = require_api_key(user)
     run_id = await dispatch_workflow(
-        "bottom_up_prepare_wf",
+        "bottom_up_prepare",
         {
             "query": body.query,
             "explore_budget": body.explore_budget,
@@ -992,7 +992,7 @@ async def agent_select(
 
     api_key = require_api_key(user)
     await dispatch_workflow(
-        "agent_select_wf",
+        "agent_select",
         {
             "proposed_nodes": proposed_nodes,
             "max_select": body.max_select,

--- a/services/api/src/kt_api/seeds.py
+++ b/services/api/src/kt_api/seeds.py
@@ -193,7 +193,7 @@ async def synthesize_perspective(seed_key: str) -> SynthesizeResponse:
         # Build thesis
         try:
             await run_workflow(
-                "build_composite_task",
+                "build_composite",
                 {
                     "node_type": "perspective",
                     "concept": claim,
@@ -213,7 +213,7 @@ async def synthesize_perspective(seed_key: str) -> SynthesizeResponse:
         if antithesis:
             try:
                 await run_workflow(
-                    "build_composite_task",
+                    "build_composite",
                     {
                         "node_type": "perspective",
                         "concept": antithesis,
@@ -327,7 +327,7 @@ async def promote_seed_to_node(
 
     try:
         run_id = await dispatch_workflow(
-            "node_pipeline_wf",
+            "node_pipeline",
             {
                 "scope_id": scope_id,
                 "concept": seed.name,

--- a/services/api/src/kt_api/sources.py
+++ b/services/api/src/kt_api/sources.py
@@ -183,7 +183,7 @@ async def reingest_source(
     from kt_hatchet.client import run_workflow
     from kt_hatchet.models import ReingestSourceOutput
 
-    result = await run_workflow("reingest_source_wf", {"raw_source_id": source_id})
+    result = await run_workflow("reingest_source", {"raw_source_id": source_id})
     output = ReingestSourceOutput.model_validate(result)
 
     # Refresh source detail after workflow completion


### PR DESCRIPTION
## Summary
- Fixes all API `dispatch_workflow`/`run_workflow` calls that used incorrect workflow names
- 12 dispatch names were mismatched (wrong suffix like `_wf` or `_task`) causing Hatchet to silently accept the dispatch but never execute the workflow
- This broke all research flows: bottom-up prepare, ingest, node pipeline, edge enrichment, etc.

## Test plan
- [ ] CI passes
- [ ] Start a bottom-up research in dev — workflow should appear in Hatchet UI and execute
- [ ] Verify ingest and node pipeline flows work

🤖 Generated with [Claude Code](https://claude.com/claude-code)