### PR TITLE
docs: add early development disclaimers and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Knowledge Tree
+
+Knowledge Tree is a **knowledge integration system** that builds understanding exclusively from raw external data. It constructs and evolves a knowledge graph where every node is grounded in provenance-tracked facts decomposed from real sources. It aims to make the underlying data and sources visible enabling the comprehension, understanding and integration of complex data and seemingly opposing ideas.
+
+> **Early Development Notice:** Knowledge Tree is currently under active development and not yet generally available. Features may change, and the system may experience downtime or instability. You can **join the waitlist** on the [Research App](https://research.openktree.com) to get early access.
+
+## What makes Knowledge Tree different
+
+- **Knowledge from data, not from models.** AI models are reasoning engines, not knowledge sources. All knowledge traces back to external raw data.
+- **Integration, not ignoring.** The system never discards coherent information. Contradictory facts produce perspectives with alternate viewpoints, not suppression.
+- **Multi-model convergence.** Multiple AI models analyze the same evidence independently. Consensus reveals genuine truth; divergence reveals where biases determine conclusions.
+- **Transparent provenance.** Every claim traces through facts back to original sources. Nothing is hidden.
+- **Accumulation.** The graph improves with every query. Frequently explored topics become deeply supported over time.
+
+## Services
+
+| Service | URL | Description |
+|---------|-----|-------------|
+| **Landing Page** | [openktree.com](https://openktree.com) | Project overview and links |
+| **Research App** | [research.openktree.com](https://research.openktree.com) | Ingest sources, create syntheses, explore the graph |
+| **Wiki** | [wiki.openktree.com](https://wiki.openktree.com) | Read-only knowledge graph browser |
+| **Docs** | [docs.openktree.com](https://docs.openktree.com) | Developer documentation |
+| **MCP Server** | [mcp.openktree.com](https://mcp.openktree.com) | Model Context Protocol endpoint |
+| **API** | [api.openktree.com](https://api.openktree.com) | REST + SSE API |
+
+## Getting Started
+
+### Using the Research App
+
+The fastest way to try Knowledge Tree is through the [Research App](https://research.openktree.com). Join the waitlist to get access, then:
+
+1. **Ingest sources** — paste links or upload documents to feed the knowledge graph
+2. **Explore the graph** — browse nodes, facts, dimensions, and relationships
+3. **Create syntheses** — generate research documents that weave evidence into analytical narratives
+
+### MCP Integration
+
+Connect your AI tools (Claude Desktop, etc.) to the Knowledge Tree graph via the [Model Context Protocol](https://docs.openktree.com/mcp/overview). Browse nodes, facts, dimensions, and relationships directly from any MCP client.
+
+See the [MCP docs](https://docs.openktree.com/mcp/connecting) for setup instructions.
+
+### Local Development
+
+Knowledge Tree is a microservices monorepo using **uv** (Python) and **pnpm** (frontend). To run locally:
+
+```bash
+# Prerequisites: Docker, uv, pnpm, just
+
+# Start infrastructure (Postgres, Redis, Hatchet)
+just setup
+
+# Run database migrations
+just migrate
+
+# Start the API, workers, and frontend
+just api-dev          # Terminal 1 — FastAPI on port 8000
+just worker           # Terminal 2 — Hatchet workers
+cd frontend && pnpm dev  # Terminal 3 — Next.js frontend
+```
+
+See the [development setup guide](https://docs.openktree.com/contributing/development-setup) for full instructions.
+
+## Documentation
+
+- [How It Works](https://docs.openktree.com/how-it-works/values-and-principles) — Core concepts: facts, entities, seeds, nodes, dimensions, and synthesis
+- [MCP Integration](https://docs.openktree.com/mcp/overview) — Connect AI tools to the knowledge graph
+- [Contributing](https://docs.openktree.com/contributing/architecture-overview) — Architecture, core objects, services, and development setup
+
+## License
+
+This project is licensed under AGPL-3.0. See [LICENSE](LICENSE) for details.

--- a/docs-site/docs/how-it-works/values-and-principles.md
+++ b/docs-site/docs/how-it-works/values-and-principles.md
@@ -5,11 +5,15 @@ title: Values & Principles
 
 # System Values & Principles
 
-Knowledge Tree is built on a simple conviction: **humanity deserves a shared, open knowledge commons** — a living World Graph where every piece of evidence is preserved, every source is traceable, and every perspective is represented.
+:::note[Early Development]
+Knowledge Tree is currently **under active development** and not yet generally available. Features may change, and the system may experience downtime or instability. You can **join the waitlist** on the [Research App](https://research.openktree.com) to get early access. For questions or feedback, reach out to **carlosgomezsoza@gmail.com**.
+:::
+
+Knowledge Tree is built on a simple conviction: **humanity deserves a shared, open knowledge commons** — a living cognitive tool that enables the use of AI to creating clarity when overloaded with massive ammounts of information or contradicting information. The world graph is a data commons archive where every piece of evidence is preserved, every source is traceable, and every perspective is represented.
 
 ## The World Graph
 
-The goal of Knowledge Tree is to create the **World Graph** — a global, open knowledge commons for humanity. Not a chatbot. Not a search engine. A persistent, growing graph of interconnected knowledge where:
+One of the goals of Knowledge Tree is to create the **World Graph** — a global, open knowledge commons for humanity. Not a chatbot. Not a search engine. A persistent, growing graph of interconnected knowledge where:
 
 - Every fact is grounded in real, external sources
 - Every connection between ideas is backed by shared evidence
@@ -24,7 +28,7 @@ The World Graph grows richer with every query, every source ingested, and every 
 
 AI models are **reasoning engines**, not knowledge sources. All knowledge in the graph traces back to raw external data — web pages, research papers, uploaded documents, and other real sources.
 
-Models analyze, compare, and synthesize facts. They never inject their own training data as knowledge. This separation is fundamental: it means the graph's knowledge is auditable, updatable, and independent of any single model's biases or training cutoff.
+Models analyze, compare, and synthesize facts. They are discouraged from injecting their own training data as knowledge. This separation is fundamental: it means the graph's knowledge is auditable, updatable, and independent of any single model's biases or training cutoff.
 
 ### 2. Integration, not ignoring
 

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -6,7 +6,7 @@ title: Welcome
 
 # Knowledge Tree Documentation
 
-Knowledge Tree is a **knowledge integration system** that builds understanding exclusively from raw external data — never from AI model internal knowledge. It constructs and evolves a knowledge graph where every node is grounded in provenance-tracked facts decomposed from real sources.
+Knowledge Tree is a **knowledge integration system** that builds understanding exclusively from raw external data. It constructs and evolves a knowledge graph where every node is grounded in provenance-tracked facts decomposed from real sources. It aims to make the underlying data and sources visible enabling the comprehension,  understanding and integration of complex data and seemingly oposing ideas. 
 
 ## What makes Knowledge Tree different
 
@@ -40,3 +40,13 @@ Dive into the architecture, core objects, services, and development setup. Every
 | **Docs** | [docs.openktree.com](https://docs.openktree.com) | Developer documentation (you are here) |
 | **MCP Server** | [mcp.openktree.com](https://mcp.openktree.com) | Model Context Protocol endpoint |
 | **API** | [api.openktree.com](https://api.openktree.com) | REST + SSE API |
+
+---
+
+:::note[Early Development]
+Knowledge Tree is currently **under active development** and not yet generally available. Features may change, and the system may experience downtime or instability.
+
+If you'd like to try it out, you can **join the waitlist** on the [Research App](https://research.openktree.com) — it's already deployed and accepting signups.
+
+For any questions, feedback, or collaboration inquiries, please reach out to **carlosgomezsoza@gmail.com**.
+:::


### PR DESCRIPTION
## Summary
- Add early development disclaimer with waitlist link and contact email to docs-site pages (index + values & principles)
- Create project README with getting started instructions, service links, MCP integration info, local dev setup, and documentation pointers
- README includes the development disclaimer with waitlist link (no email per request)

## Test plan
- [ ] Verify docs-site renders the admonition blocks correctly
- [ ] Verify README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)