### PR TITLE
chore: replace personal email and add docker-compose dev warning

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -180,7 +180,7 @@ edges:
 #   cache_ttl: 604800
 #   enable_ancestry: true
 #   similarity_threshold: 0.85
-#   wikidata_user_agent: "KnowledgeTree/1.0 (carlosgomezsoza@gmail.com)"
+#   wikidata_user_agent: "KnowledgeTree/1.0 (example@openktree.com)"
 #   crystallization_child_threshold: 10
 #   crystallization_child_change_ratio: 0.5
 #   crystallization_model: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# DEVELOPMENT ONLY - Do not use these credentials in production.
+# For production, use environment variables from a secure vault.
+
 services:
   postgres:
     image: pgvector/pgvector:pg16

--- a/libs/kt-config/src/kt_config/settings.py
+++ b/libs/kt-config/src/kt_config/settings.py
@@ -400,7 +400,7 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"
     ontology_cache_ttl: int = 604800  # 7 days in seconds
     ontology_model: str = "openrouter/x-ai/grok-4.1-fast"
-    wikidata_user_agent: str = "KnowledgeTree/1.0 (carlosgomezsoza@gmail.com)"
+    wikidata_user_agent: str = "KnowledgeTree/1.0 (example@openktree.com)"
     enable_ontology_ancestry: bool = True
     ontology_similarity_threshold: float = 0.82  # embedding threshold for matching existing nodes
 


### PR DESCRIPTION
## Summary
- Replace personal email (`carlosgomezsoza@gmail.com`) with `example@openktree.com` in Wikidata user agent string (settings.py + config.yaml)
- Add development-only credential warning comment to docker-compose.yml

## Context
Public repo readiness cleanup. The personal email in the user agent doesn't need to be a real mailbox — it's just an identifier for the Wikidata API. Docs-site contact email is left unchanged intentionally.

## Test plan
- [x] `kt-config` tests pass (26/26)
- [x] No functional change — email is only used as a user agent string
- [x] docker-compose.yml comment is cosmetic only

🤖 Generated with [Claude Code](https://claude.com/claude-code)