### PR TITLE
fix(wiki-frontend): dark mode evidence dialog, markdown bold/lists, grouped syntheses

### DIFF
--- a/wiki-frontend/src/components/RichSegments.astro
+++ b/wiki-frontend/src/components/RichSegments.astro
@@ -1,0 +1,16 @@
+---
+import type { RichTextSegment } from "../lib/justification.js";
+
+interface Props {
+  segments: RichTextSegment[];
+}
+
+const { segments } = Astro.props;
+---
+
+{segments.map((s) =>
+  s.kind === "text" ? s.text :
+  s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
+  s.kind === "bold" ? <strong>{s.text}</strong> :
+  <a href={s.href}>{s.text}</a>
+)}

--- a/wiki-frontend/src/lib/justification.ts
+++ b/wiki-frontend/src/lib/justification.ts
@@ -18,8 +18,14 @@ export interface LinkSegment {
   href: string;
 }
 
+/** Bold text segment. */
+export interface BoldSegment {
+  kind: "bold";
+  text: string;
+}
+
 export type JustificationSegment = TextSegment | CitationSegment;
-export type RichTextSegment = TextSegment | CitationSegment | LinkSegment;
+export type RichTextSegment = TextSegment | CitationSegment | LinkSegment | BoldSegment;
 
 /**
  * Convert a justification string to plain text, replacing {fact:uuid}
@@ -108,8 +114,8 @@ export function parseRichText(
   const seen = new Map<string, number>();
   let counter = 1;
 
-  // Match {{fact:uuid|label}}, {fact:uuid}, or [text](url) markdown links
-  const pattern = /\{\{fact:([0-9a-f-]+)\|[^}]*\}\}|\{fact:([0-9a-f-]+)\}|\[([^\]]+)\]\(([^)]+)\)/gi;
+  // Match {{fact:uuid|label}}, {fact:uuid}, **bold**, or [text](url) markdown links
+  const pattern = /\{\{fact:([0-9a-f-]+)\|[^}]*\}\}|\{fact:([0-9a-f-]+)\}|\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*/gi;
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
@@ -127,6 +133,9 @@ export function parseRichText(
       const factId = match[2];
       if (!seen.has(factId)) seen.set(factId, counter++);
       segments.push({ kind: "citation", factId, num: seen.get(factId)! });
+    } else if (match[5]) {
+      // **bold** format
+      segments.push({ kind: "bold", text: match[5] });
     } else {
       segments.push({ kind: "link", text: match[3], href: match[4] });
     }
@@ -139,9 +148,9 @@ export function parseRichText(
   return segments;
 }
 
-/** A block of parsed markdown content (header or paragraph). */
+/** A block of parsed markdown content (header, paragraph, or list item). */
 export interface MarkdownBlock {
-  kind: "heading" | "paragraph";
+  kind: "heading" | "paragraph" | "list-item";
   level?: number; // 1-6 for headings
   segments: RichTextSegment[];
 }
@@ -171,6 +180,7 @@ export function parseMarkdownBlocks(
 
   for (const line of lines) {
     const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    const listMatch = line.match(/^(\s*)([-*]|\d+\.)\s+(.+)$/);
     if (headingMatch) {
       flushParagraph();
       const level = headingMatch[1].length;
@@ -178,6 +188,12 @@ export function parseMarkdownBlocks(
         kind: "heading",
         level,
         segments: parseRichText(headingMatch[2]),
+      });
+    } else if (listMatch) {
+      flushParagraph();
+      blocks.push({
+        kind: "list-item",
+        segments: parseRichText(listMatch[3]),
       });
     } else if (line.trim() === "") {
       flushParagraph();

--- a/wiki-frontend/src/pages/index.astro
+++ b/wiki-frontend/src/pages/index.astro
@@ -11,6 +11,14 @@ let nodes: NodeResponse[] = [];
 let syntheses: SynthesisListItem[] = [];
 let error: string | null = null;
 
+// Grouped synthesis data for investigations tab
+interface SynthesisGroup {
+  parent: SynthesisListItem;
+  children: SynthesisListItem[];
+}
+let synthGroups: SynthesisGroup[] = [];
+let standaloneSyntheses: SynthesisListItem[] = [];
+
 try {
   if (q) {
     nodes = await searchNodes(q);
@@ -23,6 +31,26 @@ try {
   }
 } catch (e) {
   error = e instanceof Error ? e.message : String(e);
+}
+
+// Group syntheses: super-syntheses with their children, standalone at top level
+if (syntheses.length > 0) {
+  const byId = new Map(syntheses.map((s) => [s.id, s]));
+  const childIds = new Set<string>();
+  for (const s of syntheses) {
+    for (const cid of s.sub_synthesis_ids) childIds.add(cid);
+  }
+  for (const s of syntheses) {
+    if (childIds.has(s.id)) continue; // skip children at top level
+    if (s.sub_synthesis_ids.length > 0) {
+      const children = s.sub_synthesis_ids
+        .map((cid) => byId.get(cid))
+        .filter((c): c is SynthesisListItem => !!c);
+      synthGroups.push({ parent: s, children });
+    } else {
+      standaloneSyntheses.push(s);
+    }
+  }
 }
 ---
 
@@ -80,24 +108,64 @@ try {
         syntheses.length === 0 ? (
           <p class="empty-state">No public investigations yet.</p>
         ) : (
-          <ul class="node-flat-list synthesis-list">
-            {syntheses.map((syn) => {
-              const { title, date } = formatSynthesisConcept(syn.concept);
-              const typeLabel = syn.node_type === "supersynthesis" ? "super-synthesis" : "synthesis";
+          <div class="synthesis-list">
+            {/* Super-syntheses with grouped children */}
+            {synthGroups.map((group) => {
+              const { title, date } = formatSynthesisConcept(group.parent.concept);
               return (
-                <li>
-                  <a href={synthesisHref(syn)} class="node-flat-link" title={title}>
-                    {title}
-                  </a>
-                  <span class="type-badge synthesis">{typeLabel}</span>
-                  <span class="synthesis-meta">
-                    {syn.sentence_count} sentence{syn.sentence_count !== 1 ? "s" : ""}
-                    {date && <> &middot; {date}</>}
-                  </span>
-                </li>
+                <details class="synthesis-group" open>
+                  <summary class="synthesis-group-header">
+                    <span class="synthesis-group-chevron">&#9656;</span>
+                    <a href={synthesisHref(group.parent)} class="node-flat-link" title={title}>
+                      {title}
+                    </a>
+                    <span class="type-badge synthesis">super-synthesis</span>
+                    <span class="synthesis-meta">
+                      {group.children.length} sub-synthes{group.children.length !== 1 ? "es" : "is"}
+                      {date && <> &middot; {date}</>}
+                    </span>
+                  </summary>
+                  <ul class="synthesis-group-children">
+                    {group.children.map((child) => {
+                      const { title: childTitle, date: childDate } = formatSynthesisConcept(child.concept);
+                      return (
+                        <li>
+                          <a href={synthesisHref(child)} class="node-flat-link" title={childTitle}>
+                            {childTitle}
+                          </a>
+                          <span class="synthesis-meta">
+                            {child.sentence_count} sentence{child.sentence_count !== 1 ? "s" : ""}
+                            {childDate && <> &middot; {childDate}</>}
+                          </span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </details>
               );
             })}
-          </ul>
+
+            {/* Standalone syntheses */}
+            {standaloneSyntheses.length > 0 && (
+              <ul class="node-flat-list">
+                {standaloneSyntheses.map((syn) => {
+                  const { title, date } = formatSynthesisConcept(syn.concept);
+                  return (
+                    <li>
+                      <a href={synthesisHref(syn)} class="node-flat-link" title={title}>
+                        {title}
+                      </a>
+                      <span class="type-badge synthesis">synthesis</span>
+                      <span class="synthesis-meta">
+                        {syn.sentence_count} sentence{syn.sentence_count !== 1 ? "s" : ""}
+                        {date && <> &middot; {date}</>}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
         )
       ) : (
         nodes.length === 0 ? (

--- a/wiki-frontend/src/pages/nodes/[id].astro
+++ b/wiki-frontend/src/pages/nodes/[id].astro
@@ -1,6 +1,7 @@
 ---
 import WikiLayout from "../../layouts/WikiLayout.astro";
 import FactsSection from "../../components/FactsSection.astro";
+import RichSegments from "../../components/RichSegments.astro";
 import {
   getNode,
   getSubgraph,
@@ -220,27 +221,13 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                   <div class="perspective-definition">
                     {parseMarkdownBlocks(node.definition).map((block) =>
                       block.kind === "heading" ? (
-                        block.level === 1 ? <h2 class="perspective-h1">{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</h2> :
-                        block.level === 2 ? <h3 class="perspective-h2">{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</h3> :
-                        <h4 class="perspective-h3">{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</h4>
+                        block.level === 1 ? <h2 class="perspective-h1"><RichSegments segments={block.segments} /></h2> :
+                        block.level === 2 ? <h3 class="perspective-h2"><RichSegments segments={block.segments} /></h3> :
+                        <h4 class="perspective-h3"><RichSegments segments={block.segments} /></h4>
+                      ) : block.kind === "list-item" ? (
+                        <li class="perspective-paragraph"><RichSegments segments={block.segments} /></li>
                       ) : (
-                        <p class="perspective-paragraph">{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</p>
+                        <p class="perspective-paragraph"><RichSegments segments={block.segments} /></p>
                       )
                     )}
                   </div>
@@ -248,27 +235,13 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                   <div class="node-definition">
                     {parseMarkdownBlocks(node.definition).map((block) =>
                       block.kind === "heading" ? (
-                        block.level === 1 ? <h2>{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</h2> :
-                        block.level === 2 ? <h3>{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</h3> :
-                        <h4>{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</h4>
+                        block.level === 1 ? <h2><RichSegments segments={block.segments} /></h2> :
+                        block.level === 2 ? <h3><RichSegments segments={block.segments} /></h3> :
+                        <h4><RichSegments segments={block.segments} /></h4>
+                      ) : block.kind === "list-item" ? (
+                        <li><RichSegments segments={block.segments} /></li>
                       ) : (
-                        <p>{block.segments.map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}</p>
+                        <p><RichSegments segments={block.segments} /></p>
                       )
                     )}
                   </div>
@@ -283,11 +256,7 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                   No definition has been generated yet — showing the first model analysis as a summary.
                 </p>
                 <p class="node-definition">
-                  {parseRichText(dimensions[0].content).map((s) =>
-                    s.kind === "text" ? s.text :
-                    s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                    <a href={s.href}>{s.text}</a>
-                  )}
+                  <RichSegments segments={parseRichText(dimensions[0].content)} />
                 </p>
               </>
             ) : null}
@@ -310,11 +279,7 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                         </span>
                       </div>
                       <div class="dimension-card-body">
-                        {parseRichText(dim.content).map((s) =>
-                          s.kind === "text" ? s.text :
-                          s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                          <a href={s.href}>{s.text}</a>
-                        )}
+                        <RichSegments segments={parseRichText(dim.content)} />
                       </div>
                     </div>
                   ))}

--- a/wiki-frontend/src/pages/syntheses/[id].astro
+++ b/wiki-frontend/src/pages/syntheses/[id].astro
@@ -1,5 +1,6 @@
 ---
 import WikiLayout from "../../layouts/WikiLayout.astro";
+import RichSegments from "../../components/RichSegments.astro";
 import { getSynthesis, nodeHref } from "../../lib/api.js";
 import { parseMarkdownBlocks } from "../../lib/justification.js";
 import { formatSynthesisConcept, buildParagraphSentenceMap } from "../../lib/synthesis-utils.js";
@@ -87,41 +88,34 @@ const blockMetas: BlockMeta[] = blocks.map((block) => {
           {blocks.map((block, i) => {
             const meta = blockMetas[i];
             const hasEvidence = meta.paraKey && (meta.nodeCount > 0 || meta.factCount > 0);
+            const blockCls = `synthesis-block ${hasEvidence ? "synthesis-block--clickable" : ""}`;
+            const dataAttrs = {
+              "data-para-key": meta.paraKey ?? undefined,
+              "data-sentence-positions": meta.sentencePositions.length > 0 ? JSON.stringify(meta.sentencePositions) : undefined,
+              "data-node-ids": meta.nodeIds.length > 0 ? JSON.stringify(meta.nodeIds) : undefined,
+            };
+            const badge = hasEvidence ? <span class="synthesis-para-badge">{meta.nodeCount}n {meta.factCount}f</span> : null;
             if (block.kind === "heading") {
               const Tag = block.level === 1 ? "h2" : block.level === 2 ? "h3" : "h4";
               return (
-                <Tag
-                  class={`synthesis-block ${hasEvidence ? "synthesis-block--clickable" : ""}`}
-                  data-para-key={meta.paraKey ?? undefined}
-                  data-sentence-positions={meta.sentencePositions.length > 0 ? JSON.stringify(meta.sentencePositions) : undefined}
-                  data-node-ids={meta.nodeIds.length > 0 ? JSON.stringify(meta.nodeIds) : undefined}
-                >
-                  {block.segments.map((s) =>
-                    s.kind === "text" ? s.text :
-                    s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                    <a href={s.href}>{s.text}</a>
-                  )}
-                  {hasEvidence && (
-                    <span class="synthesis-para-badge">{meta.nodeCount}n {meta.factCount}f</span>
-                  )}
+                <Tag class={blockCls} {...dataAttrs}>
+                  <RichSegments segments={block.segments} />
+                  {badge}
                 </Tag>
               );
             }
+            if (block.kind === "list-item") {
+              return (
+                <li class={blockCls} {...dataAttrs}>
+                  <RichSegments segments={block.segments} />
+                  {badge}
+                </li>
+              );
+            }
             return (
-              <p
-                class={`synthesis-block ${hasEvidence ? "synthesis-block--clickable" : ""}`}
-                data-para-key={meta.paraKey ?? undefined}
-                data-sentence-positions={meta.sentencePositions.length > 0 ? JSON.stringify(meta.sentencePositions) : undefined}
-                data-node-ids={meta.nodeIds.length > 0 ? JSON.stringify(meta.nodeIds) : undefined}
-              >
-                {block.segments.map((s) =>
-                  s.kind === "text" ? s.text :
-                  s.kind === "citation" ? <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a> :
-                  <a href={s.href}>{s.text}</a>
-                )}
-                {hasEvidence && (
-                  <span class="synthesis-para-badge">{meta.nodeCount}n {meta.factCount}f</span>
-                )}
+              <p class={blockCls} {...dataAttrs}>
+                <RichSegments segments={block.segments} />
+                {badge}
               </p>
             );
           })}

--- a/wiki-frontend/src/styles/global.css
+++ b/wiki-frontend/src/styles/global.css
@@ -2265,15 +2265,77 @@ a.fact-group-title:hover {
 
 /* ── Synthesis List (Investigations Tab) ────────────────────── */
 
-.synthesis-list li {
-  gap: 0.5rem;
-}
-
 .synthesis-meta {
   font-size: 0.78rem;
   color: var(--color-text-muted);
   font-family: var(--font-mono);
   white-space: nowrap;
+}
+
+.synthesis-group {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  margin-bottom: 0.5rem;
+}
+
+.synthesis-group[open] {
+  border-color: var(--color-border);
+}
+
+.synthesis-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.92rem;
+  list-style: none;
+}
+
+.synthesis-group-header::-webkit-details-marker { display: none; }
+
+.synthesis-group-chevron {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  transition: transform var(--t-fast);
+  flex-shrink: 0;
+}
+
+.synthesis-group[open] > .synthesis-group-header .synthesis-group-chevron {
+  transform: rotate(90deg);
+}
+
+.synthesis-group-children {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--color-border-light);
+  border-left: 2px solid var(--ocean-dim);
+  margin-left: 1rem;
+}
+
+.synthesis-group-children li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.88rem;
+}
+
+.synthesis-group-children li + li {
+  border-top: 1px solid var(--color-border-light);
+}
+
+.synthesis-group-children .node-flat-link {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.synthesis-list > .node-flat-list {
+  margin-top: 0.5rem;
 }
 
 /* ── Synthesis Detail Page ──────────────────────────────────── */
@@ -2322,6 +2384,24 @@ a.fact-group-title:hover {
   margin: 0 0 1rem;
 }
 
+.synthesis-body li,
+.node-definition li,
+.perspective-definition li {
+  line-height: 1.75;
+  margin: 0 0 0.35rem;
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.synthesis-body li::before,
+.node-definition li::before,
+.perspective-definition li::before {
+  content: "\2022";
+  position: absolute;
+  left: 0.25rem;
+  color: var(--color-text-muted);
+}
+
 .synthesis-block {
   padding: 0.3rem 0.5rem;
   margin-left: -0.5rem;
@@ -2363,12 +2443,14 @@ a.fact-group-title:hover {
   border-radius: var(--radius-md);
   padding: 0;
   background: var(--color-surface);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  color: var(--color-text);
+  box-shadow: var(--shadow-lg);
   overflow-y: auto;
 }
 
 .evidence-dialog::backdrop {
-  background: rgba(0, 0, 0, 0.35);
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
 }
 
 .evidence-dialog-inner {


### PR DESCRIPTION
## Summary

Follow-up fixes to #57:

- **Dark mode**: Evidence dialog text was invisible (dark on dark) — added `color: var(--color-text)` to `.evidence-dialog`
- **Markdown bold**: `**text**` now renders as `<strong>` via new `BoldSegment` type in `parseRichText`
- **List items**: `- item` / `* item` / `1. item` now parse as `list-item` blocks with bullet styling instead of being merged into paragraphs
- **Grouped syntheses**: Super-syntheses on the investigations tab show as collapsible `<details>` groups with sub-syntheses indented below
- **RichSegments component**: Extracted shared segment rendering into `RichSegments.astro` to reduce duplication

## Test plan

- [x] Astro type check passes (0 errors)
- [x] Wiki frontend builds successfully
- [ ] Manual: verify evidence dialog text is readable in dark mode
- [ ] Manual: verify bold text and list items render correctly in definitions/syntheses
- [ ] Manual: verify super-syntheses collapse/expand on investigations tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)