### PR TITLE
feat(worker-synthesis): store synthesis errors and add regeneration

### DIFF
--- a/frontend/src/app/investigate/[id]/page.tsx
+++ b/frontend/src/app/investigate/[id]/page.tsx
@@ -5,8 +5,9 @@ import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Loader2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { getSynthesis, deleteSynthesis } from "@/lib/api";
+import { getSynthesis, deleteSynthesis, regenerateSynthesis } from "@/lib/api";
 import { SynthesisDocument } from "@/components/synthesis/SynthesisDocument";
+import { SynthesisProgress } from "@/components/synthesis/SynthesisProgress";
 import { ExportButtons } from "@/components/synthesis/ExportPDF";
 import type { SynthesisDocumentResponse } from "@/types";
 
@@ -20,6 +21,8 @@ export default function SynthesisDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [regenerating, setRegenerating] = useState(false);
+  const [workflowRunId, setWorkflowRunId] = useState<string | null>(null);
 
   const fetchDocument = useCallback(async () => {
     if (!id) return;
@@ -39,6 +42,12 @@ export default function SynthesisDetailPage() {
     fetchDocument();
   }, [fetchDocument]);
 
+  const handleRegenerateComplete = useCallback(async () => {
+    setWorkflowRunId(null);
+    setRegenerating(false);
+    await fetchDocument();
+  }, [fetchDocument]);
+
   const handleDelete = async () => {
     if (!confirm("Delete this synthesis? This cannot be undone.")) return;
     setDeleting(true);
@@ -48,6 +57,17 @@ export default function SynthesisDetailPage() {
     } catch (err) {
       console.error("Failed to delete synthesis:", err);
       setDeleting(false);
+    }
+  };
+
+  const handleRegenerate = async () => {
+    setRegenerating(true);
+    try {
+      const result = await regenerateSynthesis(id);
+      setWorkflowRunId(result.workflow_run_id);
+    } catch (err) {
+      console.error("Failed to regenerate synthesis:", err);
+      setRegenerating(false);
     }
   };
 
@@ -102,7 +122,17 @@ export default function SynthesisDetailPage() {
         </div>
       </div>
 
-      <SynthesisDocument document={document} />
+      {workflowRunId && (
+        <div className="max-w-4xl mx-auto mb-6">
+          <SynthesisProgress workflowRunId={workflowRunId} onComplete={handleRegenerateComplete} />
+        </div>
+      )}
+
+      <SynthesisDocument
+        document={document}
+        onRegenerate={document.status === "error" ? handleRegenerate : undefined}
+        isRegenerating={regenerating}
+      />
     </div>
   );
 }

--- a/frontend/src/app/investigate/page.tsx
+++ b/frontend/src/app/investigate/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Plus, FileText, Loader2, Trash2 } from "lucide-react";
+import { Plus, FileText, Loader2, Trash2, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { listSyntheses, deleteSynthesis } from "@/lib/api";
@@ -202,6 +202,15 @@ function SynthesisCard({
                 {item.node_type === "supersynthesis"
                   ? "Super-Synthesis"
                   : "Synthesis"}
+              </Badge>
+            )}
+            {item.status === "error" && (
+              <Badge
+                variant="destructive"
+                className="text-[0.6rem] uppercase tracking-wider px-2 py-0 gap-1"
+              >
+                <AlertCircle className="size-2.5" />
+                Failed
               </Badge>
             )}
             <Badge

--- a/frontend/src/components/synthesis/SynthesisDocument.tsx
+++ b/frontend/src/components/synthesis/SynthesisDocument.tsx
@@ -31,6 +31,8 @@ import { SubSynthesisList } from "./SubSynthesisList";
 
 interface SynthesisDocumentProps {
   document: SynthesisDocumentResponse;
+  onRegenerate?: () => void;
+  isRegenerating?: boolean;
 }
 
 interface FactGroup {
@@ -145,7 +147,7 @@ function groupFactsBySource(facts: SentenceFactLink[]): FactGroup[] {
 
 // ── Main Component ───────────────────────────────────────────────
 
-export function SynthesisDocument({ document }: SynthesisDocumentProps) {
+export function SynthesisDocument({ document, onRegenerate, isRegenerating }: SynthesisDocumentProps) {
   const [selectedParaKey, setSelectedParaKey] = useState<string | null>(null);
   const [selectedParaText, setSelectedParaText] = useState<string>("");
   const [selectedNodes, setSelectedNodes] = useState<string[]>([]);
@@ -501,7 +503,38 @@ export function SynthesisDocument({ document }: SynthesisDocumentProps) {
 
         {/* Body */}
         <div className="mb-10">
-          {hasDefinition ? (
+          {document.status === "error" ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 size-5 rounded-full bg-destructive/20 flex items-center justify-center flex-shrink-0">
+                  <span className="text-destructive text-xs font-bold">!</span>
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-destructive mb-1">Synthesis Failed</p>
+                  <p className="text-sm text-muted-foreground mb-4">
+                    {document.error_message || "The synthesis agent was unable to produce a document."}
+                  </p>
+                  {onRegenerate && (
+                    <button
+                      type="button"
+                      onClick={onRegenerate}
+                      disabled={isRegenerating}
+                      className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                    >
+                      {isRegenerating ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" />
+                          Regenerating...
+                        </>
+                      ) : (
+                        "Regenerate"
+                      )}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : hasDefinition ? (
             <Markdown components={markdownComponents}>
               {document.definition!}
             </Markdown>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1259,3 +1259,10 @@ export async function updateSynthesisVisibility(id: string, visibility: string) 
     { method: "PATCH", body: JSON.stringify({ visibility }) }
   );
 }
+
+export async function regenerateSynthesis(id: string) {
+  return request<{ status: string; workflow_run_id: string; synthesis_id: string }>(
+    `/syntheses/${id}/regenerate`,
+    { method: "POST" }
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1297,6 +1297,8 @@ export interface SynthesisDocumentResponse {
   referenced_nodes: SynthesisNodeResponse[];
   sub_syntheses: SynthesisNodeResponse[];
   created_at: string | null;
+  status: "completed" | "error";
+  error_message: string | null;
 }
 
 export interface SynthesisListItem {
@@ -1307,6 +1309,7 @@ export interface SynthesisListItem {
   sentence_count: number;
   sub_synthesis_ids: string[];
   created_at: string | null;
+  status: "completed" | "error";
 }
 
 export interface PaginatedSynthesesResponse {

--- a/libs/kt-hatchet/src/kt_hatchet/models.py
+++ b/libs/kt-hatchet/src/kt_hatchet/models.py
@@ -739,3 +739,15 @@ class SuperSynthesizerOutput(BaseModel):
     sub_synthesis_node_ids: list[str] = Field(default_factory=list)
     total_sentences: int = 0
     total_facts_linked: int = 0
+
+
+class RegenerateSynthesisInput(BaseModel):
+    """Input for regenerating a failed synthesis."""
+
+    node_id: str
+
+
+class RecombineSuperSynthesisInput(BaseModel):
+    """Input for re-combining a super-synthesis from its sub-syntheses."""
+
+    node_id: str

--- a/services/api/src/kt_api/syntheses.py
+++ b/services/api/src/kt_api/syntheses.py
@@ -72,6 +72,8 @@ class SynthesisDocumentResponse(BaseModel):
     referenced_nodes: list[SynthesisNodeResponse] = Field(default_factory=list)
     sub_syntheses: list[SynthesisNodeResponse] = Field(default_factory=list)
     created_at: str | None = None
+    status: str = "completed"
+    error_message: str | None = None
 
 
 class SynthesisListItem(BaseModel):
@@ -82,6 +84,7 @@ class SynthesisListItem(BaseModel):
     sentence_count: int = 0
     sub_synthesis_ids: list[str] = Field(default_factory=list)
     created_at: str | None = None
+    status: str = "completed"
 
 
 class PaginatedSynthesesResponse(BaseModel):
@@ -121,6 +124,15 @@ def _get_sentence_count(node: Node) -> int:
     doc = _get_synthesis_doc(node)
     stats = doc.get("stats", {})
     return stats.get("sentences_count", 0)
+
+
+def _get_synthesis_status(node: Node) -> tuple[str, str | None]:
+    """Return (status, error_message) for a synthesis node."""
+    meta = node.metadata_ or {}
+    error = meta.get("synthesis_error")
+    if error:
+        return "error", error.get("message")
+    return "completed", None
 
 
 # ── Endpoints ──────────────────────────────────────────────────────
@@ -201,18 +213,21 @@ async def list_syntheses(
     q = select(Node).where(base_filter).order_by(Node.created_at.desc()).offset(offset).limit(limit)
     nodes = (await session.execute(q)).scalars().all()
 
-    items = [
-        SynthesisListItem(
-            id=str(n.id),
-            concept=n.concept,
-            node_type=n.node_type,
-            visibility=n.visibility,
-            sentence_count=_get_sentence_count(n),
-            sub_synthesis_ids=_get_synthesis_doc(n).get("sub_synthesis_ids", []),
-            created_at=n.created_at.isoformat() if n.created_at else None,
+    items = []
+    for n in nodes:
+        status, _ = _get_synthesis_status(n)
+        items.append(
+            SynthesisListItem(
+                id=str(n.id),
+                concept=n.concept,
+                node_type=n.node_type,
+                visibility=n.visibility,
+                sentence_count=_get_sentence_count(n),
+                sub_synthesis_ids=_get_synthesis_doc(n).get("sub_synthesis_ids", []),
+                created_at=n.created_at.isoformat() if n.created_at else None,
+                status=status,
+            )
         )
-        for n in nodes
-    ]
 
     return PaginatedSynthesesResponse(items=items, total=total, offset=offset, limit=limit)
 
@@ -271,6 +286,8 @@ async def get_synthesis(
             except Exception:
                 pass
 
+    status, error_message = _get_synthesis_status(node)
+
     return SynthesisDocumentResponse(
         id=str(node.id),
         concept=node.concept,
@@ -281,6 +298,8 @@ async def get_synthesis(
         referenced_nodes=referenced_nodes,
         sub_syntheses=sub_syntheses,
         created_at=node.created_at.isoformat() if node.created_at else None,
+        status=status,
+        error_message=error_message,
     )
 
 
@@ -416,3 +435,40 @@ async def update_synthesis(
     await session.commit()
 
     return {"id": synthesis_id, "visibility": node.visibility}
+
+
+@router.post("/syntheses/{synthesis_id}/regenerate")
+async def regenerate_synthesis(
+    synthesis_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> dict[str, Any]:
+    """Regenerate a failed synthesis by re-running the synthesizer agent.
+
+    For sub-syntheses with a parent super-synthesis, regeneration will
+    also trigger a re-combine of the parent after completion.
+    """
+    try:
+        nid = uuid.UUID(synthesis_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid synthesis ID")
+
+    node = (await session.execute(select(Node).where(Node.id == nid))).scalar_one_or_none()
+    if not node or node.node_type not in ("synthesis", "supersynthesis"):
+        raise HTTPException(status_code=404, detail="Synthesis not found")
+
+    meta = node.metadata_ or {}
+    if "synthesis_error" not in meta:
+        raise HTTPException(status_code=400, detail="Synthesis is not in error state")
+    if "synthesis_input" not in meta:
+        raise HTTPException(status_code=400, detail="No stored input available for regeneration")
+
+    from kt_hatchet.client import dispatch_workflow
+
+    workflow_name = "recombine_supersynthesis_wf" if node.node_type == "supersynthesis" else "regenerate_synthesis_wf"
+
+    try:
+        run_id = await dispatch_workflow(workflow_name, {"node_id": synthesis_id})
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc))
+
+    return {"status": "pending", "workflow_run_id": run_id, "synthesis_id": synthesis_id}

--- a/services/worker-all/src/kt_worker_all/__main__.py
+++ b/services/worker-all/src/kt_worker_all/__main__.py
@@ -77,6 +77,10 @@ def main() -> None:
     )
     from kt_worker_search.workflows.seed_dedup import seed_dedup_task
     from kt_worker_sync.workflows.sync import sync_wf
+    from kt_worker_synthesis.workflows.regenerate import (
+        recombine_supersynthesis_wf,
+        regenerate_synthesis_wf,
+    )
     from kt_worker_synthesis.workflows.super_synthesizer import super_synthesizer_wf
     from kt_worker_synthesis.workflows.synthesizer import synthesizer_wf
 
@@ -114,6 +118,8 @@ def main() -> None:
             sync_wf,
             synthesizer_wf,
             super_synthesizer_wf,
+            regenerate_synthesis_wf,
+            recombine_supersynthesis_wf,
         ],
         lifespan=worker_lifespan,
     )

--- a/services/worker-synthesis/src/kt_worker_synthesis/workflows/_helpers.py
+++ b/services/worker-synthesis/src/kt_worker_synthesis/workflows/_helpers.py
@@ -1,0 +1,280 @@
+"""Shared helpers for synthesis workflows.
+
+Extracted from synthesizer.py and super_synthesizer.py so that the
+regeneration workflows can reuse the same agent-running logic.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass, field
+from typing import Any
+
+from kt_hatchet.models import SynthesizerInput
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SynthesisResult:
+    """Result of running the synthesizer agent."""
+
+    synthesis_text: str = ""
+    nodes_visited: list[str] = field(default_factory=list)
+
+
+async def run_synthesis_agent(
+    input: SynthesizerInput,
+    model_gateway: Any,
+    graph_engine: Any,
+    provider_registry: Any,
+    embedding_service: Any,
+    session: Any,
+    session_factory: Any,
+    write_session_factory: Any | None,
+    qdrant_client: Any | None,
+    emit_event: Callable[..., Coroutine[Any, Any, None]],
+) -> SynthesisResult:
+    """Run the synthesizer agent and return the result.
+
+    This is the core agent logic extracted from the synthesizer workflow
+    so it can be reused by the regeneration workflow.
+    """
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    from kt_agents_core.state import AgentContext
+    from kt_worker_synthesis.agents.synthesizer_agent import SynthesizerAgent
+    from kt_worker_synthesis.agents.synthesizer_state import SynthesizerState
+    from kt_worker_synthesis.prompts.synthesizer import build_synthesizer_system_message
+
+    agent_ctx = AgentContext(
+        graph_engine=graph_engine,
+        provider_registry=provider_registry,
+        model_gateway=model_gateway,
+        embedding_service=embedding_service,
+        session=session,
+        session_factory=session_factory,
+        emit_event=emit_event,
+        write_session_factory=write_session_factory,
+        qdrant_client=qdrant_client,
+    )
+
+    system_content = build_synthesizer_system_message(
+        topic=input.topic,
+        starting_node_ids=input.starting_node_ids,
+        budget=input.exploration_budget,
+    )
+
+    initial_state = SynthesizerState(
+        topic=input.topic,
+        starting_node_ids=input.starting_node_ids,
+        exploration_budget=input.exploration_budget,
+        messages=[
+            SystemMessage(content=system_content),
+            HumanMessage(
+                content=(
+                    "Investigate the topic using the tools available. When done, "
+                    "call finish_synthesis(text) with your complete markdown document. "
+                    "The text argument must contain the COMPLETE document — anything "
+                    "written outside finish_synthesis() is discarded."
+                )
+            ),
+        ],
+    )
+
+    await emit_event("synthesis_agent_started", topic=input.topic)
+
+    agent = SynthesizerAgent(agent_ctx)
+    graph, _ = agent.build_graph()
+    compiled = graph.compile()
+
+    recursion_limit = max(input.exploration_budget * 30, 500)
+    final = await compiled.ainvoke(initial_state, config={"recursion_limit": recursion_limit})
+
+    if isinstance(final, dict):
+        synthesis_text = final.get("synthesis_text", "")
+        nodes_visited = final.get("nodes_visited", [])
+    else:
+        synthesis_text = final.synthesis_text
+        nodes_visited = final.nodes_visited
+
+    return SynthesisResult(synthesis_text=synthesis_text, nodes_visited=nodes_visited)
+
+
+async def process_and_store_synthesis(
+    *,
+    synthesis_text: str,
+    synthesis_node_id: uuid.UUID,
+    nodes_visited: list[str],
+    graph_engine: Any,
+    embedding_service: Any,
+    qdrant_client: Any | None,
+    write_session: Any | None,
+    synthesis_input_data: dict[str, Any],
+    parent_supersynthesis_id: str | None = None,
+) -> dict[str, Any]:
+    """Process synthesis text and store the document in node metadata.
+
+    Sets the node definition, runs the document processing pipeline,
+    and stores the result in the node's metadata. Returns the document dict.
+    """
+    from sqlalchemy import select as sa_select
+    from sqlalchemy import update
+
+    from kt_db.write_models import WriteNode
+    from kt_worker_synthesis.pipelines.document_processing import process_synthesis_document
+
+    await graph_engine.set_node_definition(synthesis_node_id, synthesis_text)
+
+    # Build node name/alias lookup for text matching
+    node_names: dict[str, list[str]] = {}
+    for nid in nodes_visited:
+        try:
+            n = await graph_engine.get_node(uuid.UUID(nid))
+            if n:
+                node_names[nid] = [n.concept]
+        except Exception:
+            pass
+
+    doc = await process_synthesis_document(
+        synthesis_text=synthesis_text,
+        embedding_service=embedding_service,
+        qdrant_client=qdrant_client,
+        node_names_and_aliases=node_names,
+    )
+
+    if write_session:
+        row = (
+            await write_session.execute(sa_select(WriteNode.metadata_).where(WriteNode.node_uuid == synthesis_node_id))
+        ).scalar_one_or_none()
+        existing_meta = row if isinstance(row, dict) else {}
+
+        existing_meta["synthesis_document"] = doc
+        existing_meta["synthesis_input"] = synthesis_input_data
+        # Clear any previous error
+        existing_meta.pop("synthesis_error", None)
+        if parent_supersynthesis_id:
+            existing_meta["parent_supersynthesis_id"] = parent_supersynthesis_id
+
+        await write_session.execute(
+            update(WriteNode).where(WriteNode.node_uuid == synthesis_node_id).values(metadata_=existing_meta)
+        )
+        await write_session.commit()
+
+    return doc
+
+
+async def store_synthesis_error(
+    *,
+    synthesis_node_id: uuid.UUID,
+    write_session: Any,
+    synthesis_input_data: dict[str, Any],
+    error_message: str = "Synthesis agent ended without producing text",
+    parent_supersynthesis_id: str | None = None,
+    visibility: str = "public",
+    creator_id: str | None = None,
+) -> None:
+    """Store error metadata on a failed synthesis node.
+
+    Sets no definition, stores error info and the original input for
+    regeneration in the node's metadata.
+    """
+    from datetime import UTC, datetime
+
+    from sqlalchemy import select as sa_select
+    from sqlalchemy import update
+
+    from kt_db.write_models import WriteNode
+
+    row = (
+        await write_session.execute(sa_select(WriteNode.metadata_).where(WriteNode.node_uuid == synthesis_node_id))
+    ).scalar_one_or_none()
+    existing_meta = row if isinstance(row, dict) else {}
+
+    existing_meta["synthesis_error"] = {
+        "message": error_message,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    existing_meta["synthesis_input"] = synthesis_input_data
+    # Remove stale document if any
+    existing_meta.pop("synthesis_document", None)
+    if parent_supersynthesis_id:
+        existing_meta["parent_supersynthesis_id"] = parent_supersynthesis_id
+
+    await write_session.execute(
+        update(WriteNode)
+        .where(WriteNode.node_uuid == synthesis_node_id)
+        .values(
+            metadata_=existing_meta,
+            visibility=visibility,
+            creator_id=creator_id,
+        )
+    )
+    await write_session.commit()
+
+
+async def run_super_synthesis_combine(
+    *,
+    topic: str,
+    synthesis_node_ids: list[str],
+    graph_engine: Any,
+    model_gateway: Any,
+    embedding_service: Any,
+    session: Any,
+    session_factory: Any,
+    write_session_factory: Any | None,
+    qdrant_client: Any | None,
+    provider_registry: Any,
+) -> str:
+    """Run the SuperSynthesizerAgent to combine sub-syntheses.
+
+    Returns the super-synthesis text (may be empty on failure).
+    """
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    from kt_agents_core.state import AgentContext
+    from kt_worker_synthesis.agents.super_synthesizer_agent import SuperSynthesizerAgent
+    from kt_worker_synthesis.agents.super_synthesizer_state import SuperSynthesizerState
+    from kt_worker_synthesis.prompts.super_synthesizer import build_super_synthesizer_system_message
+
+    agent_ctx = AgentContext(
+        graph_engine=graph_engine,
+        provider_registry=provider_registry,
+        model_gateway=model_gateway,
+        embedding_service=embedding_service,
+        session=session,
+        session_factory=session_factory,
+        write_session_factory=write_session_factory,
+        qdrant_client=qdrant_client,
+    )
+
+    system_content = build_super_synthesizer_system_message(
+        topic=topic,
+        synthesis_node_ids=synthesis_node_ids,
+    )
+
+    initial_state = SuperSynthesizerState(
+        synthesis_node_ids=synthesis_node_ids,
+        messages=[
+            SystemMessage(content=system_content),
+            HumanMessage(
+                content=(
+                    "Read all sub-syntheses, then produce a comprehensive super-synthesis "
+                    "using finish_super_synthesis(text)."
+                )
+            ),
+        ],
+    )
+
+    agent = SuperSynthesizerAgent(agent_ctx)
+    graph, _ = agent.build_graph()
+    compiled = graph.compile()
+
+    recursion_limit = max(len(synthesis_node_ids) * 30, 500)
+    final = await compiled.ainvoke(initial_state, config={"recursion_limit": recursion_limit})
+
+    if isinstance(final, dict):
+        return final.get("super_synthesis_text", "")
+    return final.super_synthesis_text

--- a/services/worker-synthesis/src/kt_worker_synthesis/workflows/regenerate.py
+++ b/services/worker-synthesis/src/kt_worker_synthesis/workflows/regenerate.py
@@ -1,0 +1,315 @@
+"""Hatchet workflows for regenerating failed syntheses.
+
+regenerate_synthesis_wf — Re-runs the synthesizer agent on an existing
+    failed synthesis node, updating it in-place.
+
+recombine_supersynthesis_wf — Re-runs only the combine step of the
+    super-synthesizer on an existing super-synthesis node.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import timedelta
+from typing import Any, cast
+
+from hatchet_sdk import Context
+
+from kt_hatchet.client import get_hatchet
+from kt_hatchet.lifespan import WorkerState
+from kt_hatchet.models import (
+    RecombineSuperSynthesisInput,
+    RegenerateSynthesisInput,
+    SuperSynthesizerOutput,
+    SynthesizerInput,
+    SynthesizerOutput,
+)
+
+logger = logging.getLogger(__name__)
+
+hatchet = get_hatchet()
+
+# ── Regenerate a single synthesis ──────────────────────────────────
+
+regenerate_synthesis_wf = hatchet.workflow(
+    name="regenerate_synthesis_wf",
+    input_validator=RegenerateSynthesisInput,
+)
+
+
+@regenerate_synthesis_wf.task(execution_timeout=timedelta(minutes=30))
+async def run_regenerate_synthesis(input: RegenerateSynthesisInput, ctx: Context) -> dict[str, Any]:
+    """Re-run the synthesizer agent on a failed synthesis node."""
+    worker_state = cast(WorkerState, ctx.lifespan)
+
+    from kt_graph.engine import GraphEngine
+    from kt_worker_synthesis.workflows._helpers import (
+        process_and_store_synthesis,
+        run_synthesis_agent,
+        store_synthesis_error,
+    )
+
+    node_id = uuid.UUID(input.node_id)
+
+    async with worker_state.session_factory() as session:
+        write_session = None
+        if worker_state.write_session_factory is not None:
+            write_session = worker_state.write_session_factory()
+
+        try:
+            graph_engine = GraphEngine(
+                session,
+                worker_state.embedding_service,
+                write_session=write_session,
+                qdrant_client=worker_state.qdrant_client,
+            )
+
+            # Read stored synthesis input from metadata
+            node = await graph_engine.get_node(node_id)
+            if not node:
+                logger.error("Node %s not found for regeneration", input.node_id)
+                return SynthesizerOutput(synthesis_node_id=input.node_id).model_dump()
+
+            meta = node.metadata_ or {}
+            synthesis_input_data = meta.get("synthesis_input")
+            if not synthesis_input_data:
+                logger.error("No synthesis_input in metadata for node %s", input.node_id)
+                return SynthesizerOutput(synthesis_node_id=input.node_id).model_dump()
+
+            synth_input = SynthesizerInput(**synthesis_input_data)
+            parent_supersynthesis_id = meta.get("parent_supersynthesis_id")
+
+            async def emit_event(event_type: str, **data: Any) -> None:
+                try:
+                    await ctx.aio_put_stream(json.dumps({"type": event_type, **data}))
+                except Exception:
+                    pass
+
+            await emit_event("synthesis_regenerate_started", node_id=input.node_id)
+
+            result = await run_synthesis_agent(
+                input=synth_input,
+                model_gateway=worker_state.model_gateway,
+                graph_engine=graph_engine,
+                provider_registry=worker_state.provider_registry,
+                embedding_service=worker_state.embedding_service,
+                session=session,
+                session_factory=worker_state.session_factory,
+                write_session_factory=worker_state.write_session_factory,
+                qdrant_client=worker_state.qdrant_client,
+                emit_event=emit_event,
+            )
+
+            if not result.synthesis_text:
+                logger.warning("Regeneration failed — agent still produced no text for %s", input.node_id)
+
+                if write_session:
+                    await store_synthesis_error(
+                        synthesis_node_id=node_id,
+                        write_session=write_session,
+                        synthesis_input_data=synthesis_input_data,
+                        error_message="Regeneration failed — agent still produced no text",
+                        parent_supersynthesis_id=parent_supersynthesis_id,
+                        visibility=synth_input.visibility,
+                        creator_id=synth_input.creator_id,
+                    )
+
+                await emit_event(
+                    "synthesis_failed",
+                    synthesis_node_id=input.node_id,
+                    error="Regeneration failed — agent still produced no text",
+                )
+                return SynthesizerOutput(synthesis_node_id=input.node_id).model_dump()
+
+            # Success: update the existing node in-place
+            doc = await process_and_store_synthesis(
+                synthesis_text=result.synthesis_text,
+                synthesis_node_id=node_id,
+                nodes_visited=result.nodes_visited,
+                graph_engine=graph_engine,
+                embedding_service=worker_state.embedding_service,
+                qdrant_client=worker_state.qdrant_client,
+                write_session=write_session,
+                synthesis_input_data=synthesis_input_data,
+                parent_supersynthesis_id=parent_supersynthesis_id,
+            )
+
+            stats = doc.get("stats", {})
+
+            await emit_event(
+                "synthesis_completed",
+                synthesis_node_id=input.node_id,
+                **stats,
+            )
+
+            # If this is a sub-synthesis with a parent, dispatch recombine
+            if parent_supersynthesis_id:
+                try:
+                    from kt_hatchet.client import dispatch_workflow
+
+                    await dispatch_workflow(
+                        "recombine_supersynthesis_wf",
+                        {"node_id": parent_supersynthesis_id},
+                    )
+                    logger.info(
+                        "Dispatched recombine for parent super-synthesis %s",
+                        parent_supersynthesis_id,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to dispatch recombine for parent %s",
+                        parent_supersynthesis_id,
+                        exc_info=True,
+                    )
+
+            return SynthesizerOutput(
+                synthesis_node_id=input.node_id,
+                sentences_count=stats.get("sentences_count", 0),
+                facts_linked=stats.get("facts_linked", 0),
+                nodes_referenced=stats.get("nodes_referenced", 0),
+            ).model_dump()
+
+        finally:
+            if write_session is not None:
+                await write_session.close()
+
+
+# ── Recombine a super-synthesis ────────────────────────────────────
+
+recombine_supersynthesis_wf = hatchet.workflow(
+    name="recombine_supersynthesis_wf",
+    input_validator=RecombineSuperSynthesisInput,
+)
+
+
+@recombine_supersynthesis_wf.task(execution_timeout=timedelta(minutes=30))
+async def run_recombine(input: RecombineSuperSynthesisInput, ctx: Context) -> dict[str, Any]:
+    """Re-run the combine step on an existing super-synthesis node."""
+    worker_state = cast(WorkerState, ctx.lifespan)
+
+    from sqlalchemy import select as sa_select
+    from sqlalchemy import update
+
+    from kt_db.write_models import WriteNode
+    from kt_graph.engine import GraphEngine
+    from kt_worker_synthesis.workflows._helpers import (
+        run_super_synthesis_combine,
+        store_synthesis_error,
+    )
+
+    node_id = uuid.UUID(input.node_id)
+
+    async with worker_state.session_factory() as session:
+        write_session = None
+        if worker_state.write_session_factory is not None:
+            write_session = worker_state.write_session_factory()
+
+        try:
+            graph_engine = GraphEngine(
+                session,
+                worker_state.embedding_service,
+                write_session=write_session,
+                qdrant_client=worker_state.qdrant_client,
+            )
+
+            # Read stored metadata
+            node = await graph_engine.get_node(node_id)
+            if not node:
+                logger.error("Super-synthesis node %s not found", input.node_id)
+                return SuperSynthesizerOutput(supersynthesis_node_id=input.node_id).model_dump()
+
+            meta = node.metadata_ or {}
+            doc = meta.get("synthesis_document", {})
+            synthesis_node_ids = doc.get("sub_synthesis_ids", [])
+            synthesis_input_data = meta.get("synthesis_input", {})
+            topic = synthesis_input_data.get("topic", node.concept)
+
+            if not synthesis_node_ids:
+                logger.error("No sub_synthesis_ids found for super-synthesis %s", input.node_id)
+                return SuperSynthesizerOutput(supersynthesis_node_id=input.node_id).model_dump()
+
+            super_text = await run_super_synthesis_combine(
+                topic=topic,
+                synthesis_node_ids=synthesis_node_ids,
+                graph_engine=graph_engine,
+                model_gateway=worker_state.model_gateway,
+                embedding_service=worker_state.embedding_service,
+                session=session,
+                session_factory=worker_state.session_factory,
+                write_session_factory=worker_state.write_session_factory,
+                qdrant_client=worker_state.qdrant_client,
+                provider_registry=worker_state.provider_registry,
+            )
+
+            if not super_text:
+                logger.warning("Recombine failed — agent produced no text for %s", input.node_id)
+
+                if write_session:
+                    await store_synthesis_error(
+                        synthesis_node_id=node_id,
+                        write_session=write_session,
+                        synthesis_input_data=synthesis_input_data,
+                        error_message="Recombine failed — agent produced no text",
+                    )
+
+                return SuperSynthesizerOutput(
+                    supersynthesis_node_id=input.node_id,
+                    sub_synthesis_node_ids=synthesis_node_ids,
+                ).model_dump()
+
+            # Success: update the existing super-synthesis node
+            await graph_engine.set_node_definition(node_id, super_text)
+
+            # Collect node names from sub-syntheses for text matching
+            from kt_worker_synthesis.pipelines.document_processing import process_synthesis_document
+
+            node_names: dict[str, list[str]] = {}
+            for sid in synthesis_node_ids:
+                try:
+                    sub_node = await graph_engine.get_node(uuid.UUID(sid))
+                    if sub_node and sub_node.metadata_:
+                        sub_doc = sub_node.metadata_.get("synthesis_document", {})
+                        for ref_node in sub_doc.get("referenced_nodes", []):
+                            nid = ref_node.get("node_id", "")
+                            concept = ref_node.get("concept", "unknown")
+                            if nid:
+                                node_names[nid] = [concept]
+                except Exception:
+                    pass
+
+            new_doc = await process_synthesis_document(
+                synthesis_text=super_text,
+                embedding_service=worker_state.embedding_service,
+                qdrant_client=worker_state.qdrant_client,
+                node_names_and_aliases=node_names,
+            )
+            new_doc["sub_synthesis_ids"] = synthesis_node_ids
+
+            if write_session:
+                row = (
+                    await write_session.execute(sa_select(WriteNode.metadata_).where(WriteNode.node_uuid == node_id))
+                ).scalar_one_or_none()
+                existing_meta = row if isinstance(row, dict) else {}
+                existing_meta["synthesis_document"] = new_doc
+                existing_meta.pop("synthesis_error", None)
+                if synthesis_input_data:
+                    existing_meta["synthesis_input"] = synthesis_input_data
+                await write_session.execute(
+                    update(WriteNode).where(WriteNode.node_uuid == node_id).values(metadata_=existing_meta)
+                )
+                await write_session.commit()
+
+            stats = new_doc.get("stats", {})
+
+            return SuperSynthesizerOutput(
+                supersynthesis_node_id=input.node_id,
+                sub_synthesis_node_ids=synthesis_node_ids,
+                total_sentences=stats.get("sentences_count", 0),
+                total_facts_linked=stats.get("facts_linked", 0),
+            ).model_dump()
+
+        finally:
+            if write_session is not None:
+                await write_session.close()

--- a/services/worker-synthesis/src/kt_worker_synthesis/workflows/super_synthesizer.py
+++ b/services/worker-synthesis/src/kt_worker_synthesis/workflows/super_synthesizer.py
@@ -230,14 +230,11 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
 
     worker_state = cast(WorkerState, ctx.lifespan)
 
-    from langchain_core.messages import HumanMessage, SystemMessage
-
-    from kt_agents_core.state import AgentContext
     from kt_graph.engine import GraphEngine
-    from kt_worker_synthesis.agents.super_synthesizer_agent import SuperSynthesizerAgent
-    from kt_worker_synthesis.agents.super_synthesizer_state import SuperSynthesizerState
-    from kt_worker_synthesis.pipelines.document_processing import process_synthesis_document
-    from kt_worker_synthesis.prompts.super_synthesizer import build_super_synthesizer_system_message
+    from kt_worker_synthesis.workflows._helpers import (
+        run_super_synthesis_combine,
+        store_synthesis_error,
+    )
 
     async with worker_state.session_factory() as session:
         write_session = None
@@ -245,6 +242,11 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
             write_session = worker_state.write_session_factory()
 
         try:
+            from sqlalchemy import select as sa_select
+            from sqlalchemy import update
+
+            from kt_db.write_models import WriteNode
+
             graph_engine = GraphEngine(
                 session,
                 worker_state.embedding_service,
@@ -252,49 +254,18 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
                 qdrant_client=worker_state.qdrant_client,
             )
 
-            agent_ctx = AgentContext(
+            super_text = await run_super_synthesis_combine(
+                topic=input.topic,
+                synthesis_node_ids=synthesis_node_ids,
                 graph_engine=graph_engine,
-                provider_registry=worker_state.provider_registry,
                 model_gateway=worker_state.model_gateway,
                 embedding_service=worker_state.embedding_service,
                 session=session,
                 session_factory=worker_state.session_factory,
                 write_session_factory=worker_state.write_session_factory,
                 qdrant_client=worker_state.qdrant_client,
+                provider_registry=worker_state.provider_registry,
             )
-
-            system_content = build_super_synthesizer_system_message(
-                topic=input.topic,
-                synthesis_node_ids=synthesis_node_ids,
-            )
-
-            initial_state = SuperSynthesizerState(
-                synthesis_node_ids=synthesis_node_ids,
-                messages=[
-                    SystemMessage(content=system_content),
-                    HumanMessage(
-                        content=(
-                            "Read all sub-syntheses, then produce a comprehensive super-synthesis "
-                            "using finish_super_synthesis(text)."
-                        )
-                    ),
-                ],
-            )
-
-            agent = SuperSynthesizerAgent(agent_ctx)
-            graph, _ = agent.build_graph()
-            compiled = graph.compile()
-
-            recursion_limit = max(len(synthesis_node_ids) * 30, 500)
-            final = await compiled.ainvoke(initial_state, config={"recursion_limit": recursion_limit})
-
-            if isinstance(final, dict):
-                super_text = final.get("super_synthesis_text", "")
-            else:
-                super_text = final.super_synthesis_text
-
-            if not super_text:
-                super_text = "Super-synthesis completed but no document was produced."
 
             # Create supersynthesis node — append timestamp for unique key
             from datetime import UTC, datetime
@@ -306,14 +277,9 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
                 node_type="supersynthesis",
             )
             supersynthesis_node_id = node.id
-            await graph_engine.set_node_definition(supersynthesis_node_id, super_text)
 
             # Set visibility
             if write_session:
-                from sqlalchemy import update
-
-                from kt_db.write_models import WriteNode
-
                 await write_session.execute(
                     update(WriteNode)
                     .where(WriteNode.node_uuid == supersynthesis_node_id)
@@ -321,8 +287,32 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
                 )
                 await write_session.flush()
 
+            synthesis_input_data = input.model_dump()
+
+            if not super_text:
+                logger.warning("SuperSynthesizer agent ended without producing text")
+
+                if write_session:
+                    await store_synthesis_error(
+                        synthesis_node_id=supersynthesis_node_id,
+                        write_session=write_session,
+                        synthesis_input_data=synthesis_input_data,
+                        error_message="Super-synthesis agent ended without producing text",
+                        visibility=input.visibility,
+                        creator_id=input.creator_id,
+                    )
+
+                return SuperSynthesizerOutput(
+                    supersynthesis_node_id=str(supersynthesis_node_id),
+                    sub_synthesis_node_ids=synthesis_node_ids,
+                ).model_dump()
+
+            # Success: set definition
+            await graph_engine.set_node_definition(supersynthesis_node_id, super_text)
+
             # Collect node names from all sub-syntheses for text matching
-            # Read from sub-synthesis nodes' metadata (which has synthesis_document)
+            from kt_worker_synthesis.pipelines.document_processing import process_synthesis_document
+
             node_names: dict[str, list[str]] = {}
             for sid in synthesis_node_ids:
                 try:
@@ -350,8 +340,6 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
 
             # Store document JSON in node metadata via write-db
             if write_session:
-                from sqlalchemy import select as sa_select
-
                 row = (
                     await write_session.execute(
                         sa_select(WriteNode.metadata_).where(WriteNode.node_uuid == supersynthesis_node_id)
@@ -359,11 +347,34 @@ async def combine(input: SuperSynthesizerInput, ctx: Context) -> dict[str, Any]:
                 ).scalar_one_or_none()
                 existing_meta = row if isinstance(row, dict) else {}
                 existing_meta["synthesis_document"] = doc
+                existing_meta["synthesis_input"] = synthesis_input_data
+                existing_meta.pop("synthesis_error", None)
                 await write_session.execute(
                     update(WriteNode)
                     .where(WriteNode.node_uuid == supersynthesis_node_id)
                     .values(metadata_=existing_meta)
                 )
+
+                # Write parent_supersynthesis_id back to each sub-synthesis
+                for sid in synthesis_node_ids:
+                    try:
+                        sub_row = (
+                            await write_session.execute(
+                                sa_select(WriteNode.metadata_).where(WriteNode.node_uuid == uuid.UUID(sid))
+                            )
+                        ).scalar_one_or_none()
+                        sub_meta = sub_row if isinstance(sub_row, dict) else {}
+                        sub_meta["parent_supersynthesis_id"] = str(supersynthesis_node_id)
+                        await write_session.execute(
+                            update(WriteNode).where(WriteNode.node_uuid == uuid.UUID(sid)).values(metadata_=sub_meta)
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to set parent_supersynthesis_id on sub-synthesis %s",
+                            sid,
+                            exc_info=True,
+                        )
+
                 await write_session.commit()
 
             stats = doc.get("stats", {})

--- a/services/worker-synthesis/src/kt_worker_synthesis/workflows/synthesizer.py
+++ b/services/worker-synthesis/src/kt_worker_synthesis/workflows/synthesizer.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import logging
-import uuid
 from datetime import timedelta
 from typing import Any, cast
 
@@ -32,14 +31,12 @@ async def run_synthesizer(input: SynthesizerInput, ctx: Context) -> dict[str, An
     """Run the full synthesis pipeline."""
     worker_state = cast(WorkerState, ctx.lifespan)
 
-    from langchain_core.messages import HumanMessage, SystemMessage
-
-    from kt_agents_core.state import AgentContext
     from kt_graph.engine import GraphEngine
-    from kt_worker_synthesis.agents.synthesizer_agent import SynthesizerAgent
-    from kt_worker_synthesis.agents.synthesizer_state import SynthesizerState
-    from kt_worker_synthesis.pipelines.document_processing import process_synthesis_document
-    from kt_worker_synthesis.prompts.synthesizer import build_synthesizer_system_message
+    from kt_worker_synthesis.workflows._helpers import (
+        process_and_store_synthesis,
+        run_synthesis_agent,
+        store_synthesis_error,
+    )
 
     async with worker_state.session_factory() as session:
         write_session = None
@@ -60,62 +57,18 @@ async def run_synthesizer(input: SynthesizerInput, ctx: Context) -> dict[str, An
                 except Exception:
                     pass
 
-            agent_ctx = AgentContext(
+            result = await run_synthesis_agent(
+                input=input,
+                model_gateway=worker_state.model_gateway,
                 graph_engine=graph_engine,
                 provider_registry=worker_state.provider_registry,
-                model_gateway=worker_state.model_gateway,
                 embedding_service=worker_state.embedding_service,
                 session=session,
                 session_factory=worker_state.session_factory,
-                emit_event=emit_event,
                 write_session_factory=worker_state.write_session_factory,
                 qdrant_client=worker_state.qdrant_client,
+                emit_event=emit_event,
             )
-
-            # Build system message
-            system_content = build_synthesizer_system_message(
-                topic=input.topic,
-                starting_node_ids=input.starting_node_ids,
-                budget=input.exploration_budget,
-            )
-
-            initial_state = SynthesizerState(
-                topic=input.topic,
-                starting_node_ids=input.starting_node_ids,
-                exploration_budget=input.exploration_budget,
-                messages=[
-                    SystemMessage(content=system_content),
-                    HumanMessage(
-                        content=(
-                            "Investigate the topic using the tools available. When done, "
-                            "call finish_synthesis(text) with your complete markdown document. "
-                            "The text argument must contain the COMPLETE document — anything "
-                            "written outside finish_synthesis() is discarded."
-                        )
-                    ),
-                ],
-            )
-
-            # Run the agent
-            await emit_event("synthesis_agent_started", topic=input.topic)
-
-            agent = SynthesizerAgent(agent_ctx)
-            graph, _ = agent.build_graph()
-            compiled = graph.compile()
-
-            recursion_limit = max(input.exploration_budget * 30, 500)
-            final = await compiled.ainvoke(initial_state, config={"recursion_limit": recursion_limit})
-
-            if isinstance(final, dict):
-                synthesis_text = final.get("synthesis_text", "")
-                nodes_visited = final.get("nodes_visited", [])
-            else:
-                synthesis_text = final.synthesis_text
-                nodes_visited = final.nodes_visited
-
-            if not synthesis_text:
-                logger.warning("Synthesizer agent ended without producing text")
-                synthesis_text = "Synthesis completed but no document was produced."
 
             # Create synthesis node — append timestamp for unique key
             from datetime import UTC, datetime
@@ -127,7 +80,6 @@ async def run_synthesizer(input: SynthesizerInput, ctx: Context) -> dict[str, An
                 node_type="synthesis",
             )
             synthesis_node_id = node.id
-            await graph_engine.set_node_definition(synthesis_node_id, synthesis_text)
 
             # Set visibility and creator via write-db
             if write_session:
@@ -145,47 +97,41 @@ async def run_synthesizer(input: SynthesizerInput, ctx: Context) -> dict[str, An
                 )
                 await write_session.flush()
 
-            # Build node name/alias lookup for text matching
-            node_names: dict[str, list[str]] = {}
-            for nid in nodes_visited:
-                try:
-                    n = await graph_engine.get_node(uuid.UUID(nid))
-                    if n:
-                        names = [n.concept]
-                        node_names[nid] = names
-                except Exception:
-                    pass
+            synthesis_input_data = input.model_dump()
 
-            # Run document processing pipeline (returns JSON doc)
-            doc = await process_synthesis_document(
-                synthesis_text=synthesis_text,
+            if not result.synthesis_text:
+                logger.warning("Synthesizer agent ended without producing text")
+
+                if write_session:
+                    await store_synthesis_error(
+                        synthesis_node_id=synthesis_node_id,
+                        write_session=write_session,
+                        synthesis_input_data=synthesis_input_data,
+                        visibility=input.visibility,
+                        creator_id=input.creator_id,
+                    )
+
+                await emit_event(
+                    "synthesis_failed",
+                    synthesis_node_id=str(synthesis_node_id),
+                    error="Synthesis agent ended without producing text",
+                )
+
+                return SynthesizerOutput(
+                    synthesis_node_id=str(synthesis_node_id),
+                ).model_dump()
+
+            # Success path: process document and store
+            doc = await process_and_store_synthesis(
+                synthesis_text=result.synthesis_text,
+                synthesis_node_id=synthesis_node_id,
+                nodes_visited=result.nodes_visited,
+                graph_engine=graph_engine,
                 embedding_service=worker_state.embedding_service,
                 qdrant_client=worker_state.qdrant_client,
-                node_names_and_aliases=node_names,
+                write_session=write_session,
+                synthesis_input_data=synthesis_input_data,
             )
-
-            # Store document JSON in node metadata via write-db
-            if write_session:
-                from sqlalchemy import update
-
-                from kt_db.write_models import WriteNode
-
-                existing_meta = {}
-                from sqlalchemy import select as sa_select
-
-                row = (
-                    await write_session.execute(
-                        sa_select(WriteNode.metadata_).where(WriteNode.node_uuid == synthesis_node_id)
-                    )
-                ).scalar_one_or_none()
-                if row and isinstance(row, dict):
-                    existing_meta = row
-
-                existing_meta["synthesis_document"] = doc
-                await write_session.execute(
-                    update(WriteNode).where(WriteNode.node_uuid == synthesis_node_id).values(metadata_=existing_meta)
-                )
-                await write_session.commit()
 
             stats = doc.get("stats", {})
 


### PR DESCRIPTION
## Summary

- When a synthesizer agent fails to produce text, the workflow now stores the failure as an error state (`metadata["synthesis_error"]`) instead of a fake fallback string. The original input is preserved in `metadata["synthesis_input"]` for regeneration.
- Adds `POST /syntheses/{id}/regenerate` API endpoint that dispatches a new `regenerate_synthesis_wf` Hatchet workflow to re-run the agent on the existing node in-place.
- For sub-syntheses: regenerating automatically triggers `recombine_supersynthesis_wf` on the parent super-synthesis via `parent_supersynthesis_id` back-references.
- Frontend shows an error banner with "Regenerate" button on failed syntheses, a "Failed" badge in the investigations list, and polls for regeneration progress.

## Changes

### Backend
- **`_helpers.py`** (new) — Extracted `run_synthesis_agent()`, `process_and_store_synthesis()`, `store_synthesis_error()`, and `run_super_synthesis_combine()` helpers to share between original and regeneration workflows
- **`regenerate.py`** (new) — `regenerate_synthesis_wf` and `recombine_supersynthesis_wf` Hatchet workflows
- **`synthesizer.py`** — Uses helpers, stores error state on failure instead of fallback text
- **`super_synthesizer.py`** — Same error handling, writes `parent_supersynthesis_id` back to sub-syntheses
- **`syntheses.py`** (API) — New regenerate endpoint, `status`/`error_message` fields in response schemas
- **`models.py`** (kt-hatchet) — `RegenerateSynthesisInput`, `RecombineSuperSynthesisInput`

### Frontend
- Error banner with regenerate button in `SynthesisDocument.tsx`
- "Failed" badge in investigations list
- Regeneration progress polling in detail page

## Test plan
- [x] Frontend: lint, type-check, and 123 tests pass
- [x] Backend: worker-synthesis 9 tests pass, API 92 tests pass
- [ ] Manual: trigger a synthesis failure (tiny budget, no matching nodes), verify error state is shown, click regenerate, verify document is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)