### PR TITLE
feat: add plugin system with hooks, RBAC, and extension points

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,322 @@
+# Knowledge Tree Plugin API
+
+This document defines the **Plugin API** referenced by the AGPL Plugin Exception in the [LICENSE](LICENSE) (Section 7, lines 237-289). Independent modules that communicate **solely** through this documented API may be conveyed under terms of your choice.
+
+## Overview
+
+Knowledge Tree plugins are standard Python packages discovered via `importlib.metadata` entry points. They extend the platform through typed extension points, async hooks, and FastAPI route contribution — without modifying core source code.
+
+## Plugin Package Structure
+
+```
+kt-plugin-<name>/
+  pyproject.toml              # declares entry point + dependencies
+  src/kt_plugin_<name>/
+    __init__.py
+    manifest.py               # PluginManifest instance
+    lifecycle.py              # PluginLifecycle implementation
+    routes.py                 # FastAPI router(s) (optional)
+    models.py                 # SQLAlchemy models (optional)
+    migrations/               # Alembic migrations (optional)
+      env.py
+      versions/
+    settings.py               # Plugin-specific Pydantic settings (optional)
+  tests/
+```
+
+### Entry Point Declaration
+
+In `pyproject.toml`, declare your plugin in the `kt.plugins` entry point group:
+
+```toml
+[project.entry-points."kt.plugins"]
+<name> = "kt_plugin_<name>.manifest:plugin_manifest"
+```
+
+The entry point must resolve to a `PluginManifest` instance.
+
+## PluginManifest
+
+```python
+from kt_plugins.manifest import PluginManifest
+
+plugin_manifest = PluginManifest(
+    id="my-plugin",                    # unique identifier
+    name="My Plugin",                  # human-readable name
+    version="1.0.0",
+    description="What this plugin does",
+    author="Your Name",
+    license="proprietary",             # or "AGPL-3.0"
+    requires_license_key=False,        # True for commercial plugins
+    lifecycle=MyPluginLifecycle(),      # PluginLifecycle implementation
+    settings_class=MyPluginSettings,   # Pydantic BaseSettings subclass (optional)
+    migration_path="path/to/migrations", # Alembic versions dir (optional)
+    dependencies=["other-plugin"],     # Plugin IDs this depends on (optional)
+)
+```
+
+## PluginLifecycle Protocol
+
+Plugins implement the `PluginLifecycle` protocol:
+
+```python
+from kt_plugins.extension_points import ExtensionRegistry
+from kt_plugins.context import PluginContext
+
+class MyPluginLifecycle:
+    async def register(self, registry: ExtensionRegistry) -> None:
+        """Phase 1: Declare extensions. No runtime services available yet."""
+        registry.add_routes(my_router, auth_required=True, prefix="my-plugin")
+
+    async def bootstrap(self, ctx: PluginContext) -> None:
+        """Phase 2: Access runtime services, subscribe to hooks."""
+        ctx.hook_registry.register("usage.record", my_handler, priority=100)
+
+    async def shutdown(self) -> None:
+        """Cleanup on application shutdown."""
+        pass
+```
+
+### Lifecycle Phases
+
+1. **Discovery** — Plugins found via `importlib.metadata` entry points
+2. **Register** — `register()` called; declare routes, providers, hooks, workflows
+3. **Bootstrap** — `bootstrap()` called with `PluginContext`; access services, subscribe to hooks
+4. **Shutdown** — `shutdown()` called in reverse order on application exit
+
+## PluginContext
+
+Provided during the bootstrap phase:
+
+```python
+@dataclass
+class PluginContext:
+    plugin_id: str                                          # Your plugin's ID
+    settings: Any                                           # Your resolved settings (or None)
+    hook_registry: HookRegistry                             # Subscribe to hooks
+    session_factory: async_sessionmaker[AsyncSession] | None  # Graph-db sessions
+    write_session_factory: async_sessionmaker[AsyncSession] | None  # Write-db sessions
+```
+
+## Extension Points
+
+### Routes
+
+Contribute FastAPI routers mounted at `/api/v1/plugins/<prefix>/`:
+
+```python
+from fastapi import APIRouter
+
+router = APIRouter(tags=["my-plugin"])
+
+@router.get("/status")
+async def get_status():
+    return {"status": "ok"}
+
+# In register():
+registry.add_routes(router, auth_required=True, prefix="my-plugin")
+```
+
+### Knowledge Providers
+
+Contribute search providers implementing `KnowledgeProvider` ABC:
+
+```python
+registry.add_provider(lambda ctx: MySearchProvider(ctx.settings.api_key))
+```
+
+### Auth Backends
+
+Contribute authentication backends (SSO, OIDC, SAML):
+
+```python
+registry.add_auth_backend(lambda ctx: create_saml_backend(ctx.settings))
+```
+
+### Workflows
+
+Contribute Hatchet workflows:
+
+```python
+registry.add_workflow(my_hatchet_workflow)
+```
+
+### Custom Types
+
+Register new node or fact types:
+
+```python
+registry.add_node_type("custom_type", {"description": "My custom node type"})
+registry.add_fact_type("custom_fact", {"description": "My custom fact type"})
+```
+
+## Hook System
+
+Hooks enable cross-cutting concerns without modifying core code. Two invocation styles:
+
+### Trigger Hooks (Actions)
+
+Fire all handlers, collect results:
+
+```python
+# Subscribe in bootstrap():
+ctx.hook_registry.register("usage.record", my_handler, priority=100, plugin_id="my-plugin")
+
+# Handler signature:
+async def my_handler(**kwargs) -> Any:
+    user_id = kwargs["user_id"]
+    cost_usd = kwargs["cost_usd"]
+    # ... process usage ...
+```
+
+### Filter Hooks
+
+Chain handlers that transform a value:
+
+```python
+ctx.hook_registry.register("usage.pre_workflow", my_filter, priority=10)
+
+async def my_filter(value, **kwargs):
+    # value is the current result; return transformed value
+    if insufficient_credits(kwargs["user_id"]):
+        return {"allowed": False, "reason": "No credits"}
+    return value
+```
+
+### Available Core Hooks
+
+| Hook Name | Type | Fired When | Kwargs |
+|---|---|---|---|
+| `auth.user_created` | trigger | After user registration | `user_id`, `email` |
+| `auth.user_login` | trigger | After successful login | `user_id`, `method` |
+| `usage.record` | trigger | After LLM usage recorded | `user_id`, `cost_usd`, `prompt_tokens`, `completion_tokens`, `model_id`, `task_type` |
+| `usage.pre_workflow` | filter | Before workflow dispatch | `user_id`, `workflow_name`, `estimated_cost` |
+
+### Priority
+
+Lower priority values run first (default: 100). Use priority < 100 for handlers that must run early (e.g., billing checks), > 100 for those that run late (e.g., audit logging).
+
+## Database Extensions
+
+Plugins may create their own tables using a separate Alembic migration chain.
+
+### Rules
+
+- Each plugin uses its own version table: `alembic_version_<plugin_id>`
+- Table names must use `plugin_<id>_` prefix to avoid collisions
+- Plugins may reference core tables via foreign keys
+- Core tables never reference plugin tables
+
+### Setup
+
+Set `migration_path` in your manifest to point to your Alembic versions directory. Migrations run automatically during application startup.
+
+## Plugin Settings
+
+Plugins declare settings via a Pydantic `BaseSettings` subclass:
+
+```python
+from pydantic_settings import BaseSettings
+
+class MyPluginSettings(BaseSettings):
+    my_plugin_api_key: str = ""
+    my_plugin_timeout: int = 30
+
+    model_config = {"env_prefix": "KT_PLUGIN_MYPLUGIN_"}
+```
+
+Convention:
+- Environment variables: `KT_PLUGIN_<ID>_*`
+- YAML config (in `config.yaml`):
+
+```yaml
+plugins:
+  my-plugin:
+    api_key: "..."
+    timeout: 30
+```
+
+## License Keys (Commercial Plugins)
+
+Commercial plugins set `requires_license_key=True` in their manifest. The license key is configured in the core settings:
+
+```yaml
+plugins:
+  license_keys:
+    billing: "payload.signature"
+    sso: "payload.signature"
+```
+
+Or via environment variable: `PLUGIN_LICENSE_KEYS='{"billing": "payload.signature"}'`
+
+License validation uses HMAC-SHA256 and runs at startup only (offline, no phone-home).
+
+## Example: Minimal Provider Plugin
+
+```python
+# kt_plugin_jira/manifest.py
+from kt_plugins.manifest import PluginManifest
+
+class JiraLifecycle:
+    async def register(self, registry):
+        registry.add_provider(lambda ctx: JiraProvider(ctx.settings.jira_url))
+
+    async def bootstrap(self, ctx):
+        pass
+
+    async def shutdown(self):
+        pass
+
+plugin_manifest = PluginManifest(
+    id="jira",
+    name="Jira Integration",
+    version="1.0.0",
+    lifecycle=JiraLifecycle(),
+)
+```
+
+## Example: Minimal Route Plugin
+
+```python
+# kt_plugin_analytics/manifest.py
+from fastapi import APIRouter
+from kt_plugins.manifest import PluginManifest
+
+router = APIRouter(tags=["analytics"])
+
+@router.get("/dashboard")
+async def dashboard():
+    return {"charts": []}
+
+class AnalyticsLifecycle:
+    async def register(self, registry):
+        registry.add_routes(router, prefix="analytics")
+
+    async def bootstrap(self, ctx):
+        pass
+
+    async def shutdown(self):
+        pass
+
+plugin_manifest = PluginManifest(
+    id="analytics",
+    name="Analytics Dashboard",
+    version="1.0.0",
+    lifecycle=AnalyticsLifecycle(),
+)
+```
+
+## Core Platform Boundary
+
+The following components are **core platform** and remain under AGPLv3:
+
+- Knowledge graph engine and database models
+- LLM system prompts and prompt templates
+- Synthesis agents and their tools
+- Fact extraction and decomposition pipelines
+- Document processing pipeline
+- Core user interfaces (frontend, wiki-frontend)
+- API service and endpoint logic
+- Worker services and workflow definitions
+
+Plugins that modify these components (rather than extending through the Plugin API) are derivative works subject to AGPLv3.

--- a/libs/kt-config/src/kt_config/settings.py
+++ b/libs/kt-config/src/kt_config/settings.py
@@ -274,6 +274,15 @@ _register(
     },
 )
 
+# ---- Plugins ---------------------------------------------------------------
+_register(
+    "plugins",
+    {
+        "enabled_plugins": "enabled",
+        "plugin_license_keys": "license_keys",
+    },
+)
+
 
 class YamlSettingsSource(PydanticBaseSettingsSource):
     """Load settings from a sectioned YAML file.
@@ -517,6 +526,10 @@ class Settings(BaseSettings):
 
     # BYOK (Bring Your Own Key) — Fernet encryption key for stored API keys
     byok_encryption_key: str = ""
+
+    # Plugins
+    enabled_plugins: list[str] = []  # empty = all discovered plugins loaded
+    plugin_license_keys: dict[str, str] = {}  # {"billing": "payload.signature", ...}
 
     model_config = {"extra": "ignore"}
 

--- a/libs/kt-db/alembic/versions/zzag_add_rbac_tables.py
+++ b/libs/kt-db/alembic/versions/zzag_add_rbac_tables.py
@@ -1,0 +1,132 @@
+"""Add RBAC roles and user_roles tables with default roles.
+
+Revision ID: zzag
+Revises: zzaf
+Create Date: 2026-03-28
+"""
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "zzag"
+down_revision = "zzaf"
+branch_labels = None
+depends_on = None
+
+# Default permission sets
+_ALL_PERMISSIONS = {
+    "nodes.read": True,
+    "nodes.write": True,
+    "nodes.delete": True,
+    "facts.read": True,
+    "facts.write": True,
+    "edges.read": True,
+    "edges.write": True,
+    "syntheses.create": True,
+    "syntheses.read": True,
+    "sources.ingest": True,
+    "sources.read": True,
+    "research.create": True,
+    "research.read": True,
+    "admin.users": True,
+    "admin.settings": True,
+    "admin.usage": True,
+    "admin.roles": True,
+    "plugins.manage": True,
+}
+
+_EDITOR_PERMISSIONS = {
+    "nodes.read": True,
+    "nodes.write": True,
+    "facts.read": True,
+    "facts.write": True,
+    "edges.read": True,
+    "edges.write": True,
+    "syntheses.create": True,
+    "syntheses.read": True,
+    "sources.ingest": True,
+    "sources.read": True,
+    "research.create": True,
+    "research.read": True,
+}
+
+_VIEWER_PERMISSIONS = {
+    "nodes.read": True,
+    "facts.read": True,
+    "edges.read": True,
+    "syntheses.read": True,
+    "sources.read": True,
+    "research.read": True,
+}
+
+# Fixed UUIDs for system roles (deterministic so migrations are idempotent)
+ADMIN_ROLE_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+EDITOR_ROLE_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+VIEWER_ROLE_ID = uuid.UUID("00000000-0000-0000-0000-000000000003")
+
+
+def upgrade() -> None:
+    # Create roles table
+    op.create_table(
+        "roles",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(100), unique=True, nullable=False),
+        sa.Column("permissions", JSONB, nullable=False, server_default="{}"),
+        sa.Column("is_system", sa.Boolean, server_default="false", nullable=False),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+    )
+
+    # Create user_roles table
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", UUID(as_uuid=True), sa.ForeignKey("user.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("role_id", UUID(as_uuid=True), sa.ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("assigned_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+    )
+
+    # Seed default system roles
+    roles_table = sa.table(
+        "roles",
+        sa.column("id", UUID(as_uuid=True)),
+        sa.column("name", sa.String),
+        sa.column("permissions", JSONB),
+        sa.column("is_system", sa.Boolean),
+    )
+    op.bulk_insert(
+        roles_table,
+        [
+            {"id": ADMIN_ROLE_ID, "name": "admin", "permissions": _ALL_PERMISSIONS, "is_system": True},
+            {"id": EDITOR_ROLE_ID, "name": "editor", "permissions": _EDITOR_PERMISSIONS, "is_system": True},
+            {"id": VIEWER_ROLE_ID, "name": "viewer", "permissions": _VIEWER_PERMISSIONS, "is_system": True},
+        ],
+    )
+
+    # Assign admin role to all existing superusers
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO user_roles (user_id, role_id)
+            SELECT id, :admin_role_id FROM "user" WHERE is_superuser = true
+            ON CONFLICT DO NOTHING
+            """
+        ).bindparams(admin_role_id=ADMIN_ROLE_ID)
+    )
+
+    # Assign editor role to all existing non-superusers
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO user_roles (user_id, role_id)
+            SELECT id, :editor_role_id FROM "user" WHERE is_superuser = false
+            ON CONFLICT DO NOTHING
+            """
+        ).bindparams(editor_role_id=EDITOR_ROLE_ID)
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_roles")
+    op.drop_table("roles")

--- a/libs/kt-db/src/kt_db/models.py
+++ b/libs/kt-db/src/kt_db/models.py
@@ -702,3 +702,38 @@ class LlmUsage(Base):
     completion_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     cost_usd: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+class Role(Base):
+    """RBAC role with JSONB permission set."""
+
+    __tablename__ = "roles"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    permissions: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    is_system: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+    user_roles: Mapped[list["UserRole"]] = relationship(back_populates="role", cascade="all, delete-orphan")
+
+
+class UserRole(Base):
+    """Many-to-many link between users and roles."""
+
+    __tablename__ = "user_roles"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="CASCADE"), primary_key=True
+    )
+    role_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True
+    )
+    assigned_at: Mapped[datetime] = mapped_column(DateTime, default=_utcnow)
+
+    role: Mapped["Role"] = relationship(back_populates="user_roles")

--- a/libs/kt-db/src/kt_db/repositories/roles.py
+++ b/libs/kt-db/src/kt_db/repositories/roles.py
@@ -1,0 +1,92 @@
+"""Repository for RBAC roles and user-role assignments."""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_db.models import Role, UserRole
+
+
+class RoleRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    # -- Role CRUD -------------------------------------------------------------
+
+    async def list_all(self) -> list[Role]:
+        result = await self._session.execute(select(Role).order_by(Role.name))
+        return list(result.scalars().all())
+
+    async def get_by_id(self, role_id: uuid.UUID) -> Role | None:
+        result = await self._session.execute(select(Role).where(Role.id == role_id))
+        return result.scalar_one_or_none()
+
+    async def get_by_name(self, name: str) -> Role | None:
+        result = await self._session.execute(select(Role).where(Role.name == name))
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        name: str,
+        permissions: dict[str, bool],
+        *,
+        is_system: bool = False,
+    ) -> Role:
+        role = Role(
+            id=uuid.uuid4(),
+            name=name,
+            permissions=permissions,
+            is_system=is_system,
+        )
+        self._session.add(role)
+        await self._session.flush()
+        return role
+
+    async def update_permissions(self, role_id: uuid.UUID, permissions: dict[str, bool]) -> Role | None:
+        role = await self.get_by_id(role_id)
+        if role is None:
+            return None
+        role.permissions = permissions
+        await self._session.flush()
+        return role
+
+    async def delete(self, role_id: uuid.UUID) -> bool:
+        """Delete a non-system role. Returns False if role is system or not found."""
+        role = await self.get_by_id(role_id)
+        if role is None or role.is_system:
+            return False
+        await self._session.execute(delete(Role).where(Role.id == role_id))
+        await self._session.flush()
+        return True
+
+    # -- User-Role assignments -------------------------------------------------
+
+    async def assign_role(self, user_id: uuid.UUID, role_id: uuid.UUID) -> None:
+        stmt = pg_insert(UserRole).values(user_id=user_id, role_id=role_id).on_conflict_do_nothing()
+        await self._session.execute(stmt)
+        await self._session.flush()
+
+    async def remove_role(self, user_id: uuid.UUID, role_id: uuid.UUID) -> bool:
+        result = await self._session.execute(
+            delete(UserRole).where(UserRole.user_id == user_id, UserRole.role_id == role_id)
+        )
+        await self._session.flush()
+        return result.rowcount > 0
+
+    async def get_user_roles(self, user_id: uuid.UUID) -> list[Role]:
+        result = await self._session.execute(select(Role).join(UserRole).where(UserRole.user_id == user_id))
+        return list(result.scalars().all())
+
+    async def get_user_permissions(self, user_id: uuid.UUID) -> set[str]:
+        """Return the union of all permission keys across the user's roles."""
+        roles = await self.get_user_roles(user_id)
+        permissions: set[str] = set()
+        for role in roles:
+            for key, granted in (role.permissions or {}).items():
+                if granted:
+                    permissions.add(key)
+        return permissions

--- a/libs/kt-hatchet/src/kt_hatchet/lifespan.py
+++ b/libs/kt-hatchet/src/kt_hatchet/lifespan.py
@@ -30,6 +30,7 @@ class WorkerState:
     content_fetcher: object | None  # ContentFetcher | None
     ontology_registry: object | None = None  # OntologyProviderRegistry | None
     qdrant_client: object | None = None  # AsyncQdrantClient | None
+    hook_registry: object | None = None  # kt_plugins.HookRegistry | None
 
 
 async def worker_lifespan() -> AsyncGenerator[WorkerState, None]:

--- a/libs/kt-plugins/pyproject.toml
+++ b/libs/kt-plugins/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "kt-plugins"
+version = "0.1.0"
+description = "Knowledge Tree plugin system — discovery, lifecycle, hooks, and extension points"
+requires-python = ">=3.12"
+dependencies = [
+    "kt-config",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+kt-config = { workspace = true }
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/kt_plugins"]

--- a/libs/kt-plugins/src/kt_plugins/__init__.py
+++ b/libs/kt-plugins/src/kt_plugins/__init__.py
@@ -1,0 +1,15 @@
+"""Knowledge Tree plugin system."""
+
+from kt_plugins.context import PluginContext
+from kt_plugins.errors import PluginError, PluginLicenseError, PluginLoadError
+from kt_plugins.hooks import HookRegistry
+from kt_plugins.manifest import PluginManifest
+
+__all__ = [
+    "HookRegistry",
+    "PluginContext",
+    "PluginError",
+    "PluginLicenseError",
+    "PluginLoadError",
+    "PluginManifest",
+]

--- a/libs/kt-plugins/src/kt_plugins/context.py
+++ b/libs/kt-plugins/src/kt_plugins/context.py
@@ -1,0 +1,28 @@
+"""Plugin context — scoped services provided to plugins during bootstrap."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from kt_plugins.hooks import HookRegistry
+
+
+@dataclass
+class PluginContext:
+    """Services available to a plugin during the bootstrap phase.
+
+    Each plugin receives its own ``PluginContext`` with access to
+    shared infrastructure. Plugins should NOT store references to
+    the session factories beyond bootstrap — use them to create
+    sessions as needed at runtime.
+    """
+
+    plugin_id: str
+    settings: Any  # Plugin's own resolved Pydantic settings, or None
+    hook_registry: HookRegistry
+    session_factory: async_sessionmaker[AsyncSession] | None = None
+    write_session_factory: async_sessionmaker[AsyncSession] | None = None

--- a/libs/kt-plugins/src/kt_plugins/discovery.py
+++ b/libs/kt-plugins/src/kt_plugins/discovery.py
@@ -1,0 +1,73 @@
+"""Plugin discovery via Python entry points."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import logging
+
+from kt_plugins.errors import PluginLoadError
+from kt_plugins.manifest import PluginManifest
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "kt.plugins"
+
+
+def discover_plugins(
+    enabled: list[str] | None = None,
+) -> list[PluginManifest]:
+    """Discover installed plugins via ``importlib.metadata`` entry points.
+
+    Scans the ``kt.plugins`` entry point group for ``PluginManifest``
+    instances. If ``enabled`` is a non-empty list, only plugins whose
+    ``id`` appears in the list are loaded. An empty list means load all.
+
+    Args:
+        enabled: Optional allowlist of plugin IDs. Empty or None = all.
+
+    Returns:
+        List of discovered ``PluginManifest`` instances.
+    """
+    manifests: list[PluginManifest] = []
+    eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+
+    for ep in eps:
+        try:
+            obj = ep.load()
+        except Exception:
+            logger.warning("Failed to load plugin entry point: %s", ep.name, exc_info=True)
+            continue
+
+        if not isinstance(obj, PluginManifest):
+            logger.warning(
+                "Entry point %s did not resolve to a PluginManifest (got %s)",
+                ep.name,
+                type(obj).__name__,
+            )
+            continue
+
+        # Filter by enabled list
+        if enabled and obj.id not in enabled:
+            logger.info("Plugin %r skipped (not in enabled_plugins list)", obj.id)
+            continue
+
+        manifests.append(obj)
+        logger.info("Discovered plugin: %s v%s", obj.id, obj.version)
+
+    return manifests
+
+
+def validate_dependencies(manifests: list[PluginManifest]) -> None:
+    """Check that all plugin dependencies are satisfied.
+
+    Raises ``PluginLoadError`` if a plugin declares a dependency
+    on another plugin that is not in the manifest list.
+    """
+    ids = {m.id for m in manifests}
+    for m in manifests:
+        for dep in m.dependencies:
+            if dep not in ids:
+                raise PluginLoadError(
+                    m.id,
+                    f"Missing dependency: plugin {m.id!r} requires {dep!r}",
+                )

--- a/libs/kt-plugins/src/kt_plugins/errors.py
+++ b/libs/kt-plugins/src/kt_plugins/errors.py
@@ -1,0 +1,17 @@
+"""Plugin-specific error classes."""
+
+
+class PluginError(Exception):
+    """Base exception for all plugin errors."""
+
+    def __init__(self, plugin_id: str, message: str) -> None:
+        self.plugin_id = plugin_id
+        super().__init__(f"[plugin:{plugin_id}] {message}")
+
+
+class PluginLoadError(PluginError):
+    """Raised when a plugin fails to load or initialize."""
+
+
+class PluginLicenseError(PluginError):
+    """Raised when a commercial plugin has an invalid or missing license key."""

--- a/libs/kt-plugins/src/kt_plugins/extension_points.py
+++ b/libs/kt-plugins/src/kt_plugins/extension_points.py
@@ -1,0 +1,139 @@
+"""Extension registry — accumulates plugin contributions during registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class RouteRegistration:
+    """A FastAPI router contributed by a plugin."""
+
+    router: Any  # fastapi.APIRouter
+    auth_required: bool = True
+    prefix: str = ""
+    plugin_id: str = ""
+
+
+@dataclass
+class ProviderRegistration:
+    """A KnowledgeProvider factory contributed by a plugin."""
+
+    factory: Callable[..., Any]
+    plugin_id: str = ""
+
+
+@dataclass
+class AuthBackendRegistration:
+    """An auth backend factory contributed by a plugin."""
+
+    factory: Callable[..., Any]
+    plugin_id: str = ""
+
+
+@dataclass
+class WorkflowRegistration:
+    """A Hatchet workflow contributed by a plugin."""
+
+    workflow: Any
+    plugin_id: str = ""
+
+
+class ExtensionRegistry:
+    """Accumulates plugin contributions during the registration phase.
+
+    Plugins call ``add_*`` methods during their ``register()`` lifecycle
+    phase. The ``PluginManager`` later consumes these registrations to
+    wire them into the running application.
+    """
+
+    def __init__(self) -> None:
+        self._routes: list[RouteRegistration] = []
+        self._providers: list[ProviderRegistration] = []
+        self._auth_backends: list[AuthBackendRegistration] = []
+        self._workflows: list[WorkflowRegistration] = []
+        self._node_types: dict[str, dict[str, Any]] = {}
+        self._fact_types: dict[str, dict[str, Any]] = {}
+
+    # -- Routes ----------------------------------------------------------------
+
+    def add_routes(
+        self,
+        router: Any,
+        *,
+        auth_required: bool = True,
+        prefix: str = "",
+        plugin_id: str = "",
+    ) -> None:
+        """Register a FastAPI APIRouter to be mounted at startup."""
+        self._routes.append(
+            RouteRegistration(
+                router=router,
+                auth_required=auth_required,
+                prefix=prefix,
+                plugin_id=plugin_id,
+            )
+        )
+
+    def get_routes(self) -> list[RouteRegistration]:
+        return list(self._routes)
+
+    # -- Providers -------------------------------------------------------------
+
+    def add_provider(
+        self,
+        factory: Callable[..., Any],
+        *,
+        plugin_id: str = "",
+    ) -> None:
+        """Register a KnowledgeProvider factory."""
+        self._providers.append(ProviderRegistration(factory=factory, plugin_id=plugin_id))
+
+    def get_providers(self) -> list[ProviderRegistration]:
+        return list(self._providers)
+
+    # -- Auth backends ---------------------------------------------------------
+
+    def add_auth_backend(
+        self,
+        factory: Callable[..., Any],
+        *,
+        plugin_id: str = "",
+    ) -> None:
+        """Register an authentication backend factory (SSO, OIDC, etc.)."""
+        self._auth_backends.append(AuthBackendRegistration(factory=factory, plugin_id=plugin_id))
+
+    def get_auth_backends(self) -> list[AuthBackendRegistration]:
+        return list(self._auth_backends)
+
+    # -- Workflows -------------------------------------------------------------
+
+    def add_workflow(
+        self,
+        workflow: Any,
+        *,
+        plugin_id: str = "",
+    ) -> None:
+        """Register a Hatchet workflow class/function."""
+        self._workflows.append(WorkflowRegistration(workflow=workflow, plugin_id=plugin_id))
+
+    def get_workflows(self) -> list[WorkflowRegistration]:
+        return list(self._workflows)
+
+    # -- Custom types ----------------------------------------------------------
+
+    def add_node_type(self, type_id: str, schema: dict[str, Any] | None = None) -> None:
+        """Register a custom node type."""
+        self._node_types[type_id] = schema or {}
+
+    def add_fact_type(self, type_id: str, schema: dict[str, Any] | None = None) -> None:
+        """Register a custom fact type."""
+        self._fact_types[type_id] = schema or {}
+
+    def get_node_types(self) -> dict[str, dict[str, Any]]:
+        return dict(self._node_types)
+
+    def get_fact_types(self) -> dict[str, dict[str, Any]]:
+        return dict(self._fact_types)

--- a/libs/kt-plugins/src/kt_plugins/hooks.py
+++ b/libs/kt-plugins/src/kt_plugins/hooks.py
@@ -1,0 +1,114 @@
+"""Hook registry — WordPress-inspired async hooks/filters for cross-cutting concerns."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Handler signature: async def handler(**kwargs) -> Any
+HookHandler = Callable[..., Awaitable[Any]]
+
+
+@dataclass(order=True)
+class _HookRegistration:
+    """Internal registration entry, ordered by priority."""
+
+    priority: int
+    plugin_id: str = field(compare=False)
+    handler: HookHandler = field(compare=False)
+
+
+class HookRegistry:
+    """Central registry for named async hooks.
+
+    Supports two invocation styles:
+
+    - **trigger**: Fire all handlers, collecting results (action hooks).
+    - **filter**: Chain handlers, each transforming a value (filter hooks).
+
+    Priority ordering: lower priority values run first (default 100).
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list[_HookRegistration]] = {}
+
+    def register(
+        self,
+        hook_name: str,
+        handler: HookHandler,
+        *,
+        priority: int = 100,
+        plugin_id: str = "",
+    ) -> None:
+        """Register a handler for a named hook.
+
+        Args:
+            hook_name: The hook to subscribe to (e.g. ``"usage.record"``).
+            handler: Async callable invoked when the hook fires.
+            priority: Execution order; lower runs first. Default 100.
+            plugin_id: Identifier of the registering plugin (for debugging).
+        """
+        reg = _HookRegistration(priority=priority, plugin_id=plugin_id, handler=handler)
+        handlers = self._handlers.setdefault(hook_name, [])
+        handlers.append(reg)
+        handlers.sort()
+
+    def unregister(self, hook_name: str, handler: HookHandler) -> bool:
+        """Remove a previously registered handler. Returns True if found."""
+        handlers = self._handlers.get(hook_name, [])
+        for i, reg in enumerate(handlers):
+            if reg.handler is handler:
+                handlers.pop(i)
+                return True
+        return False
+
+    async def trigger(self, hook_name: str, **kwargs: Any) -> list[Any]:
+        """Fire all handlers for a hook, returning their results.
+
+        If a handler raises an exception, it is logged and skipped.
+        Remaining handlers still execute.
+        """
+        results: list[Any] = []
+        for reg in self._handlers.get(hook_name, []):
+            try:
+                result = await reg.handler(**kwargs)
+                results.append(result)
+            except Exception:
+                logger.exception(
+                    "Hook handler failed: %s (plugin=%s, hook=%s)",
+                    reg.handler,
+                    reg.plugin_id,
+                    hook_name,
+                )
+        return results
+
+    async def filter(self, hook_name: str, value: Any, **kwargs: Any) -> Any:
+        """Chain handlers as filters, each transforming the value.
+
+        Each handler receives ``value`` as its first positional arg
+        plus any extra ``kwargs``. The return value becomes the input
+        to the next handler.
+        """
+        for reg in self._handlers.get(hook_name, []):
+            try:
+                value = await reg.handler(value, **kwargs)
+            except Exception:
+                logger.exception(
+                    "Filter handler failed: %s (plugin=%s, hook=%s)",
+                    reg.handler,
+                    reg.plugin_id,
+                    hook_name,
+                )
+        return value
+
+    def has_handlers(self, hook_name: str) -> bool:
+        """Check if any handlers are registered for a hook."""
+        return bool(self._handlers.get(hook_name))
+
+    def get_hook_names(self) -> list[str]:
+        """Return all hook names that have at least one handler."""
+        return [k for k, v in self._handlers.items() if v]

--- a/libs/kt-plugins/src/kt_plugins/license.py
+++ b/libs/kt-plugins/src/kt_plugins/license.py
@@ -1,0 +1,77 @@
+"""License key validation for commercial plugins."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+
+from kt_plugins.errors import PluginLicenseError
+
+logger = logging.getLogger(__name__)
+
+# Public key used for offline HMAC validation.
+# In production, each commercial plugin ships with its own public key.
+# This is a placeholder for the signing infrastructure.
+_DEFAULT_SIGNING_KEY = b"kt-plugin-license-v1"
+
+
+def validate_license_key(
+    plugin_id: str,
+    license_key: str,
+    *,
+    signing_key: bytes = _DEFAULT_SIGNING_KEY,
+) -> bool:
+    """Validate a license key for a commercial plugin.
+
+    The license key format is: ``<payload>.<signature>``
+    where signature = HMAC-SHA256(signing_key, payload).hex()
+
+    This is a simple offline check. Future versions may support
+    online validation, seat counting, and expiry dates.
+
+    Args:
+        plugin_id: The plugin requesting validation.
+        license_key: The key string from configuration.
+        signing_key: HMAC signing key (plugin-specific in production).
+
+    Returns:
+        True if valid.
+
+    Raises:
+        PluginLicenseError: If the key is missing, malformed, or invalid.
+    """
+    if not license_key:
+        raise PluginLicenseError(plugin_id, "No license key configured")
+
+    parts = license_key.rsplit(".", 1)
+    if len(parts) != 2:
+        raise PluginLicenseError(plugin_id, "Malformed license key")
+
+    payload, signature = parts
+
+    expected = hmac.new(signing_key, payload.encode(), hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(signature, expected):
+        raise PluginLicenseError(plugin_id, "Invalid license key")
+
+    logger.info("License validated for plugin %r", plugin_id)
+    return True
+
+
+def generate_license_key(
+    payload: str,
+    *,
+    signing_key: bytes = _DEFAULT_SIGNING_KEY,
+) -> str:
+    """Generate a license key (for testing and key distribution).
+
+    Args:
+        payload: Arbitrary payload string (e.g. org name, expiry, etc.).
+        signing_key: HMAC signing key.
+
+    Returns:
+        License key in ``<payload>.<signature>`` format.
+    """
+    signature = hmac.new(signing_key, payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{signature}"

--- a/libs/kt-plugins/src/kt_plugins/manager.py
+++ b/libs/kt-plugins/src/kt_plugins/manager.py
@@ -1,0 +1,172 @@
+"""Plugin manager — orchestrates discovery, lifecycle, and wiring."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from kt_plugins.context import PluginContext
+from kt_plugins.discovery import discover_plugins, validate_dependencies
+from kt_plugins.errors import PluginLicenseError, PluginLoadError
+from kt_plugins.extension_points import ExtensionRegistry, RouteRegistration
+from kt_plugins.hooks import HookRegistry
+from kt_plugins.license import validate_license_key
+from kt_plugins.manifest import PluginManifest
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+logger = logging.getLogger(__name__)
+
+
+class PluginManager:
+    """Orchestrates the full plugin lifecycle.
+
+    Usage::
+
+        manager = PluginManager()
+        await manager.initialize(enabled_plugins=["billing"], license_keys={"billing": "key"})
+        await manager.bootstrap(session_factory=sf, write_session_factory=wsf)
+        # ... application runs ...
+        await manager.shutdown()
+    """
+
+    def __init__(self) -> None:
+        self._manifests: list[PluginManifest] = []
+        self._extension_registry = ExtensionRegistry()
+        self._hook_registry = HookRegistry()
+        self._plugin_contexts: dict[str, PluginContext] = {}
+        self._initialized = False
+        self._bootstrapped = False
+
+    @property
+    def hook_registry(self) -> HookRegistry:
+        return self._hook_registry
+
+    @property
+    def extension_registry(self) -> ExtensionRegistry:
+        return self._extension_registry
+
+    @property
+    def manifests(self) -> list[PluginManifest]:
+        return list(self._manifests)
+
+    async def initialize(
+        self,
+        *,
+        enabled_plugins: list[str] | None = None,
+        license_keys: dict[str, str] | None = None,
+    ) -> None:
+        """Discover plugins, validate licenses, and run registration phase.
+
+        Args:
+            enabled_plugins: Optional allowlist (empty/None = all discovered).
+            license_keys: Map of plugin_id -> license key for commercial plugins.
+        """
+        if self._initialized:
+            logger.warning("PluginManager.initialize() called twice — skipping")
+            return
+
+        license_keys = license_keys or {}
+
+        # Phase 1: Discover
+        self._manifests = discover_plugins(enabled=enabled_plugins or None)
+        if not self._manifests:
+            logger.info("No plugins discovered")
+            self._initialized = True
+            return
+
+        # Validate inter-plugin dependencies
+        validate_dependencies(self._manifests)
+
+        # Phase 2: Validate licenses
+        for manifest in self._manifests:
+            if manifest.requires_license_key:
+                key = license_keys.get(manifest.id, "")
+                try:
+                    validate_license_key(manifest.id, key)
+                except PluginLicenseError:
+                    logger.error("License validation failed for plugin %r — skipping", manifest.id)
+                    self._manifests = [m for m in self._manifests if m.id != manifest.id]
+                    continue
+
+        # Phase 3: Register
+        for manifest in self._manifests:
+            if manifest.lifecycle is not None:
+                try:
+                    await manifest.lifecycle.register(self._extension_registry)
+                    logger.info("Plugin %r registered", manifest.id)
+                except Exception:
+                    logger.exception("Plugin %r failed during register()", manifest.id)
+                    raise PluginLoadError(manifest.id, "register() failed") from None
+
+        self._initialized = True
+        logger.info(
+            "Plugin initialization complete: %d plugin(s) loaded",
+            len(self._manifests),
+        )
+
+    async def bootstrap(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession] | None = None,
+        write_session_factory: async_sessionmaker[AsyncSession] | None = None,
+    ) -> None:
+        """Run the bootstrap phase — provide runtime services to plugins.
+
+        Args:
+            session_factory: Graph-db async session factory.
+            write_session_factory: Write-db async session factory.
+        """
+        if not self._initialized:
+            raise RuntimeError("Must call initialize() before bootstrap()")
+        if self._bootstrapped:
+            logger.warning("PluginManager.bootstrap() called twice — skipping")
+            return
+
+        for manifest in self._manifests:
+            settings: Any = None
+            if manifest.settings_class is not None:
+                try:
+                    settings = manifest.settings_class()
+                except Exception:
+                    logger.warning("Failed to load settings for plugin %r", manifest.id, exc_info=True)
+
+            ctx = PluginContext(
+                plugin_id=manifest.id,
+                settings=settings,
+                hook_registry=self._hook_registry,
+                session_factory=session_factory,
+                write_session_factory=write_session_factory,
+            )
+            self._plugin_contexts[manifest.id] = ctx
+
+            if manifest.lifecycle is not None:
+                try:
+                    await manifest.lifecycle.bootstrap(ctx)
+                    logger.info("Plugin %r bootstrapped", manifest.id)
+                except Exception:
+                    logger.exception("Plugin %r failed during bootstrap()", manifest.id)
+                    raise PluginLoadError(manifest.id, "bootstrap() failed") from None
+
+        self._bootstrapped = True
+
+    async def shutdown(self) -> None:
+        """Shutdown all plugins in reverse registration order."""
+        for manifest in reversed(self._manifests):
+            if manifest.lifecycle is not None:
+                try:
+                    await manifest.lifecycle.shutdown()
+                    logger.info("Plugin %r shut down", manifest.id)
+                except Exception:
+                    logger.exception("Plugin %r failed during shutdown()", manifest.id)
+
+    # -- Accessors for wiring into the application -----------------------------
+
+    def get_plugin_routes(self) -> list[RouteRegistration]:
+        """Return all route registrations from plugins."""
+        return self._extension_registry.get_routes()
+
+    def get_plugin_workflows(self) -> list[Any]:
+        """Return all workflow objects from plugins."""
+        return [w.workflow for w in self._extension_registry.get_workflows()]

--- a/libs/kt-plugins/src/kt_plugins/manifest.py
+++ b/libs/kt-plugins/src/kt_plugins/manifest.py
@@ -1,0 +1,59 @@
+"""Plugin manifest and lifecycle protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from kt_plugins.context import PluginContext
+    from kt_plugins.extension_points import ExtensionRegistry
+
+
+@runtime_checkable
+class PluginLifecycle(Protocol):
+    """Protocol that plugin lifecycle implementations must satisfy.
+
+    Plugins implement this to declare extensions (register) and
+    perform setup with runtime services (bootstrap).
+    """
+
+    async def register(self, registry: ExtensionRegistry) -> None:
+        """Called during registration phase.
+
+        Declare routes, providers, hooks, workflows, etc.
+        Cannot access other plugins or runtime services yet.
+        """
+        ...
+
+    async def bootstrap(self, ctx: PluginContext) -> None:
+        """Called after all plugins are registered.
+
+        Access runtime services, subscribe to hooks, perform startup logic.
+        """
+        ...
+
+    async def shutdown(self) -> None:
+        """Called on application shutdown for cleanup."""
+        ...
+
+
+@dataclass
+class PluginManifest:
+    """Metadata and lifecycle for a plugin.
+
+    Plugin packages expose a module-level instance of this class
+    via a Python entry point in the ``kt.plugins`` group.
+    """
+
+    id: str
+    name: str
+    version: str
+    description: str = ""
+    author: str = ""
+    license: str = ""
+    requires_license_key: bool = False
+    lifecycle: PluginLifecycle | None = None
+    settings_class: type[Any] | None = None
+    migration_path: str | None = None
+    dependencies: list[str] = field(default_factory=list)

--- a/libs/kt-plugins/src/kt_plugins/migrations.py
+++ b/libs/kt-plugins/src/kt_plugins/migrations.py
@@ -1,0 +1,55 @@
+"""Per-plugin Alembic migration runner."""
+
+from __future__ import annotations
+
+import logging
+
+from kt_plugins.manifest import PluginManifest
+
+logger = logging.getLogger(__name__)
+
+
+def run_plugin_migrations(
+    manifests: list[PluginManifest],
+    database_url: str,
+) -> None:
+    """Run Alembic migrations for all plugins that declare a migration path.
+
+    Each plugin uses its own ``alembic_version_<plugin_id>`` table
+    so migrations never conflict with each other or the core schema.
+
+    Args:
+        manifests: Plugin manifests (only those with ``migration_path`` are processed).
+        database_url: Database URL (async driver is replaced with sync for Alembic).
+    """
+    plugins_with_migrations = [m for m in manifests if m.migration_path]
+    if not plugins_with_migrations:
+        return
+
+    # Alembic requires a sync driver
+    sync_url = database_url.replace("+asyncpg", "").replace("+aiosqlite", "")
+
+    try:
+        from alembic import command
+        from alembic.config import Config
+    except ImportError:
+        logger.warning("Alembic not installed — skipping plugin migrations")
+        return
+
+    for manifest in plugins_with_migrations:
+        version_table = f"alembic_version_{manifest.id}"
+        logger.info(
+            "Running migrations for plugin %r (version_table=%s, path=%s)",
+            manifest.id,
+            version_table,
+            manifest.migration_path,
+        )
+        try:
+            cfg = Config()
+            cfg.set_main_option("script_location", manifest.migration_path)
+            cfg.set_main_option("sqlalchemy.url", sync_url)
+            cfg.set_main_option("version_table", version_table)
+            command.upgrade(cfg, "head")
+            logger.info("Migrations complete for plugin %r", manifest.id)
+        except Exception:
+            logger.exception("Failed to run migrations for plugin %r", manifest.id)

--- a/libs/kt-plugins/tests/conftest.py
+++ b/libs/kt-plugins/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures for kt-plugins tests."""

--- a/libs/kt-plugins/tests/test_discovery.py
+++ b/libs/kt-plugins/tests/test_discovery.py
@@ -1,0 +1,98 @@
+"""Tests for plugin discovery via entry points."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kt_plugins.discovery import discover_plugins, validate_dependencies
+from kt_plugins.errors import PluginLoadError
+from kt_plugins.manifest import PluginManifest
+
+
+def _make_manifest(plugin_id: str, deps: list[str] | None = None) -> PluginManifest:
+    return PluginManifest(
+        id=plugin_id,
+        name=plugin_id.title(),
+        version="1.0.0",
+        dependencies=deps or [],
+    )
+
+
+def _make_entry_point(name: str, manifest: PluginManifest) -> MagicMock:
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = manifest
+    return ep
+
+
+def test_discover_plugins_finds_manifests() -> None:
+    m1 = _make_manifest("billing")
+    m2 = _make_manifest("sso")
+    eps = [_make_entry_point("billing", m1), _make_entry_point("sso", m2)]
+
+    with patch("kt_plugins.discovery.importlib.metadata.entry_points", return_value=eps):
+        result = discover_plugins()
+
+    assert len(result) == 2
+    assert result[0].id == "billing"
+    assert result[1].id == "sso"
+
+
+def test_discover_plugins_filters_by_enabled() -> None:
+    m1 = _make_manifest("billing")
+    m2 = _make_manifest("sso")
+    eps = [_make_entry_point("billing", m1), _make_entry_point("sso", m2)]
+
+    with patch("kt_plugins.discovery.importlib.metadata.entry_points", return_value=eps):
+        result = discover_plugins(enabled=["billing"])
+
+    assert len(result) == 1
+    assert result[0].id == "billing"
+
+
+def test_discover_plugins_skips_bad_entry_points() -> None:
+    bad_ep = MagicMock()
+    bad_ep.name = "broken"
+    bad_ep.load.side_effect = ImportError("no module")
+
+    good = _make_manifest("good")
+    good_ep = _make_entry_point("good", good)
+
+    with patch("kt_plugins.discovery.importlib.metadata.entry_points", return_value=[bad_ep, good_ep]):
+        result = discover_plugins()
+
+    assert len(result) == 1
+    assert result[0].id == "good"
+
+
+def test_discover_plugins_skips_non_manifest() -> None:
+    ep = MagicMock()
+    ep.name = "notplugin"
+    ep.load.return_value = "not a manifest"
+
+    with patch("kt_plugins.discovery.importlib.metadata.entry_points", return_value=[ep]):
+        result = discover_plugins()
+
+    assert result == []
+
+
+def test_discover_empty() -> None:
+    with patch("kt_plugins.discovery.importlib.metadata.entry_points", return_value=[]):
+        result = discover_plugins()
+    assert result == []
+
+
+def test_validate_dependencies_ok() -> None:
+    manifests = [
+        _make_manifest("a", deps=["b"]),
+        _make_manifest("b"),
+    ]
+    validate_dependencies(manifests)  # should not raise
+
+
+def test_validate_dependencies_missing() -> None:
+    manifests = [_make_manifest("a", deps=["missing"])]
+    with pytest.raises(PluginLoadError, match="missing"):
+        validate_dependencies(manifests)

--- a/libs/kt-plugins/tests/test_extension_registry.py
+++ b/libs/kt-plugins/tests/test_extension_registry.py
@@ -1,0 +1,87 @@
+"""Tests for ExtensionRegistry — accumulation and retrieval."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from kt_plugins.extension_points import ExtensionRegistry
+
+
+def test_add_and_get_routes() -> None:
+    reg = ExtensionRegistry()
+    router = MagicMock()
+
+    reg.add_routes(router, auth_required=True, prefix="billing", plugin_id="billing")
+
+    routes = reg.get_routes()
+    assert len(routes) == 1
+    assert routes[0].router is router
+    assert routes[0].auth_required is True
+    assert routes[0].prefix == "billing"
+    assert routes[0].plugin_id == "billing"
+
+
+def test_add_routes_returns_copies() -> None:
+    reg = ExtensionRegistry()
+    reg.add_routes(MagicMock(), plugin_id="a")
+
+    routes1 = reg.get_routes()
+    routes2 = reg.get_routes()
+    assert routes1 is not routes2
+
+
+def test_add_and_get_providers() -> None:
+    reg = ExtensionRegistry()
+    factory = MagicMock()
+
+    reg.add_provider(factory, plugin_id="jira")
+
+    providers = reg.get_providers()
+    assert len(providers) == 1
+    assert providers[0].factory is factory
+    assert providers[0].plugin_id == "jira"
+
+
+def test_add_and_get_auth_backends() -> None:
+    reg = ExtensionRegistry()
+    factory = MagicMock()
+
+    reg.add_auth_backend(factory, plugin_id="sso")
+
+    backends = reg.get_auth_backends()
+    assert len(backends) == 1
+    assert backends[0].factory is factory
+
+
+def test_add_and_get_workflows() -> None:
+    reg = ExtensionRegistry()
+    wf = MagicMock()
+
+    reg.add_workflow(wf, plugin_id="billing")
+
+    workflows = reg.get_workflows()
+    assert len(workflows) == 1
+    assert workflows[0].workflow is wf
+
+
+def test_add_node_and_fact_types() -> None:
+    reg = ExtensionRegistry()
+    reg.add_node_type("custom_node", {"field": "value"})
+    reg.add_fact_type("custom_fact")
+
+    assert "custom_node" in reg.get_node_types()
+    assert reg.get_node_types()["custom_node"] == {"field": "value"}
+    assert "custom_fact" in reg.get_fact_types()
+    assert reg.get_fact_types()["custom_fact"] == {}
+
+
+def test_multiple_routes_from_different_plugins() -> None:
+    reg = ExtensionRegistry()
+    reg.add_routes(MagicMock(), plugin_id="billing")
+    reg.add_routes(MagicMock(), plugin_id="sso", auth_required=False)
+
+    routes = reg.get_routes()
+    assert len(routes) == 2
+    assert routes[0].plugin_id == "billing"
+    assert routes[1].plugin_id == "sso"
+    assert routes[1].auth_required is False

--- a/libs/kt-plugins/tests/test_hooks.py
+++ b/libs/kt-plugins/tests/test_hooks.py
@@ -1,0 +1,147 @@
+"""Tests for HookRegistry — registration, ordering, trigger, filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from kt_plugins.hooks import HookRegistry
+
+
+@pytest.fixture
+def registry() -> HookRegistry:
+    return HookRegistry()
+
+
+async def test_trigger_no_handlers(registry: HookRegistry) -> None:
+    results = await registry.trigger("nonexistent")
+    assert results == []
+
+
+async def test_register_and_trigger(registry: HookRegistry) -> None:
+    calls: list[dict] = []
+
+    async def handler(**kwargs: object) -> str:
+        calls.append(dict(kwargs))
+        return "ok"
+
+    registry.register("test.hook", handler)
+    results = await registry.trigger("test.hook", foo="bar")
+
+    assert results == ["ok"]
+    assert calls == [{"foo": "bar"}]
+
+
+async def test_priority_ordering(registry: HookRegistry) -> None:
+    order: list[int] = []
+
+    async def handler_a(**_: object) -> None:
+        order.append(1)
+
+    async def handler_b(**_: object) -> None:
+        order.append(2)
+
+    async def handler_c(**_: object) -> None:
+        order.append(3)
+
+    registry.register("test.order", handler_c, priority=300)
+    registry.register("test.order", handler_a, priority=10)
+    registry.register("test.order", handler_b, priority=50)
+
+    await registry.trigger("test.order")
+    assert order == [1, 2, 3]
+
+
+async def test_filter_chains_value(registry: HookRegistry) -> None:
+    async def add_one(value: int, **_: object) -> int:
+        return value + 1
+
+    async def double(value: int, **_: object) -> int:
+        return value * 2
+
+    registry.register("test.filter", add_one, priority=10)
+    registry.register("test.filter", double, priority=20)
+
+    result = await registry.filter("test.filter", 5)
+    # 5 -> add_one -> 6 -> double -> 12
+    assert result == 12
+
+
+async def test_filter_empty_returns_original(registry: HookRegistry) -> None:
+    result = await registry.filter("nonexistent", "unchanged")
+    assert result == "unchanged"
+
+
+async def test_trigger_error_isolation(registry: HookRegistry) -> None:
+    """A failing handler should not prevent others from running."""
+    results_log: list[str] = []
+
+    async def good_handler(**_: object) -> str:
+        results_log.append("good")
+        return "good"
+
+    async def bad_handler(**_: object) -> str:
+        raise RuntimeError("boom")
+
+    registry.register("test.errors", good_handler, priority=10)
+    registry.register("test.errors", bad_handler, priority=20)
+    registry.register("test.errors", good_handler, priority=30)
+
+    results = await registry.trigger("test.errors")
+    assert results == ["good", "good"]
+    assert results_log == ["good", "good"]
+
+
+async def test_unregister(registry: HookRegistry) -> None:
+    async def handler(**_: object) -> str:
+        return "hit"
+
+    registry.register("test.unreg", handler)
+    assert registry.has_handlers("test.unreg")
+
+    removed = registry.unregister("test.unreg", handler)
+    assert removed is True
+    assert not registry.has_handlers("test.unreg")
+
+
+async def test_unregister_not_found(registry: HookRegistry) -> None:
+    async def handler(**_: object) -> None:
+        pass
+
+    assert registry.unregister("nope", handler) is False
+
+
+async def test_has_handlers(registry: HookRegistry) -> None:
+    assert not registry.has_handlers("empty")
+
+    async def handler(**_: object) -> None:
+        pass
+
+    registry.register("filled", handler)
+    assert registry.has_handlers("filled")
+
+
+async def test_get_hook_names(registry: HookRegistry) -> None:
+    async def handler(**_: object) -> None:
+        pass
+
+    registry.register("hook.a", handler)
+    registry.register("hook.b", handler)
+
+    names = registry.get_hook_names()
+    assert set(names) == {"hook.a", "hook.b"}
+
+
+async def test_multiple_plugins_same_hook(registry: HookRegistry) -> None:
+    results: list[str] = []
+
+    async def billing_handler(**_: object) -> None:
+        results.append("billing")
+
+    async def audit_handler(**_: object) -> None:
+        results.append("audit")
+
+    registry.register("usage.record", billing_handler, plugin_id="billing", priority=10)
+    registry.register("usage.record", audit_handler, plugin_id="audit", priority=20)
+
+    await registry.trigger("usage.record", user_id="u1", cost_usd=0.01)
+    assert results == ["billing", "audit"]

--- a/libs/kt-plugins/tests/test_license.py
+++ b/libs/kt-plugins/tests/test_license.py
@@ -1,0 +1,38 @@
+"""Tests for license key generation and validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from kt_plugins.errors import PluginLicenseError
+from kt_plugins.license import generate_license_key, validate_license_key
+
+
+def test_generate_and_validate() -> None:
+    key = generate_license_key("acme-corp-2026")
+    assert validate_license_key("billing", key) is True
+
+
+def test_empty_key_raises() -> None:
+    with pytest.raises(PluginLicenseError, match="No license key"):
+        validate_license_key("billing", "")
+
+
+def test_malformed_key_raises() -> None:
+    with pytest.raises(PluginLicenseError, match="Malformed"):
+        validate_license_key("billing", "no-dot-separator")
+
+
+def test_invalid_signature_raises() -> None:
+    with pytest.raises(PluginLicenseError, match="Invalid"):
+        validate_license_key("billing", "payload.invalidsignature")
+
+
+def test_custom_signing_key() -> None:
+    custom_key = b"my-secret-key"
+    key = generate_license_key("org-name", signing_key=custom_key)
+    assert validate_license_key("sso", key, signing_key=custom_key) is True
+
+    # Should fail with default key
+    with pytest.raises(PluginLicenseError):
+        validate_license_key("sso", key)

--- a/libs/kt-plugins/tests/test_manager.py
+++ b/libs/kt-plugins/tests/test_manager.py
@@ -1,0 +1,170 @@
+"""Tests for PluginManager lifecycle — initialize, bootstrap, shutdown."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kt_plugins.errors import PluginLoadError
+from kt_plugins.extension_points import ExtensionRegistry
+from kt_plugins.hooks import HookRegistry
+from kt_plugins.license import generate_license_key
+from kt_plugins.manager import PluginManager
+from kt_plugins.manifest import PluginManifest
+
+
+class FakeLifecycle:
+    """Test lifecycle that tracks calls."""
+
+    def __init__(self) -> None:
+        self.registered = False
+        self.bootstrapped = False
+        self.shut_down = False
+        self.ctx = None
+
+    async def register(self, registry: ExtensionRegistry) -> None:
+        self.registered = True
+
+    async def bootstrap(self, ctx: object) -> None:
+        self.bootstrapped = True
+        self.ctx = ctx
+
+    async def shutdown(self) -> None:
+        self.shut_down = True
+
+
+def _make_manifest(plugin_id: str = "test", lifecycle: object | None = None, **kwargs: object) -> PluginManifest:
+    return PluginManifest(
+        id=plugin_id,
+        name=plugin_id.title(),
+        version="1.0.0",
+        lifecycle=lifecycle,
+        **kwargs,
+    )
+
+
+async def test_initialize_no_plugins() -> None:
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[]):
+        await manager.initialize()
+    assert manager.manifests == []
+
+
+async def test_full_lifecycle() -> None:
+    lc = FakeLifecycle()
+    manifest = _make_manifest(lifecycle=lc)
+
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[manifest]):
+        await manager.initialize()
+
+    assert lc.registered
+    assert not lc.bootstrapped
+
+    await manager.bootstrap()
+
+    assert lc.bootstrapped
+    assert lc.ctx is not None
+    assert lc.ctx.plugin_id == "test"
+
+    await manager.shutdown()
+    assert lc.shut_down
+
+
+async def test_shutdown_reverse_order() -> None:
+    order: list[str] = []
+
+    class TrackShutdown:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        async def register(self, registry: ExtensionRegistry) -> None:
+            pass
+
+        async def bootstrap(self, ctx: object) -> None:
+            pass
+
+        async def shutdown(self) -> None:
+            order.append(self._name)
+
+    m1 = _make_manifest("first", lifecycle=TrackShutdown("first"))
+    m2 = _make_manifest("second", lifecycle=TrackShutdown("second"))
+
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[m1, m2]):
+        await manager.initialize()
+    await manager.bootstrap()
+    await manager.shutdown()
+
+    assert order == ["second", "first"]
+
+
+async def test_license_validation_skips_invalid() -> None:
+    manifest = _make_manifest(requires_license_key=True)
+
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[manifest]):
+        await manager.initialize(license_keys={"test": "bad.key"})
+
+    # Plugin should be skipped due to invalid license
+    assert len(manager.manifests) == 0
+
+
+async def test_license_validation_passes_with_valid_key() -> None:
+    lc = FakeLifecycle()
+    manifest = _make_manifest(lifecycle=lc, requires_license_key=True)
+    valid_key = generate_license_key("test-org")
+
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[manifest]):
+        await manager.initialize(license_keys={"test": valid_key})
+
+    assert len(manager.manifests) == 1
+    assert lc.registered
+
+
+async def test_double_initialize_skips() -> None:
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[]) as mock_discover:
+        await manager.initialize()
+        await manager.initialize()
+
+    assert mock_discover.call_count == 1
+
+
+async def test_bootstrap_before_initialize_raises() -> None:
+    manager = PluginManager()
+    with pytest.raises(RuntimeError, match="initialize"):
+        await manager.bootstrap()
+
+
+async def test_hook_registry_accessible() -> None:
+    manager = PluginManager()
+    assert isinstance(manager.hook_registry, HookRegistry)
+
+
+async def test_get_plugin_routes_empty() -> None:
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[]):
+        await manager.initialize()
+    assert manager.get_plugin_routes() == []
+
+
+async def test_register_failure_raises() -> None:
+    class BadLifecycle:
+        async def register(self, registry: ExtensionRegistry) -> None:
+            raise ValueError("register boom")
+
+        async def bootstrap(self, ctx: object) -> None:
+            pass
+
+        async def shutdown(self) -> None:
+            pass
+
+    manifest = _make_manifest(lifecycle=BadLifecycle())
+
+    manager = PluginManager()
+    with patch("kt_plugins.manager.discover_plugins", return_value=[manifest]):
+        with pytest.raises(PluginLoadError, match="register"):
+            await manager.initialize()

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "kt-facts",
     "kt-ontology",
     "kt-agents-core",
+    "kt-plugins",
     "kt-worker-ingest",
     "kt-worker-synthesis",
     "kt-worker-nodes",
@@ -40,6 +41,7 @@ kt-providers = { workspace = true }
 kt-facts = { workspace = true }
 kt-ontology = { workspace = true }
 kt-agents-core = { workspace = true }
+kt-plugins = { workspace = true }
 kt-worker-ingest = { workspace = true }
 kt-worker-synthesis = { workspace = true }
 kt-worker-nodes = { workspace = true }

--- a/services/api/src/kt_api/admin.py
+++ b/services/api/src/kt_api/admin.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from kt_api.auth.tokens import require_admin
 from kt_api.dependencies import get_db_session
 from kt_config.settings import get_settings
-from kt_db.models import Node
+from kt_db.models import Node, User
+from kt_db.repositories.roles import RoleRepository
 from kt_models.embeddings import EmbeddingService
 
 logger = logging.getLogger(__name__)
@@ -71,3 +75,123 @@ async def reindex(
 async def refresh_stale() -> dict[str, Any]:
     """Placeholder: Refresh stale nodes by re-fetching from providers."""
     return {"status": "ok", "message": "Refresh stale operation is not yet implemented."}
+
+
+# ---------------------------------------------------------------------------
+# RBAC role management (admin-only)
+# ---------------------------------------------------------------------------
+
+
+class RoleCreate(BaseModel):
+    name: str
+    permissions: dict[str, bool]
+
+
+class RoleUpdate(BaseModel):
+    permissions: dict[str, bool]
+
+
+class RoleResponse(BaseModel):
+    id: str
+    name: str
+    permissions: dict[str, bool]
+    is_system: bool
+
+    model_config = {"from_attributes": True}
+
+
+@router.get("/roles", response_model=list[RoleResponse])
+async def list_roles(
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[dict[str, Any]]:
+    repo = RoleRepository(session)
+    roles = await repo.list_all()
+    return [{"id": str(r.id), "name": r.name, "permissions": r.permissions, "is_system": r.is_system} for r in roles]
+
+
+@router.post("/roles", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
+async def create_role(
+    body: RoleCreate,
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> dict[str, Any]:
+    repo = RoleRepository(session)
+    existing = await repo.get_by_name(body.name)
+    if existing is not None:
+        raise HTTPException(status_code=409, detail=f"Role '{body.name}' already exists")
+    role = await repo.create(body.name, body.permissions)
+    await session.commit()
+    return {"id": str(role.id), "name": role.name, "permissions": role.permissions, "is_system": role.is_system}
+
+
+@router.patch("/roles/{role_id}", response_model=RoleResponse)
+async def update_role(
+    role_id: uuid.UUID,
+    body: RoleUpdate,
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> dict[str, Any]:
+    repo = RoleRepository(session)
+    role = await repo.update_permissions(role_id, body.permissions)
+    if role is None:
+        raise HTTPException(status_code=404, detail="Role not found")
+    await session.commit()
+    return {"id": str(role.id), "name": role.name, "permissions": role.permissions, "is_system": role.is_system}
+
+
+@router.delete("/roles/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_role(
+    role_id: uuid.UUID,
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    repo = RoleRepository(session)
+    deleted = await repo.delete(role_id)
+    if not deleted:
+        raise HTTPException(status_code=400, detail="Cannot delete system role or role not found")
+    await session.commit()
+
+
+@router.post("/users/{user_id}/roles/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def assign_role_to_user(
+    user_id: uuid.UUID,
+    role_id: uuid.UUID,
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    repo = RoleRepository(session)
+    role = await repo.get_by_id(role_id)
+    if role is None:
+        raise HTTPException(status_code=404, detail="Role not found")
+    # Verify user exists
+    result = await session.execute(select(User).where(User.id == user_id))
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    await repo.assign_role(user_id, role_id)
+    await session.commit()
+
+
+@router.delete("/users/{user_id}/roles/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_role_from_user(
+    user_id: uuid.UUID,
+    role_id: uuid.UUID,
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    repo = RoleRepository(session)
+    removed = await repo.remove_role(user_id, role_id)
+    if not removed:
+        raise HTTPException(status_code=404, detail="User-role assignment not found")
+    await session.commit()
+
+
+@router.get("/users/{user_id}/roles", response_model=list[RoleResponse])
+async def get_user_roles(
+    user_id: uuid.UUID,
+    _user: User = Depends(require_admin),
+    session: AsyncSession = Depends(get_db_session),
+) -> list[dict[str, Any]]:
+    repo = RoleRepository(session)
+    roles = await repo.get_user_roles(user_id)
+    return [{"id": str(r.id), "name": r.name, "permissions": r.permissions, "is_system": r.is_system} for r in roles]

--- a/services/api/src/kt_api/auth/manager.py
+++ b/services/api/src/kt_api/auth/manager.py
@@ -17,6 +17,19 @@ from kt_db.repositories.system_settings import SystemSettingsRepository
 logger = logging.getLogger(__name__)
 
 
+async def _fire_hook(hook_name: str, request: object | None, **kwargs: object) -> None:
+    """Fire a plugin hook if the hook registry is available on the app."""
+    try:
+        if request is not None:
+            app = getattr(request, "app", None)
+            if app is not None:
+                hook_registry = getattr(getattr(app, "state", None), "hook_registry", None)
+                if hook_registry is not None:
+                    await hook_registry.trigger(hook_name, **kwargs)
+    except Exception:
+        logger.warning("Failed to fire hook %s", hook_name, exc_info=True)
+
+
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     @property
     def reset_password_token_secret(self) -> str:
@@ -80,6 +93,26 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             session.add(user)
             await session.flush()
             logger.info("First user %s auto-promoted to admin", user.email)
+
+        # Assign default RBAC role
+        from kt_db.repositories.roles import RoleRepository
+
+        role_repo = RoleRepository(session)
+        if user.is_superuser:
+            admin_role = await role_repo.get_by_name("admin")
+            if admin_role:
+                await role_repo.assign_role(user.id, admin_role.id)
+        else:
+            editor_role = await role_repo.get_by_name("editor")
+            if editor_role:
+                await role_repo.assign_role(user.id, editor_role.id)
+
+        # Fire plugin hook: auth.user_created
+        await _fire_hook("auth.user_created", request, user_id=str(user.id), email=user.email)
+
+    async def on_after_login(self, user: User, request=None, response=None) -> None:  # type: ignore[override]
+        # Fire plugin hook: auth.user_login
+        await _fire_hook("auth.user_login", request, user_id=str(user.id), method="jwt")
 
 
 async def get_user_manager(user_db=Depends(get_user_db)) -> AsyncGenerator[UserManager, None]:

--- a/services/api/src/kt_api/auth/permissions.py
+++ b/services/api/src/kt_api/auth/permissions.py
@@ -1,0 +1,71 @@
+"""RBAC permission enforcement via FastAPI dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_api.auth.tokens import require_auth
+from kt_api.dependencies import get_db_session
+from kt_db.models import User
+from kt_db.repositories.roles import RoleRepository
+
+
+async def get_user_permissions(
+    user: User = Depends(require_auth),
+    session: AsyncSession = Depends(get_db_session),
+) -> set[str]:
+    """FastAPI dependency: return the set of permission keys for the current user.
+
+    Superusers get all permissions automatically.
+    """
+    if user.is_superuser:
+        # Superusers bypass RBAC — they have every permission
+        return {"*"}
+    repo = RoleRepository(session)
+    return await repo.get_user_permissions(user.id)
+
+
+def require_permission(
+    *permissions: str,
+) -> Callable[..., Coroutine[Any, Any, User]]:
+    """Factory that returns a FastAPI dependency enforcing RBAC permissions.
+
+    Usage::
+
+        @router.post("/syntheses")
+        async def create_synthesis(
+            user: User = Depends(require_permission("syntheses.create")),
+        ): ...
+
+    The dependency resolves the current user's roles, unions their
+    permission sets, and raises 403 if any required permission is missing.
+    Superusers always pass.
+    """
+
+    async def _check(
+        user: User = Depends(require_auth),
+        session: AsyncSession = Depends(get_db_session),
+    ) -> User:
+        if user.is_superuser:
+            return user
+
+        repo = RoleRepository(session)
+        user_perms = await repo.get_user_permissions(user.id)
+
+        # Wildcard grants everything
+        if "*" in user_perms:
+            return user
+
+        for perm in permissions:
+            if perm not in user_perms:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Missing permission: {perm}",
+                )
+        return user
+
+    return _check

--- a/services/api/src/kt_api/dependencies.py
+++ b/services/api/src/kt_api/dependencies.py
@@ -142,3 +142,28 @@ def require_api_key(user: object) -> str:
             detail="An OpenRouter API key is required. Set one in your profile settings.",
         )
     return key
+
+
+def get_hook_registry() -> object:
+    """Return a new empty hook registry.
+
+    Useful as a fallback in tests or standalone usage when the
+    plugin system is not initialized.
+    """
+    from kt_plugins.hooks import HookRegistry
+
+    return HookRegistry()
+
+
+async def get_hook_registry_from_app(request: object) -> object:
+    """FastAPI dependency that retrieves the hook registry from app state."""
+    from kt_plugins.hooks import HookRegistry
+
+    app = getattr(request, "app", None)
+    if app is not None:
+        state = getattr(app, "state", None)
+        if state is not None:
+            registry = getattr(state, "hook_registry", None)
+            if registry is not None:
+                return registry
+    return HookRegistry()

--- a/services/api/src/kt_api/main.py
+++ b/services/api/src/kt_api/main.py
@@ -41,7 +41,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Startup
     from pathlib import Path
 
+    from fastapi import Depends
+
+    from kt_api.auth.tokens import require_auth
+    from kt_api.dependencies import get_session_factory_cached, get_write_session_factory_cached
     from kt_config.settings import get_settings
+    from kt_plugins.manager import PluginManager
 
     settings = get_settings()
     Path(settings.ingest_upload_dir).mkdir(parents=True, exist_ok=True)
@@ -58,8 +63,32 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception:
         logger.warning("Failed to ensure Qdrant collections at startup", exc_info=True)
 
+    # Plugin system
+    plugin_manager = PluginManager()
+    try:
+        await plugin_manager.initialize(
+            enabled_plugins=settings.enabled_plugins or None,
+            license_keys=settings.plugin_license_keys,
+        )
+        await plugin_manager.bootstrap(
+            session_factory=get_session_factory_cached(),
+            write_session_factory=get_write_session_factory_cached(),
+        )
+        # Wire plugin routes into the API
+        for route_reg in plugin_manager.get_plugin_routes():
+            prefix = f"/api/v1/plugins/{route_reg.prefix}" if route_reg.prefix else ""
+            deps = [Depends(require_auth)] if route_reg.auth_required else []
+            api_router.include_router(route_reg.router, prefix=prefix, dependencies=deps)
+    except Exception:
+        logger.warning("Plugin system initialization failed", exc_info=True)
+
+    app.state.plugin_manager = plugin_manager
+    app.state.hook_registry = plugin_manager.hook_registry
+
     yield
     # Shutdown
+    await plugin_manager.shutdown()
+
     from kt_api.dependencies import reset_session_factory
 
     reset_session_factory()

--- a/services/worker-all/pyproject.toml
+++ b/services/worker-all/pyproject.toml
@@ -5,6 +5,7 @@ description = "Knowledge Tree all-in-one worker (dev mode)"
 requires-python = ">=3.12"
 dependencies = [
     "kt-hatchet",
+    "kt-plugins",
     "kt-worker-bottomup",
     "kt-worker-search",
     "kt-worker-nodes",
@@ -19,6 +20,7 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 kt-hatchet = { workspace = true }
+kt-plugins = { workspace = true }
 kt-worker-bottomup = { workspace = true }
 kt-worker-search = { workspace = true }
 kt-worker-nodes = { workspace = true }

--- a/services/worker-all/src/kt_worker_all/__main__.py
+++ b/services/worker-all/src/kt_worker_all/__main__.py
@@ -35,8 +35,11 @@ def main() -> None:
     except Exception:
         pass
 
+    # Discover plugin-contributed workflows
+    from kt_config.settings import get_settings
     from kt_hatchet.client import get_hatchet
     from kt_hatchet.lifespan import worker_lifespan
+    from kt_plugins.manager import PluginManager
     from kt_worker_bottomup.bottom_up import (
         agent_select_wf,
         bottom_up_prepare_scope_wf,
@@ -80,6 +83,24 @@ def main() -> None:
     from kt_worker_synthesis.workflows.super_synthesizer import super_synthesizer_wf
     from kt_worker_synthesis.workflows.synthesizer import synthesizer_wf
 
+    plugin_workflows: list[object] = []
+    try:
+        import asyncio
+
+        settings = get_settings()
+        plugin_manager = PluginManager()
+        asyncio.get_event_loop().run_until_complete(
+            plugin_manager.initialize(
+                enabled_plugins=settings.enabled_plugins or None,
+                license_keys=settings.plugin_license_keys,
+            )
+        )
+        plugin_workflows = plugin_manager.get_plugin_workflows()
+        if plugin_workflows:
+            logging.getLogger(__name__).info("Loaded %d plugin workflow(s)", len(plugin_workflows))
+    except Exception:
+        logging.getLogger(__name__).warning("Plugin workflow discovery failed", exc_info=True)
+
     hatchet = get_hatchet()
     worker = hatchet.worker(
         "knowledge-tree-all",
@@ -114,6 +135,7 @@ def main() -> None:
             sync_wf,
             synthesizer_wf,
             super_synthesizer_wf,
+            *plugin_workflows,
         ],
         lifespan=worker_lifespan,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ members = [
     "kt-mcp",
     "kt-models",
     "kt-ontology",
+    "kt-plugins",
     "kt-providers",
     "kt-qdrant",
     "kt-worker-all",
@@ -1628,7 +1629,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-tree-workspace"
-version = "0.3.0"
+version = "0.5.1"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1699,6 +1700,7 @@ dependencies = [
     { name = "kt-hatchet" },
     { name = "kt-models" },
     { name = "kt-ontology" },
+    { name = "kt-plugins" },
     { name = "kt-providers" },
     { name = "kt-worker-ingest" },
     { name = "kt-worker-nodes" },
@@ -1723,6 +1725,7 @@ requires-dist = [
     { name = "kt-hatchet", editable = "libs/kt-hatchet" },
     { name = "kt-models", editable = "libs/kt-models" },
     { name = "kt-ontology", editable = "libs/kt-ontology" },
+    { name = "kt-plugins", editable = "libs/kt-plugins" },
     { name = "kt-providers", editable = "libs/kt-providers" },
     { name = "kt-worker-ingest", editable = "services/worker-ingest" },
     { name = "kt-worker-nodes", editable = "services/worker-nodes" },
@@ -1918,6 +1921,17 @@ requires-dist = [
 ]
 
 [[package]]
+name = "kt-plugins"
+version = "0.1.0"
+source = { editable = "libs/kt-plugins" }
+dependencies = [
+    { name = "kt-config" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "kt-config", editable = "libs/kt-config" }]
+
+[[package]]
 name = "kt-providers"
 version = "0.1.0"
 source = { editable = "libs/kt-providers" }
@@ -1961,6 +1975,7 @@ version = "0.1.0"
 source = { editable = "services/worker-all" }
 dependencies = [
     { name = "kt-hatchet" },
+    { name = "kt-plugins" },
     { name = "kt-worker-bottomup" },
     { name = "kt-worker-ingest" },
     { name = "kt-worker-nodes" },
@@ -1972,6 +1987,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "kt-hatchet", editable = "libs/kt-hatchet" },
+    { name = "kt-plugins", editable = "libs/kt-plugins" },
     { name = "kt-worker-bottomup", editable = "services/worker-bottomup" },
     { name = "kt-worker-ingest", editable = "services/worker-ingest" },
     { name = "kt-worker-nodes", editable = "services/worker-nodes" },


### PR DESCRIPTION
## Summary

Implements the core plugin infrastructure for Knowledge Tree, enabling proprietary and open-source plugins through the AGPL Plugin Exception (LICENSE Section 7).

- **New `libs/kt-plugins/` library** — Plugin manifest, entry-point discovery, async hook registry (trigger/filter), typed extension registry (routes, providers, auth backends, workflows, custom types), plugin manager lifecycle, HMAC license validation, per-plugin Alembic migrations
- **RBAC (core feature)** — Role/UserRole models, migration seeding admin/editor/viewer defaults, RoleRepository, `require_permission()` FastAPI dependency, admin CRUD endpoints for role management
- **API integration** — PluginManager initialized in FastAPI lifespan, plugin routes dynamically wired, hook_registry on app.state
- **Worker integration** — Plugin workflow discovery in worker-all
- **Auth hooks** — `auth.user_created` and `auth.user_login` trigger points, auto-assign RBAC roles on registration
- **PLUGINS.md** — Documented Plugin API as required by LICENSE
- **40 unit tests** for kt-plugins covering hooks, discovery, manager, license, and extension registry

## Test plan

- [x] 40 kt-plugins unit tests pass (`uv run --project libs/kt-plugins pytest -x -v`)
- [x] kt-config tests pass (26 tests)
- [x] API unit tests pass (21 tests)
- [x] All ruff lint checks pass
- [x] All imports verified across API, worker-all, and kt-db
- [ ] CI pipeline (integration tests with Postgres)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)