### PR TITLE
feat(wiki-frontend): add homepage tabs, synthesis views, and fix definition rendering

### DIFF
--- a/libs/kt-db/src/kt_db/repositories/nodes.py
+++ b/libs/kt-db/src/kt_db/repositories/nodes.py
@@ -5,7 +5,7 @@ from sqlalchemy import func, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from kt_db.models import Edge, Node, NodeCounter, _utcnow
+from kt_db.models import Edge, Node, NodeCounter, NodeFact, _utcnow
 
 
 class NodeRepository:
@@ -184,6 +184,18 @@ class NodeRepository:
                 .outerjoin(source_count, Node.id == source_count.c.node_id)
                 .outerjoin(target_count, Node.id == target_count.c.node_id)
                 .order_by(edge_total.desc(), Node.updated_at.desc())
+            )
+        elif sort == "fact_count":
+            # Count facts linked to each node via node_facts junction table
+            fact_count_sub = (
+                select(NodeFact.node_id.label("node_id"), func.count(NodeFact.fact_id).label("cnt"))
+                .group_by(NodeFact.node_id)
+                .subquery()
+            )
+            stmt = (
+                select(Node)
+                .outerjoin(fact_count_sub, Node.id == fact_count_sub.c.node_id)
+                .order_by(func.coalesce(fact_count_sub.c.cnt, 0).desc(), Node.updated_at.desc())
             )
         else:
             stmt = select(Node).order_by(Node.updated_at.desc())

--- a/services/api/src/kt_api/nodes.py
+++ b/services/api/src/kt_api/nodes.py
@@ -367,7 +367,7 @@ async def list_nodes(
     limit: int = Query(20, ge=1, le=100),
     search: str | None = Query(None, description="Search by concept name"),
     node_type: str | None = Query(None, description="Filter by node type: concept, perspective, entity, event"),
-    sort: str = Query("updated_at", description="Sort order: updated_at, edge_count, or pending_facts"),
+    sort: str = Query("updated_at", description="Sort order: updated_at, edge_count, fact_count, or pending_facts"),
     session: AsyncSession = Depends(get_db_session),
 ) -> PaginatedNodesResponse:
     """List nodes with pagination, optional search, and optional node_type filter."""

--- a/wiki-frontend/.astro/types.d.ts
+++ b/wiki-frontend/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/wiki-frontend/src/lib/api.ts
+++ b/wiki-frontend/src/lib/api.ts
@@ -5,6 +5,9 @@ import type {
   FactResponse,
   DimensionResponse,
   FactNodeInfo,
+  SynthesisListItem,
+  SynthesisDocumentResponse,
+  SentenceFactResponse,
 } from "../types/index.js";
 
 const API_BASE_URL =
@@ -122,4 +125,31 @@ export async function searchNodes(
   return get<NodeResponse[]>(
     `/api/v1/nodes/search?query=${encoded}&limit=${limit}`
   );
+}
+
+export async function listSyntheses(
+  limit = 50,
+  visibility = "public"
+): Promise<SynthesisListItem[]> {
+  const data = await get<{ items: SynthesisListItem[]; total: number }>(
+    `/api/v1/syntheses?limit=${limit}&visibility=${visibility}`
+  );
+  return data.items;
+}
+
+export async function getSynthesis(id: string): Promise<SynthesisDocumentResponse> {
+  return get<SynthesisDocumentResponse>(`/api/v1/syntheses/${id}`);
+}
+
+export async function getSentenceFacts(
+  synthesisId: string,
+  position: number
+): Promise<SentenceFactResponse[]> {
+  return get<SentenceFactResponse[]>(
+    `/api/v1/syntheses/${synthesisId}/sentences/${position}/facts`
+  );
+}
+
+export function synthesisHref(synthesis: { id: string }): string {
+  return `/syntheses/${synthesis.id}`;
 }

--- a/wiki-frontend/src/lib/synthesis-utils.ts
+++ b/wiki-frontend/src/lib/synthesis-utils.ts
@@ -1,0 +1,96 @@
+import type { SynthesisSentenceResponse } from "../types/index.js";
+
+/**
+ * Parse a synthesis concept like "Topic [20260326-171500]" into
+ * a clean title and a human-readable date.
+ */
+export function formatSynthesisConcept(concept: string): {
+  title: string;
+  date: string | null;
+} {
+  const match = concept.match(
+    /^(.+?)\s*\[(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})\]$/
+  );
+  if (!match) {
+    return { title: concept, date: null };
+  }
+  const [, title, year, month, day, hour, minute] = match;
+  const d = new Date(`${year}-${month}-${day}T${hour}:${minute}:00Z`);
+  const date = d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return { title: title.trim(), date };
+}
+
+/**
+ * Build a map from paragraph plain-text keys (first 60 chars) to the
+ * sentences that fall within that paragraph. Used for sentence-level
+ * fact linking in synthesis views.
+ */
+export function buildParagraphSentenceMap(
+  definition: string,
+  sentences: SynthesisSentenceResponse[]
+): Map<string, SynthesisSentenceResponse[]> {
+  const map = new Map<string, SynthesisSentenceResponse[]>();
+  if (!definition || sentences.length === 0) return map;
+
+  const rawBlocks = definition
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  const paragraphs: string[] = [];
+  for (const block of rawBlocks) {
+    const lines = block
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const isList =
+      lines.length > 1 &&
+      lines.every((l) => /^(\d+\.\s|[-*]\s)/.test(l));
+    if (isList) {
+      for (const line of lines) paragraphs.push(line);
+    } else {
+      paragraphs.push(block);
+    }
+  }
+
+  for (const para of paragraphs) {
+    const plainPara = para
+      .replace(/^#{1,6}\s+/, "")
+      .replace(/^\d+\.\s+/, "")
+      .replace(/^[-*]\s+/, "")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/\*\*([^*]+)\*\*/g, "$1")
+      .replace(/\*([^*]+)\*/g, "$1");
+
+    const matched: SynthesisSentenceResponse[] = [];
+    for (const s of sentences) {
+      const plainSentence = s.text
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        .replace(/\*\*([^*]+)\*\*/g, "$1")
+        .replace(/\*([^*]+)\*/g, "$1")
+        .trim();
+      if (plainSentence.length < 10) continue;
+      const sentStart = plainSentence.slice(0, 40);
+      const sentMid =
+        plainSentence.length > 50 ? plainSentence.slice(10, 50) : "";
+      if (
+        plainPara.includes(sentStart) ||
+        (sentMid && plainPara.includes(sentMid)) ||
+        plainSentence.includes(plainPara.slice(0, 40))
+      ) {
+        matched.push(s);
+      }
+    }
+
+    if (matched.length > 0) {
+      map.set(plainPara.slice(0, 60).trim(), matched);
+    }
+  }
+  return map;
+}

--- a/wiki-frontend/src/pages/api/sentence-facts.ts
+++ b/wiki-frontend/src/pages/api/sentence-facts.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+import { getSentenceFacts } from "../../lib/api.js";
+
+export const GET: APIRoute = async ({ url }) => {
+  const synthesisId = url.searchParams.get("synthesisId");
+  const position = parseInt(url.searchParams.get("position") ?? "0", 10);
+
+  if (!synthesisId) {
+    return new Response(JSON.stringify({ error: "synthesisId is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const facts = await getSentenceFacts(synthesisId, position);
+    return new Response(JSON.stringify(facts), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};

--- a/wiki-frontend/src/pages/index.astro
+++ b/wiki-frontend/src/pages/index.astro
@@ -1,16 +1,23 @@
 ---
 import WikiLayout from "../layouts/WikiLayout.astro";
-import { listNodes, searchNodes, nodeHref } from "../lib/api.js";
-import type { NodeResponse } from "../types/index.js";
+import { listNodes, searchNodes, nodeHref, listSyntheses, synthesisHref } from "../lib/api.js";
+import { formatSynthesisConcept } from "../lib/synthesis-utils.js";
+import type { NodeResponse, SynthesisListItem } from "../types/index.js";
 
 const q = Astro.url.searchParams.get("q")?.trim() ?? "";
+const tab = q ? "" : (Astro.url.searchParams.get("tab") ?? "connected");
 
 let nodes: NodeResponse[] = [];
+let syntheses: SynthesisListItem[] = [];
 let error: string | null = null;
 
 try {
   if (q) {
     nodes = await searchNodes(q);
+  } else if (tab === "investigations") {
+    syntheses = await listSyntheses(50, "public");
+  } else if (tab === "facts") {
+    nodes = await listNodes(50, "fact_count");
   } else {
     nodes = await listNodes(50, "edge_count");
   }
@@ -36,30 +43,83 @@ try {
 
   {error && <div class="error-banner">{error}</div>}
 
-  {!error && nodes.length === 0 && (
-    <p class="empty-state">
-      {q ? `No nodes found matching "${q}".` : "No nodes in the graph yet."}
-    </p>
+  {!error && q && (
+    <>
+      {nodes.length === 0 ? (
+        <p class="empty-state">No nodes found matching "{q}".</p>
+      ) : (
+        <>
+          <p class="search-results-label">
+            {nodes.length} result{nodes.length !== 1 ? "s" : ""} for "{q}"
+          </p>
+          <ul class="node-flat-list">
+            {nodes.map((node) => (
+              <li>
+                <a href={nodeHref(node)} class="node-flat-link" title={node.concept}>
+                  {node.concept}
+                </a>
+                <span class={`type-badge ${node.node_type}`}>{node.node_type}</span>
+                <span class="node-edge-count" title="number of relations">{node.edge_count + node.child_count} rel</span>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </>
   )}
 
-  {!error && nodes.length > 0 && (
+  {!error && !q && (
     <>
-      {q && (
-        <p class="search-results-label">
-          {nodes.length} result{nodes.length !== 1 ? "s" : ""} for "{q}"
-        </p>
+      <div class="tab-bar">
+        <a href="/?tab=connected" class={`tab ${tab === "connected" ? "tab--active" : ""}`}>Most Connected</a>
+        <a href="/?tab=facts" class={`tab ${tab === "facts" ? "tab--active" : ""}`}>Most Facts</a>
+        <a href="/?tab=investigations" class={`tab ${tab === "investigations" ? "tab--active" : ""}`}>Investigations</a>
+      </div>
+
+      {tab === "investigations" ? (
+        syntheses.length === 0 ? (
+          <p class="empty-state">No public investigations yet.</p>
+        ) : (
+          <ul class="node-flat-list synthesis-list">
+            {syntheses.map((syn) => {
+              const { title, date } = formatSynthesisConcept(syn.concept);
+              const typeLabel = syn.node_type === "supersynthesis" ? "super-synthesis" : "synthesis";
+              return (
+                <li>
+                  <a href={synthesisHref(syn)} class="node-flat-link" title={title}>
+                    {title}
+                  </a>
+                  <span class="type-badge synthesis">{typeLabel}</span>
+                  <span class="synthesis-meta">
+                    {syn.sentence_count} sentence{syn.sentence_count !== 1 ? "s" : ""}
+                    {date && <> &middot; {date}</>}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )
+      ) : (
+        nodes.length === 0 ? (
+          <p class="empty-state">No nodes in the graph yet.</p>
+        ) : (
+          <ul class="node-flat-list">
+            {nodes.map((node) => (
+              <li>
+                <a href={nodeHref(node)} class="node-flat-link" title={node.concept}>
+                  {node.concept}
+                </a>
+                <span class={`type-badge ${node.node_type}`}>{node.node_type}</span>
+                {tab === "facts" ? (
+                  <span class="node-edge-count" title="number of facts">{node.fact_count} facts</span>
+                ) : (
+                  <span class="node-edge-count" title="number of relations">{node.edge_count + node.child_count} rel</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )
       )}
-      <ul class="node-flat-list">
-        {nodes.map((node) => (
-          <li>
-            <a href={nodeHref(node)} class="node-flat-link" title={node.concept}>
-              {node.concept}
-            </a>
-            <span class={`type-badge ${node.node_type}`}>{node.node_type}</span>
-            <span class="node-edge-count" title="number of relations">{node.edge_count + node.child_count} rel</span>
-          </li>
-        ))}
-      </ul>
     </>
   )}
 </WikiLayout>

--- a/wiki-frontend/src/pages/nodes/[id].astro
+++ b/wiki-frontend/src/pages/nodes/[id].astro
@@ -245,13 +245,33 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                     )}
                   </div>
                 ) : (
-                  <p class="node-definition">
-                    {parseRichText(node.definition).map((s) =>
-                      s.kind === "text" ? s.text :
-                      s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                      <a href={s.href}>{s.text}</a>
+                  <div class="node-definition">
+                    {parseMarkdownBlocks(node.definition).map((block) =>
+                      block.kind === "heading" ? (
+                        block.level === 1 ? <h2>{block.segments.map((s) =>
+                          s.kind === "text" ? s.text :
+                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+                          <a href={s.href}>{s.text}</a>
+                        )}</h2> :
+                        block.level === 2 ? <h3>{block.segments.map((s) =>
+                          s.kind === "text" ? s.text :
+                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+                          <a href={s.href}>{s.text}</a>
+                        )}</h3> :
+                        <h4>{block.segments.map((s) =>
+                          s.kind === "text" ? s.text :
+                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+                          <a href={s.href}>{s.text}</a>
+                        )}</h4>
+                      ) : (
+                        <p>{block.segments.map((s) =>
+                          s.kind === "text" ? s.text :
+                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+                          <a href={s.href}>{s.text}</a>
+                        )}</p>
+                      )
                     )}
-                  </p>
+                  </div>
                 )}
               </>
             ) : dimensions.length > 0 ? (

--- a/wiki-frontend/src/pages/syntheses/[id].astro
+++ b/wiki-frontend/src/pages/syntheses/[id].astro
@@ -1,0 +1,384 @@
+---
+import WikiLayout from "../../layouts/WikiLayout.astro";
+import { getSynthesis, nodeHref } from "../../lib/api.js";
+import { parseMarkdownBlocks } from "../../lib/justification.js";
+import { formatSynthesisConcept, buildParagraphSentenceMap } from "../../lib/synthesis-utils.js";
+import type { SynthesisDocumentResponse } from "../../types/index.js";
+
+const { id } = Astro.params as { id: string };
+
+let synthesis: SynthesisDocumentResponse | null = null;
+let error: string | null = null;
+
+try {
+  synthesis = await getSynthesis(id);
+} catch (e) {
+  error = e instanceof Error ? e.message : String(e);
+}
+
+const { title, date } = synthesis
+  ? formatSynthesisConcept(synthesis.concept)
+  : { title: "Synthesis not found", date: null };
+
+import type { SynthesisSentenceResponse } from "../../types/index.js";
+
+const paragraphMap: Map<string, SynthesisSentenceResponse[]> = synthesis
+  ? buildParagraphSentenceMap(synthesis.definition ?? "", synthesis.sentences)
+  : new Map();
+
+const typeLabel = synthesis?.node_type === "supersynthesis" ? "Super-Synthesis" : "Synthesis";
+
+// Helper: strip markdown for plain-text key matching
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/^\d+\.\s+/, "")
+    .replace(/^[-*]\s+/, "")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1");
+}
+
+// Build block metadata for the template
+interface BlockMeta {
+  paraKey: string | null;
+  nodeCount: number;
+  factCount: number;
+  sentencePositions: number[];
+  nodeIds: string[];
+}
+
+const blocks = parseMarkdownBlocks(synthesis?.definition);
+const blockMetas: BlockMeta[] = blocks.map((block) => {
+  const plainText = stripMarkdown(
+    block.segments.map((s) => ("text" in s ? s.text : "")).join("")
+  );
+  const key = plainText.slice(0, 60).trim();
+  const sentences = paragraphMap.get(key);
+  if (!sentences || sentences.length === 0) {
+    return { paraKey: null, nodeCount: 0, factCount: 0, sentencePositions: [], nodeIds: [] };
+  }
+  const allNodeIds: string[] = [...new Set(sentences.flatMap((s) => s.node_ids))];
+  const totalFacts: number = sentences.reduce((sum, s) => sum + s.fact_count, 0);
+  const positions: number[] = sentences.filter((s) => s.fact_count > 0).map((s) => s.position);
+  return { paraKey: key, nodeCount: allNodeIds.length, factCount: totalFacts, sentencePositions: positions, nodeIds: allNodeIds };
+});
+---
+
+<WikiLayout title={title}>
+  {error && <div class="error-banner">{error}</div>}
+
+  {synthesis && (
+    <>
+      <div class="synthesis-header">
+        <div class="node-meta">
+          <span class="type-badge synthesis">{typeLabel}</span>
+          {date && <span class="synthesis-date">{date}</span>}
+        </div>
+        <h1 class="node-title">{title}</h1>
+        <p class="synthesis-stats">
+          {synthesis.sentences.length} sentence{synthesis.sentences.length !== 1 ? "s" : ""}
+          &middot; {synthesis.referenced_nodes.length} node{synthesis.referenced_nodes.length !== 1 ? "s" : ""} referenced
+        </p>
+      </div>
+
+      <div class="synthesis-layout">
+        <div class="synthesis-body" data-synthesis-id={synthesis.id}>
+          {blocks.map((block, i) => {
+            const meta = blockMetas[i];
+            const hasEvidence = meta.paraKey && (meta.nodeCount > 0 || meta.factCount > 0);
+            if (block.kind === "heading") {
+              const Tag = block.level === 1 ? "h2" : block.level === 2 ? "h3" : "h4";
+              return (
+                <Tag
+                  class={`synthesis-block ${hasEvidence ? "synthesis-block--clickable" : ""}`}
+                  data-para-key={meta.paraKey ?? undefined}
+                  data-sentence-positions={meta.sentencePositions.length > 0 ? JSON.stringify(meta.sentencePositions) : undefined}
+                  data-node-ids={meta.nodeIds.length > 0 ? JSON.stringify(meta.nodeIds) : undefined}
+                >
+                  {block.segments.map((s) =>
+                    s.kind === "text" ? s.text :
+                    s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+                    <a href={s.href}>{s.text}</a>
+                  )}
+                  {hasEvidence && (
+                    <span class="synthesis-para-badge">{meta.nodeCount}n {meta.factCount}f</span>
+                  )}
+                </Tag>
+              );
+            }
+            return (
+              <p
+                class={`synthesis-block ${hasEvidence ? "synthesis-block--clickable" : ""}`}
+                data-para-key={meta.paraKey ?? undefined}
+                data-sentence-positions={meta.sentencePositions.length > 0 ? JSON.stringify(meta.sentencePositions) : undefined}
+                data-node-ids={meta.nodeIds.length > 0 ? JSON.stringify(meta.nodeIds) : undefined}
+              >
+                {block.segments.map((s) =>
+                  s.kind === "text" ? s.text :
+                  s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+                  <a href={s.href}>{s.text}</a>
+                )}
+                {hasEvidence && (
+                  <span class="synthesis-para-badge">{meta.nodeCount}n {meta.factCount}f</span>
+                )}
+              </p>
+            );
+          })}
+        </div>
+
+        <aside class="synthesis-sidebar">
+          {/* Sub-syntheses for super-syntheses */}
+          {synthesis.sub_syntheses.length > 0 && (
+            <div class="sidebar-box">
+              <div class="sidebar-box-header">Sub-syntheses ({synthesis.sub_syntheses.length})</div>
+              <ul class="sidebar-box-list">
+                {synthesis.sub_syntheses.map((sub) => {
+                  const { title: subTitle } = formatSynthesisConcept(sub.concept);
+                  return (
+                    <li class="relation-row">
+                      <a href={`/syntheses/${sub.node_id}`} class="relation-row-main" title={subTitle}>{subTitle}</a>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {/* Referenced nodes */}
+          {synthesis.referenced_nodes.length > 0 && (
+            <div class="sidebar-box">
+              <div class="sidebar-box-header sidebar-box-toggle">
+                Referenced Nodes ({synthesis.referenced_nodes.length}) <span class="sidebar-toggle-icon">&#9662;</span>
+              </div>
+              {synthesis.referenced_nodes.length > 5 && (
+                <input type="search" class="sidebar-search" data-sidebar-search placeholder="Filter nodes..." autocomplete="off" />
+              )}
+              <ul class="sidebar-box-list">
+                {synthesis.referenced_nodes.map((n) => (
+                  <li class="relation-row" data-search-text={n.concept.toLowerCase()}>
+                    <a href={nodeHref({ id: n.node_id, node_type: n.node_type, concept: n.concept, key: "" })} class="relation-row-main" title={n.concept}>
+                      {n.concept}
+                    </a>
+                    <span class={`type-badge ${n.node_type}`}>{n.node_type}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </aside>
+      </div>
+
+      {/* Evidence dialog */}
+      <dialog id="evidence-dialog" class="evidence-dialog">
+        <div class="evidence-dialog-inner">
+          <p class="evidence-dialog-excerpt" id="evidence-excerpt"></p>
+
+          <div class="evidence-nodes" id="evidence-nodes-section" style="display:none">
+            <h3>Referenced Nodes</h3>
+            <div class="evidence-node-grid" id="evidence-node-grid"></div>
+          </div>
+
+          <div class="evidence-facts" id="evidence-facts-section" style="display:none">
+            <h3>Evidence</h3>
+            <div id="evidence-facts-list"></div>
+          </div>
+
+          <div class="evidence-dialog-footer">
+            <button class="relation-dialog-close" data-close>Close</button>
+          </div>
+        </div>
+      </dialog>
+
+      {/* Embed node map as JSON for client-side evidence dialog */}
+      <script is:inline define:vars={{ nodeMapJson: JSON.stringify(
+        Object.fromEntries(
+          (synthesis?.referenced_nodes ?? []).map((n) => [
+            n.node_id,
+            { concept: n.concept, node_type: n.node_type, href: nodeHref({ id: n.node_id, node_type: n.node_type, concept: n.concept, key: "" }) }
+          ])
+        )
+      ) }}>
+        window.__nodeMap = JSON.parse(nodeMapJson);
+      </script>
+
+      <script>
+        const nodeMap: Record<string, { concept: string; node_type: string; href: string }> = (window as any).__nodeMap ?? {};
+        const synthId = document.querySelector<HTMLElement>("[data-synthesis-id]")?.dataset.synthesisId ?? "";
+
+        const dialog = document.getElementById("evidence-dialog") as HTMLDialogElement;
+        const excerptEl = document.getElementById("evidence-excerpt")!;
+        const nodesSection = document.getElementById("evidence-nodes-section")!;
+        const nodeGrid = document.getElementById("evidence-node-grid")!;
+        const factsSection = document.getElementById("evidence-facts-section")!;
+        const factsList = document.getElementById("evidence-facts-list")!;
+
+        // Close handlers
+        dialog.addEventListener("click", (e) => {
+          if (e.target === dialog) dialog.close();
+        });
+        dialog.querySelector("[data-close]")?.addEventListener("click", () => dialog.close());
+
+        // Click handler for synthesis blocks
+        document.querySelectorAll<HTMLElement>(".synthesis-block--clickable").forEach((block) => {
+          block.addEventListener("click", async (e) => {
+            // Don't intercept link clicks
+            if ((e.target as HTMLElement).closest("a")) return;
+
+            const positions: number[] = JSON.parse(block.dataset.sentencePositions ?? "[]");
+            const nodeIds: string[] = JSON.parse(block.dataset.nodeIds ?? "[]");
+
+            // Set excerpt
+            const text = block.textContent?.trim() ?? "";
+            excerptEl.textContent = text.length > 400 ? text.slice(0, 400) + "..." : text;
+
+            // Show referenced nodes
+            nodeGrid.innerHTML = "";
+            if (nodeIds.length > 0) {
+              nodesSection.style.display = "";
+              for (const nid of nodeIds) {
+                const match = nodeMap[nid];
+                if (!match) continue;
+                const pill = document.createElement("a");
+                pill.href = match.href;
+                pill.className = `evidence-node-pill type-badge ${match.node_type}`;
+                pill.textContent = match.concept;
+                nodeGrid.appendChild(pill);
+              }
+              if (nodeGrid.children.length === 0) nodesSection.style.display = "none";
+            } else {
+              nodesSection.style.display = "none";
+            }
+
+            // Load facts
+            factsList.innerHTML = "";
+            if (positions.length > 0) {
+              factsSection.style.display = "";
+              factsList.innerHTML = '<p class="evidence-loading">Loading evidence...</p>';
+              dialog.showModal();
+
+              try {
+                const allFacts: Array<{
+                  fact_id: string;
+                  content: string;
+                  fact_type: string;
+                  embedding_distance: number;
+                  source_title: string;
+                  source_uri: string;
+                  author: string;
+                }> = [];
+                const seen = new Set<string>();
+
+                await Promise.all(
+                  positions.map(async (pos) => {
+                    const res = await fetch(`/api/sentence-facts?synthesisId=${synthId}&position=${pos}`);
+                    if (!res.ok) return;
+                    const facts = await res.json();
+                    for (const f of facts) {
+                      if (!seen.has(f.fact_id)) {
+                        seen.add(f.fact_id);
+                        allFacts.push(f);
+                      }
+                    }
+                  })
+                );
+
+                // Group by source
+                const groups = new Map<string, { title: string; uri: string; author: string; bestDistance: number; facts: typeof allFacts }>();
+                for (const f of allFacts) {
+                  const key = f.source_title || f.source_uri || "Unknown source";
+                  const group = groups.get(key) ?? { title: f.source_title, uri: f.source_uri, author: f.author, bestDistance: 0, facts: [] };
+                  group.facts.push(f);
+                  if (f.embedding_distance > group.bestDistance) group.bestDistance = f.embedding_distance;
+                  groups.set(key, group);
+                }
+
+                // Sort groups by best distance
+                const sorted = [...groups.entries()].sort((a, b) => b[1].bestDistance - a[1].bestDistance);
+
+                factsList.innerHTML = "";
+                if (sorted.length === 0) {
+                  factsList.innerHTML = '<p class="evidence-empty">No evidence found for this section.</p>';
+                } else {
+                  for (const [, group] of sorted) {
+                    const groupEl = document.createElement("details");
+                    groupEl.className = "evidence-source-group";
+                    groupEl.open = true;
+
+                    const summary = document.createElement("summary");
+                    summary.className = "evidence-source-header";
+                    const titleText = group.title || new URL(group.uri || "https://unknown").hostname;
+                    summary.innerHTML = `
+                      <span class="evidence-source-title">${escapeHtml(titleText)}</span>
+                      ${group.author ? `<span class="evidence-source-author">${escapeHtml(group.author)}</span>` : ""}
+                      <span class="evidence-source-count">${group.facts.length}</span>
+                    `;
+                    groupEl.appendChild(summary);
+
+                    for (const fact of group.facts.sort((a, b) => b.embedding_distance - a.embedding_distance)) {
+                      const card = document.createElement("div");
+                      card.className = "evidence-fact-card";
+                      const pct = Math.round(fact.embedding_distance * 100);
+                      card.innerHTML = `
+                        <p class="evidence-fact-content">${escapeHtml(fact.content)}</p>
+                        <div class="evidence-fact-meta">
+                          <span class="type-badge">${escapeHtml(fact.fact_type)}</span>
+                          <span class="evidence-fact-distance">${pct}%</span>
+                          <a href="/facts/${fact.fact_id}" class="evidence-fact-link">view fact</a>
+                        </div>
+                      `;
+                      groupEl.appendChild(card);
+                    }
+
+                    factsList.appendChild(groupEl);
+                  }
+                }
+              } catch {
+                factsList.innerHTML = '<p class="evidence-error">Failed to load evidence.</p>';
+              }
+              return;
+            } else {
+              factsSection.style.display = "none";
+            }
+
+            dialog.showModal();
+          });
+        });
+
+        // Sidebar collapse toggle
+        document.querySelectorAll<HTMLElement>(".sidebar-box-toggle").forEach((header) => {
+          header.style.cursor = "pointer";
+          header.addEventListener("click", () => {
+            const box = header.closest(".sidebar-box");
+            if (box) box.classList.toggle("sidebar-box--collapsed");
+          });
+        });
+
+        // Sidebar search
+        document.querySelectorAll<HTMLInputElement>("[data-sidebar-search]").forEach((input) => {
+          const box = input.closest(".sidebar-box");
+          if (!box) return;
+          const list = box.querySelector(".sidebar-box-list");
+          if (!list) return;
+          input.addEventListener("input", () => {
+            const q = input.value.toLowerCase().trim();
+            list.querySelectorAll<HTMLLIElement>("[data-search-text]").forEach((li) => {
+              const text = li.dataset.searchText ?? "";
+              li.style.display = !q || text.includes(q) ? "" : "none";
+            });
+          });
+        });
+
+        function escapeHtml(str: string): string {
+          const div = document.createElement("div");
+          div.textContent = str;
+          return div.innerHTML;
+        }
+      </script>
+    </>
+  )}
+
+  {!error && !synthesis && (
+    <p class="empty-state">Synthesis not found.</p>
+  )}
+</WikiLayout>

--- a/wiki-frontend/src/styles/global.css
+++ b/wiki-frontend/src/styles/global.css
@@ -2223,7 +2223,323 @@ a.fact-group-title:hover {
   .index-search-form { max-width: 100%; }
 }
 
+/* ── Synthesis Type Badge ────────────────────────────────────── */
+
+.type-badge.synthesis {
+  background: var(--ocean-dim);
+  color: var(--ocean-dark);
+  border: 1px solid rgba(30, 99, 168, 0.15);
+}
+
+[data-theme="dark"] .type-badge.synthesis { color: #7dc4f0; border-color: rgba(125, 196, 240, 0.2); }
+
+/* ── Tab Bar ────────────────────────────────────────────────── */
+
+.tab-bar {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--color-border);
+  margin-bottom: 1.5rem;
+}
+
+.tab {
+  padding: 0.6rem 1.2rem;
+  font-family: var(--font-sans);
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color var(--t-fast), border-color var(--t-fast);
+}
+
+.tab:hover {
+  color: var(--color-text);
+}
+
+.tab--active {
+  color: var(--ocean);
+  border-bottom-color: var(--ocean);
+}
+
+/* ── Synthesis List (Investigations Tab) ────────────────────── */
+
+.synthesis-list li {
+  gap: 0.5rem;
+}
+
+.synthesis-meta {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+/* ── Synthesis Detail Page ──────────────────────────────────── */
+
+.synthesis-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.synthesis-date {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+.synthesis-stats {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  margin: 0.5rem 0 0;
+}
+
+.synthesis-layout {
+  display: grid;
+  grid-template-columns: 1fr 288px;
+  gap: 2rem;
+  align-items: start;
+}
+
+.synthesis-body {
+  max-width: 720px;
+}
+
+.synthesis-body h2,
+.synthesis-body h3,
+.synthesis-body h4 {
+  margin: 1.5rem 0 0.5rem;
+}
+
+.synthesis-body h2 { font-size: 1.25rem; }
+.synthesis-body h3 { font-size: 1.1rem; }
+.synthesis-body h4 { font-size: 1rem; }
+
+.synthesis-body p {
+  line-height: 1.75;
+  margin: 0 0 1rem;
+}
+
+.synthesis-block {
+  padding: 0.3rem 0.5rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  border-left: 2px solid transparent;
+  border-radius: var(--radius-sm);
+  transition: background var(--t-fast), border-color var(--t-fast);
+}
+
+.synthesis-block--clickable {
+  cursor: pointer;
+}
+
+.synthesis-block--clickable:hover {
+  background: var(--color-surface-2);
+  border-left-color: var(--color-border);
+}
+
+.synthesis-para-badge {
+  font-size: 0.65rem;
+  font-family: var(--font-mono);
+  color: var(--color-text-subtle);
+  margin-left: 0.5rem;
+  opacity: 0;
+  transition: opacity var(--t-fast);
+}
+
+.synthesis-block--clickable:hover .synthesis-para-badge {
+  opacity: 1;
+}
+
+/* ── Evidence Dialog ────────────────────────────────────────── */
+
+.evidence-dialog {
+  max-width: 680px;
+  width: 90vw;
+  max-height: 80vh;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0;
+  background: var(--color-surface);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  overflow-y: auto;
+}
+
+.evidence-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.evidence-dialog-inner {
+  padding: 1.5rem;
+}
+
+.evidence-dialog-excerpt {
+  border-left: 2px solid var(--ocean);
+  padding-left: 1rem;
+  font-style: italic;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0 0 1.5rem;
+}
+
+.evidence-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border-light);
+}
+
+/* ── Evidence Nodes ─────────────────────────────────────────── */
+
+.evidence-nodes h3,
+.evidence-facts h3 {
+  font-size: 0.88rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.evidence-node-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1.5rem;
+}
+
+.evidence-node-pill {
+  text-decoration: none;
+  font-size: 0.78rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--radius-sm);
+}
+
+.evidence-node-pill:hover {
+  opacity: 0.8;
+}
+
+/* ── Evidence Facts ─────────────────────────────────────────── */
+
+.evidence-source-group {
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+}
+
+.evidence-source-group[open] {
+  border-color: var(--color-border);
+}
+
+.evidence-source-header {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.82rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--color-surface-2);
+  border-radius: var(--radius-sm);
+}
+
+.evidence-source-group[open] .evidence-source-header {
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+}
+
+.evidence-source-title {
+  font-weight: 500;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.evidence-source-author {
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.evidence-source-count {
+  background: var(--ocean-dim);
+  color: var(--ocean-dark);
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm);
+}
+
+.evidence-fact-card {
+  padding: 0.6rem 0.75rem;
+  border-top: 1px solid var(--color-border-light);
+}
+
+.evidence-fact-content {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin: 0 0 0.4rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.evidence-fact-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.evidence-fact-distance {
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.evidence-fact-link {
+  color: var(--ocean);
+  text-decoration: none;
+  font-size: 0.75rem;
+}
+
+.evidence-fact-link:hover {
+  text-decoration: underline;
+}
+
+.evidence-loading,
+.evidence-empty,
+.evidence-error {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  padding: 0.5rem 0;
+}
+
+.evidence-error {
+  color: var(--color-error, #c53030);
+}
+
+/* ── Synthesis Sidebar ──────────────────────────────────────── */
+
+.synthesis-sidebar .sidebar-box {
+  position: sticky;
+  top: calc(var(--header-h) + 1rem);
+}
+
+@media (max-width: 820px) {
+  .synthesis-layout {
+    grid-template-columns: 1fr;
+  }
+  .synthesis-sidebar {
+    order: -1;
+  }
+}
+
 @media (max-width: 480px) {
   .header-search { display: none; }
   .node-grid { grid-template-columns: 1fr; }
+  .tab { padding: 0.5rem 0.8rem; font-size: 0.82rem; }
 }

--- a/wiki-frontend/src/types/index.ts
+++ b/wiki-frontend/src/types/index.ts
@@ -10,6 +10,7 @@ export interface NodeResponse {
   definition_source: string | null;
   edge_count: number;
   child_count: number;
+  fact_count: number;
   richness: number;
   metadata?: Record<string, unknown> | null;
 }
@@ -67,4 +68,49 @@ export interface FactNodeInfo {
 export interface SubgraphResponse {
   nodes: NodeResponse[];
   edges: EdgeResponse[];
+}
+
+export interface SynthesisListItem {
+  id: string;
+  concept: string;
+  node_type: string;
+  visibility: string;
+  sentence_count: number;
+  sub_synthesis_ids: string[];
+  created_at: string | null;
+}
+
+export interface SynthesisSentenceResponse {
+  position: number;
+  text: string;
+  fact_count: number;
+  node_ids: string[];
+}
+
+export interface SynthesisNodeResponse {
+  node_id: string;
+  concept: string;
+  node_type: string;
+}
+
+export interface SynthesisDocumentResponse {
+  id: string;
+  concept: string;
+  node_type: string;
+  visibility: string;
+  definition: string | null;
+  sentences: SynthesisSentenceResponse[];
+  referenced_nodes: SynthesisNodeResponse[];
+  sub_syntheses: SynthesisNodeResponse[];
+  created_at: string | null;
+}
+
+export interface SentenceFactResponse {
+  fact_id: string;
+  content: string;
+  fact_type: string;
+  embedding_distance: number;
+  source_title: string;
+  source_uri: string;
+  author: string;
 }


### PR DESCRIPTION
## Summary

- **Homepage tabs**: Replace single node list with 3 tabbed lists using `?tab=` query params (SSR, bookmarkable):
  - **Most Connected** (default) — nodes sorted by edge count
  - **Most Facts** — nodes sorted by fact count (new backend sort option)
  - **Investigations** — public synthesis documents
- **Synthesis detail page** (`/syntheses/[id]`): Renders synthesis markdown with interactive paragraph-level fact linking via evidence dialog, referenced nodes sidebar, sub-syntheses support for super-syntheses
- **Definition rendering bug fix**: Non-perspective node definitions now use `parseMarkdownBlocks()` instead of `parseRichText()`, fixing markdown headings and paragraphs being collapsed into a single text blob
- **Backend**: Added `fact_count` sort option to `NodeRepository.list_paginated()` using `node_facts` junction table

## Test plan

- [x] Backend tests pass (`uv run --project libs/kt-db pytest libs/kt-db/tests/ -x -v`)
- [x] API tests pass (`uv run --project services/api pytest services/api/tests/ -x -v`)
- [x] Wiki frontend builds successfully (`pnpm build`)
- [x] Astro type check passes (`astro check` — 0 errors)
- [ ] Manual: verify homepage tabs switch correctly
- [ ] Manual: verify synthesis detail page renders markdown with clickable evidence sections
- [ ] Manual: verify node definition pages render markdown with proper headings/paragraphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)