### PR TITLE
feat(frontend): rename navigation and add page instructions for UX

### DIFF
--- a/frontend/src/app/edge-candidates/page.tsx
+++ b/frontend/src/app/edge-candidates/page.tsx
@@ -3,5 +3,19 @@
 import { EdgeCandidateListView } from "@/components/edge-candidate/EdgeCandidateListView";
 
 export default function EdgeCandidatesPage() {
-  return <EdgeCandidateListView />;
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-6 pt-6 pb-0">
+        <h1 className="text-2xl font-bold tracking-tight">Edge Candidates</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Proposed relationships between nodes discovered during ingestion.
+          Review candidates to create verified edges in the graph.
+        </p>
+      </div>
+
+      <div className="flex-1 min-h-0 mt-4">
+        <EdgeCandidateListView />
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/edges/page.tsx
+++ b/frontend/src/app/edges/page.tsx
@@ -9,7 +9,9 @@ export default function EdgesPage() {
       <div className="px-6 pt-6 pb-0">
         <h1 className="text-2xl font-bold tracking-tight">Edges</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Browse, search, and manage graph edges
+          Edges represent verified relationships between nodes, weighted by
+          shared evidence. Browse and filter connections in your knowledge
+          graph.
         </p>
       </div>
 

--- a/frontend/src/app/facts/page.tsx
+++ b/frontend/src/app/facts/page.tsx
@@ -9,7 +9,8 @@ export default function FactsPage() {
       <div className="px-6 pt-6 pb-0">
         <h1 className="text-2xl font-bold tracking-tight">Facts</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Browse, search, and manage knowledge facts
+          Facts are atomic claims extracted from ingested sources — the
+          evidence base from which nodes and edges are built.
         </p>
       </div>
 

--- a/frontend/src/app/grow-graph/page.tsx
+++ b/frontend/src/app/grow-graph/page.tsx
@@ -64,9 +64,16 @@ export default function ResearchPage() {
   return (
     <div className="p-8">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold">Research</h1>
+        <h1 className="text-2xl font-bold">Grow Graph</h1>
         <p className="text-muted-foreground mt-1">
-          Gather facts from sources, then build them into graph nodes.
+          Add new data to your knowledge graph by uploading documents or
+          discovering web sources.
+        </p>
+        <p className="text-xs text-muted-foreground/70 mt-1">
+          Use &ldquo;From Source&rdquo; to upload files directly, or
+          &ldquo;From the Web&rdquo; to let an agent find and process online
+          sources. Ingested data is decomposed into facts and seeds that feed
+          the graph.
         </p>
       </div>
 
@@ -104,7 +111,7 @@ export default function ResearchPage() {
                 onClick={clearView}
               >
                 <ArrowLeft className="size-3.5" />
-                Back to research
+                Back to ingestion
               </Button>
               <h2 className="text-lg font-semibold">{viewingBuild.title}</h2>
               <ResearchBuildProgress

--- a/frontend/src/app/investigate/[id]/page.tsx
+++ b/frontend/src/app/investigate/[id]/page.tsx
@@ -44,7 +44,7 @@ export default function SynthesisDetailPage() {
     setDeleting(true);
     try {
       await deleteSynthesis(id);
-      router.push("/syntheses");
+      router.push("/investigate");
     } catch (err) {
       console.error("Failed to delete synthesis:", err);
       setDeleting(false);
@@ -63,9 +63,9 @@ export default function SynthesisDetailPage() {
     return (
       <div className="mx-auto max-w-4xl py-8 px-4">
         <Button variant="ghost" asChild className="mb-4">
-          <Link href="/syntheses">
+          <Link href="/investigate">
             <ArrowLeft className="mr-2 size-4" />
-            Back to Syntheses
+            Back to Investigations
           </Link>
         </Button>
         <p className="text-destructive">{error || "Synthesis not found"}</p>
@@ -78,9 +78,9 @@ export default function SynthesisDetailPage() {
       {/* Top bar */}
       <div className="flex items-center justify-between mb-6 max-w-4xl mx-auto">
         <Button variant="ghost" size="sm" asChild className="text-muted-foreground hover:text-foreground -ml-2">
-          <Link href="/syntheses">
+          <Link href="/investigate">
             <ArrowLeft className="mr-1.5 size-3.5" />
-            Syntheses
+            Investigations
           </Link>
         </Button>
         <div className="flex items-center gap-1">

--- a/frontend/src/app/investigate/page.tsx
+++ b/frontend/src/app/investigate/page.tsx
@@ -57,13 +57,18 @@ export default function SynthesesPage() {
       <div className="flex items-end justify-between mb-10">
         <div>
           <p className="text-[0.68rem] uppercase tracking-[0.12em] font-bold text-muted-foreground mb-1">
-            Research Documents
+            Graph Investigation
           </p>
           <h1 className="text-[2rem] font-semibold text-foreground leading-tight">
-            Syntheses
+            Investigate
           </h1>
           <p className="text-[0.85rem] text-muted-foreground mt-1">
             {total} document{total !== 1 ? "s" : ""}
+          </p>
+          <p className="text-[0.82rem] text-muted-foreground/70 mt-2 max-w-md">
+            Synthesis agents investigate topics by navigating and integrating
+            information across your knowledge graph into research documents.
+            More investigation modes coming soon.
           </p>
         </div>
         <Button
@@ -71,7 +76,7 @@ export default function SynthesesPage() {
           className="rounded-full px-5"
         >
           <Plus className="mr-2 size-4" />
-          New Synthesis
+          New Investigation
         </Button>
       </div>
 
@@ -86,18 +91,18 @@ export default function SynthesesPage() {
             <FileText className="size-8 text-muted-foreground" />
           </div>
           <h3 className="text-[1.1rem] font-medium text-foreground/80 mb-1">
-            No syntheses yet
+            No investigations yet
           </h3>
           <p className="text-[0.85rem] text-muted-foreground mb-6 max-w-sm">
-            Create a synthesis to explore and analyze topics across your
-            knowledge graph.
+            Start an investigation to have a synthesis agent explore and
+            integrate information across your knowledge graph.
           </p>
           <Button
             onClick={() => setCreateOpen(true)}
             className="rounded-full px-5"
           >
             <Plus className="mr-2 size-4" />
-            Create First Synthesis
+            Start First Investigation
           </Button>
         </div>
       ) : (
@@ -175,7 +180,7 @@ function SynthesisCard({
 
   return (
     <a
-      href={`/syntheses/${item.id}`}
+      href={`/investigate/${item.id}`}
       className={`block rounded-lg border bg-card hover:border-ocean/30 hover:shadow-sm transition-all ${
         compact ? "px-3 py-2" : "px-5 py-4"
       }`}

--- a/frontend/src/app/nodes/page.tsx
+++ b/frontend/src/app/nodes/page.tsx
@@ -140,7 +140,8 @@ export default function NodesPage() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Nodes</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Browse, search, and explore knowledge graph nodes
+            Browse, search, and explore knowledge graph nodes. Use List View
+            for search and filtering, or Graph Explorer for visual navigation.
           </p>
         </div>
         {user?.is_superuser && (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,30 +19,37 @@ export default function HomePage() {
             </h1>
           </div>
           <p className="text-muted-foreground">
-            A knowledge integration system that builds understanding from raw
-            external data. Ingest sources, grow the graph, and synthesize
-            research documents.
+            Build and investigate a knowledge graph grounded in real sources.
+            Ingest data to grow the graph, then explore findings through
+            synthesis agents or direct browsing.
+          </p>
+          <p className="text-xs text-muted-foreground/70 mt-2">
+            Suggested flow: Browse existing data → identify gaps → grow the
+            graph with new sources → investigate via synthesis agents or at your
+            own pace using the MCP.
           </p>
         </div>
 
         {/* Navigation cards */}
         <div className="grid gap-4 sm:grid-cols-2">
           <Link
-            href="/syntheses"
+            href="/investigate"
             className="rounded-lg border p-6 hover:bg-accent transition-colors"
           >
-            <h2 className="font-semibold mb-1">Syntheses</h2>
+            <h2 className="font-semibold mb-1">Investigate</h2>
             <p className="text-sm text-muted-foreground">
-              Create and view research synthesis documents from the graph.
+              Launch synthesis agents to explore topics by integrating
+              information across your knowledge graph.
             </p>
           </Link>
           <Link
-            href="/research"
+            href="/grow-graph"
             className="rounded-lg border p-6 hover:bg-accent transition-colors"
           >
-            <h2 className="font-semibold mb-1">Ingest Sources</h2>
+            <h2 className="font-semibold mb-1">Grow Graph</h2>
             <p className="text-sm text-muted-foreground">
-              Upload files or add links to grow the knowledge graph.
+              Upload documents or discover web sources to extract facts and
+              expand the knowledge graph.
             </p>
           </Link>
           <Link
@@ -51,7 +58,7 @@ export default function HomePage() {
           >
             <h2 className="font-semibold mb-1">Browse Graph</h2>
             <p className="text-sm text-muted-foreground">
-              Explore nodes, edges, facts, and seeds in the knowledge graph.
+              Explore nodes, edges, and relationships directly in the graph.
             </p>
           </Link>
           <Link
@@ -60,7 +67,8 @@ export default function HomePage() {
           >
             <h2 className="font-semibold mb-1">Seeds</h2>
             <p className="text-sm text-muted-foreground">
-              View extracted entities and concepts awaiting promotion.
+              Review extracted entities and concepts awaiting promotion to full
+              nodes.
             </p>
           </Link>
         </div>

--- a/frontend/src/app/profile/tokens/page.tsx
+++ b/frontend/src/app/profile/tokens/page.tsx
@@ -275,14 +275,20 @@ export default function TokensPage() {
 
   return (
     <div className="max-w-lg mx-auto px-6 py-10 flex flex-col gap-6">
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3">
         <Link
           href="/profile"
-          className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          className="rounded-md p-1.5 mt-0.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
         >
           <ArrowLeft className="size-4" />
         </Link>
-        <h1 className="text-xl font-semibold">API tokens</h1>
+        <div>
+          <h1 className="text-xl font-semibold">API Tokens</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Generate tokens to authenticate API requests or connect MCP clients
+            (such as Claude Desktop) to your knowledge graph.
+          </p>
+        </div>
       </div>
 
       {newToken && (

--- a/frontend/src/app/seeds/page.tsx
+++ b/frontend/src/app/seeds/page.tsx
@@ -9,8 +9,9 @@ export default function SeedsPage() {
       <div className="px-6 pt-6 pb-0">
         <h1 className="text-2xl font-bold tracking-tight">Seeds</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Proto-nodes extracted from facts. Track entity mentions, deduplication,
-          disambiguation, and promotion to full nodes.
+          Seeds are entities and concepts automatically extracted during
+          ingestion. Review them here and promote promising seeds into full
+          graph nodes.
         </p>
       </div>
 

--- a/frontend/src/app/sources/page.tsx
+++ b/frontend/src/app/sources/page.tsx
@@ -9,7 +9,8 @@ export default function SourcesPage() {
       <div className="px-6 pt-6 pb-0">
         <h1 className="text-2xl font-bold tracking-tight">Sources</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Browse processed raw sources backing knowledge facts
+          Sources are the raw documents and web pages you have ingested. Each
+          source is decomposed into facts that feed the knowledge graph.
         </p>
       </div>
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { CircleDot, ArrowLeftRight, FileText, PanelLeftClose, PanelLeft, TreePine, Upload, Globe, Sprout, GitPullRequestArrow, BarChart3, Users, Settings, BookOpen, ExternalLink } from "lucide-react";
+import { CircleDot, ArrowLeftRight, FileText, PanelLeftClose, PanelLeft, TreePine, Upload, Globe, Sprout, GitPullRequestArrow, BarChart3, Users, Settings, Search, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -15,10 +15,13 @@ import { ThemeToggle } from "@/components/theme/ThemeToggle";
 import { useAuth } from "@/contexts/auth";
 import { cn } from "@/lib/utils";
 
-const NAV_ITEMS = [
+const WORKFLOW_ITEMS = [
   { href: "/", label: "Home", icon: TreePine },
-  { href: "/syntheses", label: "Syntheses", icon: BookOpen },
-  { href: "/research", label: "Research", icon: Upload },
+  { href: "/investigate", label: "Investigate", icon: Search },
+  { href: "/grow-graph", label: "Grow Graph", icon: Upload },
+] as const;
+
+const DATA_ITEMS = [
   { href: "/nodes", label: "Nodes", icon: CircleDot },
   { href: "/edges", label: "Edges", icon: ArrowLeftRight },
   { href: "/facts", label: "Facts", icon: FileText },
@@ -69,8 +72,9 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
 
         {/* Navigation */}
         <nav className="flex-1 flex flex-col gap-1 p-2">
-          {NAV_ITEMS.map((item) => {
+          {[...WORKFLOW_ITEMS, ...DATA_ITEMS].map((item, index) => {
             const active = isActive(item.href);
+            const showDivider = index === WORKFLOW_ITEMS.length;
             const linkContent = (
               <Link
                 href={item.href}
@@ -87,16 +91,25 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
               </Link>
             );
 
-            if (collapsed) {
+            const element = collapsed ? (
+              <Tooltip key={item.href}>
+                <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+                <TooltipContent side="right">{item.label}</TooltipContent>
+              </Tooltip>
+            ) : (
+              <div key={item.href}>{linkContent}</div>
+            );
+
+            if (showDivider) {
               return (
-                <Tooltip key={item.href}>
-                  <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
-                  <TooltipContent side="right">{item.label}</TooltipContent>
-                </Tooltip>
+                <div key={item.href}>
+                  <div className={cn("border-t border-border my-1", collapsed && "mx-1")} />
+                  {element}
+                </div>
               );
             }
 
-            return <div key={item.href}>{linkContent}</div>;
+            return element;
           })}
 
           {isAdmin && (

--- a/frontend/src/components/research/SourceUploadForm.tsx
+++ b/frontend/src/components/research/SourceUploadForm.tsx
@@ -379,7 +379,7 @@ export function SourceUploadForm() {
     try {
       const selected = nodes.filter((n) => n.selected);
       await api.research.build(prepareResult.conversation_id, selected);
-      router.push(`/research`);
+      router.push(`/grow-graph`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Build failed");
       setStep("review");
@@ -404,7 +404,7 @@ export function SourceUploadForm() {
         50, // default nav budget for legacy path
         allSelected,
       );
-      router.push(`/research`);
+      router.push(`/grow-graph`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Ingest failed");
       setStep("confirm");

--- a/frontend/src/components/synthesis/SubSynthesisList.tsx
+++ b/frontend/src/components/synthesis/SubSynthesisList.tsx
@@ -21,7 +21,7 @@ export function SubSynthesisList({ subSyntheses }: SubSynthesisListProps) {
           {subSyntheses.map((sub) => (
             <a
               key={sub.node_id}
-              href={`/syntheses/${sub.node_id}`}
+              href={`/investigate/${sub.node_id}`}
               className="flex items-center gap-3 rounded-lg border p-3.5 hover:bg-accent hover:border-ocean/30 transition-all group"
             >
               <BookOpen className="size-4 text-ocean/60 group-hover:text-ocean shrink-0" />


### PR DESCRIPTION
## Summary
- Rename **Syntheses → Investigate** (`/investigate`) and **Research → Grow Graph** (`/grow-graph`) to better communicate purpose to new users
- Split sidebar navigation into **Workflow** (Home, Investigate, Grow Graph) and **Data** (Nodes, Edges, Facts, Sources, Seeds, Candidates) groups with a visual divider
- Add instructional subtitles on every page to guide new users through the system
- Restructure home page with updated card descriptions and a suggested workflow flow
- Add MCP mention to API Tokens page subtitle

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm type-check` passes  
- [x] `pnpm test` — all 123 tests pass
- [ ] Verify sidebar labels "Investigate" and "Grow Graph" render in expanded and collapsed (tooltip) states
- [ ] Verify divider renders between "Grow Graph" and "Nodes"
- [ ] Verify `/investigate` and `/grow-graph` routes load correctly
- [ ] Verify all home page card links navigate to correct pages
- [ ] Verify back links on investigate detail page work
- [ ] No broken links remain to old `/syntheses` or `/research` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)