### PR TITLE
fix(helm): bump hatchet-db memory limit to 2Gi

### DIFF
--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -89,10 +89,10 @@ hatchetDb:
     max_connections: "100"
   resources:
     requests:
-      memory: 256Mi
+      memory: 512Mi
       cpu: 100m
     limits:
-      memory: 1Gi
+      memory: 2Gi
 
 # =============================================================================
 # PgBouncer (write-db connection pooler)


### PR DESCRIPTION
## Summary
- Bumps hatchet-db memory requests from 256Mi → 512Mi and limit from 1Gi → 2Gi
- Matches the resource profile of graph-db and write-db CNPG clusters
- **Prod is unaffected** — already configured at 2Gi via prod values override

## Root cause
`hatchet-db-1` was being OOMKilled at the 1Gi limit under load, causing a cascade:
1. hatchet-db OOMKilled → crash loop
2. Hatchet migration init container times out → Hatchet crash loops
3. All workers lose gRPC connection to Hatchet → heartbeat failures → task timeouts (decompose, etc.)

## Test plan
- [ ] After merge + Flux reconciliation, verify hatchet-db pod has 2Gi limit
- [ ] Confirm hatchet-db and hatchet pods stabilize (no more CrashLoopBackOff)
- [ ] Confirm workers reconnect and tasks complete without timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)