### PR TITLE
feat(kt-models): identify as openktree on OpenRouter

### DIFF
--- a/libs/kt-models/src/kt_models/embeddings.py
+++ b/libs/kt-models/src/kt_models/embeddings.py
@@ -6,6 +6,12 @@ from litellm import aembedding
 
 from kt_config.settings import get_settings
 
+# OpenRouter app identification headers
+_OPENROUTER_HEADERS = {
+    "X-Title": "openktree",
+    "HTTP-Referer": "https://github.com/openktree/knowledge-tree",
+}
+
 logger = logging.getLogger(__name__)
 
 _MAX_RETRIES = 2
@@ -65,6 +71,7 @@ class EmbeddingService:
                     api_base="https://openrouter.ai/api/v1",
                     encoding_format="float",
                     timeout=self._timeout,
+                    extra_headers=_OPENROUTER_HEADERS,
                 )
                 _record_embedding_usage(response, self._model)
                 return response.data[0]["embedding"]  # type: ignore[index]
@@ -102,6 +109,7 @@ class EmbeddingService:
                         api_base="https://openrouter.ai/api/v1",
                         encoding_format="float",
                         timeout=self._timeout,
+                        extra_headers=_OPENROUTER_HEADERS,
                     )
                     _record_embedding_usage(response, self._model)
                     results.extend(item["embedding"] for item in response.data)  # type: ignore[index]

--- a/libs/kt-models/src/kt_models/gateway.py
+++ b/libs/kt-models/src/kt_models/gateway.py
@@ -25,6 +25,12 @@ _JSON_RETRY_MAX_DELAY = 120.0  # seconds — cap for backoff (2 minutes)
 _CODE_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?", re.MULTILINE)
 _CODE_FENCE_END_RE = re.compile(r"\n?```\s*$", re.MULTILINE)
 
+# OpenRouter app identification headers
+_OPENROUTER_HEADERS = {
+    "X-Title": "openktree",
+    "HTTP-Referer": "https://github.com/openktree/knowledge-tree",
+}
+
 
 def _extract_json(raw: str) -> str:
     """Best-effort cleanup of LLM output to extract a JSON object or array.
@@ -243,6 +249,9 @@ class ModelGateway:
         max_retries = _MAX_RETRIES
         base_delay = _BASE_DELAY
 
+        # Inject OpenRouter app identification headers
+        kwargs.setdefault("extra_headers", {}).update(_OPENROUTER_HEADERS)
+
         for attempt in range(_RATE_LIMIT_MAX_RETRIES):
             # After initial retries exhausted, only continue for rate limits
             if attempt >= max_retries and not isinstance(last_exc, RateLimitError):
@@ -308,6 +317,7 @@ class ModelGateway:
             temperature=float(kwargs.get("temperature", 0.3)),
             max_tokens=int(kwargs.get("max_tokens", 1000)),
             model_kwargs=extra_kwargs,
+            default_headers=_OPENROUTER_HEADERS,
         )
 
     @traceable(name="ModelGateway.generate_with_tools")


### PR DESCRIPTION
## Summary
- Adds `X-Title: openktree` and `HTTP-Referer` headers to all OpenRouter API calls (completions, embeddings, and LangChain ChatOpenAI)
- The app will now appear as "openktree" on the OpenRouter dashboard instead of the default "litellm"

## Test plan
- [x] All 66 kt-models tests pass
- [ ] Verify app name appears as "openktree" on OpenRouter dashboard after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)