### PR TITLE
feat(helm): mount API_TOKEN in wiki-frontend from secret

### DIFF
--- a/helm/knowledge-tree/templates/secret.yaml
+++ b/helm/knowledge-tree/templates/secret.yaml
@@ -39,4 +39,5 @@ stringData:
   hatchet-client-token: {{ .Values.secrets.hatchetClientToken | quote }}
   hatchet-admin-email: {{ $hatchetAdminEmail | quote }}
   hatchet-admin-password: {{ $hatchetAdminPassword | quote }}
+  api-token: {{ .Values.secrets.apiToken | quote }}
 {{- end }}

--- a/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
@@ -35,6 +35,11 @@ spec:
               value: "http://{{ include "knowledge-tree.fullname" . }}-api:{{ .Values.api.port }}"
             - name: SITE_DOMAIN
               value: {{ .Values.wikiFrontend.siteDomain | default .Values.global.siteDomain | default "openktree.com" | quote }}
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "knowledge-tree.secretName" . }}
+                  key: api-token
           livenessProbe:
             httpGet:
               path: /

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -28,6 +28,9 @@ secrets:
   # Auto-generated if empty (preserved across upgrades via lookup)
   jwtSecretKey: ""
 
+  # API token for wiki-frontend → API authentication
+  apiToken: ""
+
   googleOauthClientId: ""
   googleOauthClientSecret: ""
 


### PR DESCRIPTION
## Summary
- Adds `API_TOKEN` env var to the wiki-frontend deployment, sourced from the chart secret via `secretKeyRef`
- Adds `api-token` key to the Helm-managed secret template
- Adds `secrets.apiToken` to `values.yaml`

The wiki-frontend was missing API authentication — it had `API_BASE_URL` but no token to authenticate requests. The `api-token` key has already been added to the `knowledge-tree-secrets` secret in the dev cluster.

## Test plan
- [ ] Verify Helm template renders correctly: `helm template` with `secrets.existingSecret` set
- [ ] After merge + Flux reconciliation, confirm wiki-frontend pod has `API_TOKEN` env var
- [ ] Confirm wiki pages load data from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)