### PR TITLE
fix: make cross-service URLs configurable via SITE_DOMAIN

### DIFF
--- a/docs-site/Dockerfile
+++ b/docs-site/Dockerfile
@@ -8,5 +8,8 @@ RUN pnpm build
 
 FROM nginx:alpine
 COPY --from=builder /app/build /usr/share/nginx/html
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 80
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/docs-site/docker-entrypoint.sh
+++ b/docs-site/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Replace the default domain with SITE_DOMAIN at container startup.
+# This allows the same image to serve dev and prod with different cross-links.
+set -e
+
+SITE_DOMAIN="${SITE_DOMAIN:-openktree.com}"
+
+if [ "$SITE_DOMAIN" != "openktree.com" ]; then
+  echo "Replacing domain: openktree.com -> $SITE_DOMAIN"
+  find /usr/share/nginx/html -type f \( -name '*.html' -o -name '*.js' \) \
+    -exec sed -i "s|openktree\.com|${SITE_DOMAIN}|g" {} +
+fi
+
+exec "$@"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -33,11 +33,13 @@ const ADMIN_NAV_ITEMS = [
   { href: "/settings", label: "Settings", icon: Settings },
 ] as const;
 
+const SITE_DOMAIN = process.env.NEXT_PUBLIC_SITE_DOMAIN || "openktree.com";
+
 const EXTERNAL_LINKS = [
-  { href: "https://openktree.com", label: "Home" },
-  { href: "https://docs.openktree.com", label: "Docs" },
-  { href: "https://wiki.openktree.com", label: "Wiki" },
-] as const;
+  { href: `https://${SITE_DOMAIN}`, label: "Home" },
+  { href: `https://docs.${SITE_DOMAIN}`, label: "Docs" },
+  { href: `https://wiki.${SITE_DOMAIN}`, label: "Wiki" },
+];
 
 export function SidebarLayout({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);

--- a/helm/knowledge-tree/templates/docs-site-deployment.yaml
+++ b/helm/knowledge-tree/templates/docs-site-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         - name: docs-site
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.docsSite.image "defaultName" "openktree-docs-site") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: SITE_DOMAIN
+              value: {{ .Values.docsSite.siteDomain | default .Values.global.siteDomain | default "openktree.com" | quote }}
           ports:
             - containerPort: {{ .Values.docsSite.port }}
               protocol: TCP

--- a/helm/knowledge-tree/templates/frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/frontend-deployment.yaml
@@ -34,6 +34,8 @@ spec:
             - name: NEXT_PUBLIC_API_URL
               value: {{ .Values.frontend.env.NEXT_PUBLIC_API_URL | quote }}
             {{- end }}
+            - name: NEXT_PUBLIC_SITE_DOMAIN
+              value: {{ .Values.frontend.siteDomain | default .Values.global.siteDomain | default "openktree.com" | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/knowledge-tree/templates/landing-page-deployment.yaml
+++ b/helm/knowledge-tree/templates/landing-page-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         - name: landing-page
           image: {{ include "knowledge-tree.image" (dict "root" . "image" .Values.landingPage.image "defaultName" "openktree-landing-page") }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: SITE_DOMAIN
+              value: {{ .Values.landingPage.siteDomain | default .Values.global.siteDomain | default "openktree.com" | quote }}
           ports:
             - containerPort: {{ .Values.landingPage.port }}
               protocol: TCP

--- a/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
@@ -33,6 +33,8 @@ spec:
               value: {{ .Values.wikiFrontend.port | quote }}
             - name: API_BASE_URL
               value: "http://{{ include "knowledge-tree.fullname" . }}-api:{{ .Values.api.port }}"
+            - name: SITE_DOMAIN
+              value: {{ .Values.wikiFrontend.siteDomain | default .Values.global.siteDomain | default "openktree.com" | quote }}
           livenessProbe:
             httpGet:
               path: /

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -8,6 +8,8 @@ global:
   imageTag: "latest"
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []
+  # Base domain for cross-service links (e.g., "openktree.com" or "openktree-dev.com")
+  siteDomain: "openktree.com"
 
 # -- Secrets (set via --set or external secret)
 secrets:

--- a/landing-page/Dockerfile
+++ b/landing-page/Dockerfile
@@ -8,5 +8,8 @@ RUN pnpm build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 EXPOSE 80
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/landing-page/docker-entrypoint.sh
+++ b/landing-page/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Replace the default domain with SITE_DOMAIN at container startup.
+# This allows the same image to serve dev and prod with different cross-links.
+set -e
+
+SITE_DOMAIN="${SITE_DOMAIN:-openktree.com}"
+
+if [ "$SITE_DOMAIN" != "openktree.com" ]; then
+  echo "Replacing domain: openktree.com -> $SITE_DOMAIN"
+  find /usr/share/nginx/html -type f \( -name '*.html' -o -name '*.js' \) \
+    -exec sed -i "s|openktree\.com|${SITE_DOMAIN}|g" {} +
+fi
+
+exec "$@"

--- a/wiki-frontend/src/layouts/WikiLayout.astro
+++ b/wiki-frontend/src/layouts/WikiLayout.astro
@@ -7,6 +7,7 @@ interface Props {
 }
 
 const { title, query = "" } = Astro.props;
+const siteDomain = import.meta.env.SITE_DOMAIN || "openktree.com";
 ---
 
 <!doctype html>
@@ -50,9 +51,9 @@ const { title, query = "" } = Astro.props;
       </form>
 
       <div class="header-actions">
-        <a href="https://openktree.com" class="header-about-link">Home</a>
-        <a href="https://research.openktree.com" class="header-about-link">Research</a>
-        <a href="https://docs.openktree.com" class="header-about-link">Docs</a>
+        <a href={`https://${siteDomain}`} class="header-about-link">Home</a>
+        <a href={`https://research.${siteDomain}`} class="header-about-link">Research</a>
+        <a href={`https://docs.${siteDomain}`} class="header-about-link">Docs</a>
         <a href="/about" class="header-about-link">About</a>
         <button
           class="theme-toggle"


### PR DESCRIPTION
## Summary

- Cross-links between services (Home, Docs, Wiki, Research) now derive from a single `global.siteDomain` Helm value
- Dev uses `openktree-dev.com`, prod uses `openktree.com`, from the same Docker images
- **Static sites** (docs-site, landing-page): nginx entrypoint script replaces `openktree.com` with `$SITE_DOMAIN` at container start
- **Wiki frontend** (Astro SSR): reads `SITE_DOMAIN` env var at request time via `import.meta.env`
- **Research frontend** (Next.js): reads `NEXT_PUBLIC_SITE_DOMAIN` env var

## Test plan
- [ ] Deploy to dev, verify wiki links point to `*.openktree-dev.com`
- [ ] Verify landing page links point to `*.openktree-dev.com`
- [ ] Verify docs site links point to `*.openktree-dev.com`
- [ ] Verify research app sidebar links point to `*.openktree-dev.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)