### PR TITLE
feat(worker-bottomup): configurable Hatchet concurrency limits

### DIFF
--- a/helm/knowledge-tree/templates/worker-bottomup-deployment.yaml
+++ b/helm/knowledge-tree/templates/worker-bottomup-deployment.yaml
@@ -29,6 +29,26 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}
+            {{- if .Values.workers.bottomup.bottomUpMaxRuns }}
+            - name: BOTTOM_UP_MAX_RUNS
+              value: {{ .Values.workers.bottomup.bottomUpMaxRuns | quote }}
+            {{- end }}
+            {{- if .Values.workers.bottomup.bottomUpPrepareMaxRuns }}
+            - name: BOTTOM_UP_PREPARE_MAX_RUNS
+              value: {{ .Values.workers.bottomup.bottomUpPrepareMaxRuns | quote }}
+            {{- end }}
+            {{- if .Values.workers.bottomup.agentSelectMaxRuns }}
+            - name: AGENT_SELECT_MAX_RUNS
+              value: {{ .Values.workers.bottomup.agentSelectMaxRuns | quote }}
+            {{- end }}
+            {{- if .Values.workers.bottomup.workerBottomupSlots }}
+            - name: WORKER_BOTTOMUP_SLOTS
+              value: {{ .Values.workers.bottomup.workerBottomupSlots | quote }}
+            {{- end }}
+            {{- if .Values.workers.bottomup.workerBottomupDurableSlots }}
+            - name: WORKER_BOTTOMUP_DURABLE_SLOTS
+              value: {{ .Values.workers.bottomup.workerBottomupDurableSlots | quote }}
+            {{- end }}
           volumeMounts:
             {{- include "knowledge-tree.configVolumeMount" . | nindent 12 }}
           resources:

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -318,6 +318,12 @@ workers:
     image:
       repository: ""
       tag: ""
+    # Hatchet concurrency limits (pydantic-settings auto-reads uppercased env vars)
+    bottomUpMaxRuns: ""          # BOTTOM_UP_MAX_RUNS (default: 3)
+    bottomUpPrepareMaxRuns: ""   # BOTTOM_UP_PREPARE_MAX_RUNS (default: 3)
+    agentSelectMaxRuns: ""       # AGENT_SELECT_MAX_RUNS (default: 3)
+    workerBottomupSlots: ""      # WORKER_BOTTOMUP_SLOTS (default: 20)
+    workerBottomupDurableSlots: ""  # WORKER_BOTTOMUP_DURABLE_SLOTS (default: 40)
     resources:
       requests:
         memory: 512Mi

--- a/libs/kt-config/src/kt_config/settings.py
+++ b/libs/kt-config/src/kt_config/settings.py
@@ -255,6 +255,18 @@ _register(
     },
 )
 
+# ---- Hatchet concurrency ---------------------------------------------------
+_register(
+    "hatchet_concurrency",
+    {
+        "bottom_up_max_runs": "bottom_up_max_runs",
+        "bottom_up_prepare_max_runs": "bottom_up_prepare_max_runs",
+        "agent_select_max_runs": "agent_select_max_runs",
+        "worker_bottomup_slots": "worker_bottomup_slots",
+        "worker_bottomup_durable_slots": "worker_bottomup_durable_slots",
+    },
+)
+
 # ---- Seeds -----------------------------------------------------------------
 _register(
     "seeds",
@@ -477,6 +489,13 @@ class Settings(BaseSettings):
 
     # Wave pipeline
     default_wave_count: int = 2
+
+    # Hatchet concurrency limits
+    bottom_up_max_runs: int = 3
+    bottom_up_prepare_max_runs: int = 3
+    agent_select_max_runs: int = 3
+    worker_bottomup_slots: int = 20
+    worker_bottomup_durable_slots: int = 40
 
     # Timeouts
     agent_inactivity_timeout_seconds: int = 300  # stall detection: no tool/emit activity for 5 min

--- a/services/worker-bottomup/src/kt_worker_bottomup/__main__.py
+++ b/services/worker-bottomup/src/kt_worker_bottomup/__main__.py
@@ -5,6 +5,7 @@ Usage: python -m kt_worker_bottomup
 
 import logging
 
+from kt_config.settings import get_settings
 from kt_hatchet.client import get_hatchet
 from kt_hatchet.lifespan import worker_lifespan
 from kt_worker_bottomup.bottom_up import (
@@ -25,10 +26,11 @@ def main() -> None:
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
     hatchet = get_hatchet()
+    settings = get_settings()
     worker = hatchet.worker(
         "orchestrator",
-        slots=10,
-        durable_slots=20,
+        slots=settings.worker_bottomup_slots,
+        durable_slots=settings.worker_bottomup_durable_slots,
         workflows=[
             agent_select_wf,
             bottom_up_wf,

--- a/services/worker-bottomup/src/kt_worker_bottomup/bottom_up/workflow.py
+++ b/services/worker-bottomup/src/kt_worker_bottomup/bottom_up/workflow.py
@@ -337,7 +337,7 @@ bottom_up_wf = hatchet.workflow(
     input_validator=BottomUpInput,
     concurrency=ConcurrencyExpression(
         expression="input.conversation_id",
-        max_runs=1,
+        max_runs=get_settings().bottom_up_max_runs,
         limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
     ),
 )
@@ -839,7 +839,7 @@ bottom_up_prepare_wf = hatchet.workflow(
     input_validator=BottomUpPrepareInput,
     concurrency=ConcurrencyExpression(
         expression="input.conversation_id",
-        max_runs=1,
+        max_runs=get_settings().bottom_up_prepare_max_runs,
         limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
     ),
 )
@@ -1164,7 +1164,7 @@ agent_select_wf = hatchet.workflow(
     input_validator=AgentSelectInput,
     concurrency=ConcurrencyExpression(
         expression="input.conversation_id",
-        max_runs=1,
+        max_runs=get_settings().agent_select_max_runs,
         limit_strategy=ConcurrencyLimitStrategy.GROUP_ROUND_ROBIN,
     ),
 )


### PR DESCRIPTION
## Summary
- Add 5 new settings for Hatchet concurrency: `bottom_up_max_runs`, `bottom_up_prepare_max_runs`, `agent_select_max_runs`, `worker_bottomup_slots`, `worker_bottomup_durable_slots`
- Replace hardcoded `max_runs=1` → default `3` in three workflow ConcurrencyExpressions (bottom_up, bottom_up_prepare, agent_select)
- Replace hardcoded worker `slots=10` / `durable_slots=20` → default `20` / `40`
- Add optional Helm chart values for per-environment overrides via env vars

## Why
Production bottom_up_prepare_scope tasks were serialized (`max_runs=1` per conversation), causing massive queue buildup. Only one prepare task could run at a time, blocking hundreds of downstream decompose/extract tasks.

## Test plan
- [x] `pytest libs/kt-config/tests/` — 26 passed
- [x] `pytest services/worker-bottomup/tests/` — 19 passed
- [ ] Deploy and verify workers start with new defaults
- [ ] Confirm parallel prepare_scope execution in Hatchet UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)