### PR TITLE
fix(kt-db,worker-sync): prevent duplicate sources and fact_count reset

### DIFF
--- a/libs/kt-db/alembic_write/versions/w031_add_uri_index_to_write_raw_sources.py
+++ b/libs/kt-db/alembic_write/versions/w031_add_uri_index_to_write_raw_sources.py
@@ -1,0 +1,25 @@
+"""Add URI index to write_raw_sources for dedup lookups.
+
+Revision ID: w031
+Revises: w030
+Create Date: 2026-03-30
+"""
+
+from alembic import op
+
+revision = "w031"
+down_revision = "w030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_write_raw_sources_uri",
+        "write_raw_sources",
+        ["uri"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_write_raw_sources_uri", table_name="write_raw_sources")

--- a/libs/kt-db/src/kt_db/repositories/write_sources.py
+++ b/libs/kt-db/src/kt_db/repositories/write_sources.py
@@ -44,11 +44,21 @@ class WriteSourceRepository:
         provider_id: str,
         provider_metadata: dict | None = None,
     ) -> WriteRawSource:
-        """Insert or return existing source by content_hash.
+        """Insert or return existing source, deduplicating by URI then content_hash.
 
-        Uses ON CONFLICT DO UPDATE (no-op style) on content_hash to avoid
-        deadlocks from concurrent inserts of the same source.
+        First checks for an existing source with the same URI to prevent
+        duplicate entries when search engines return different snippets for
+        the same URL across queries.  Falls back to content_hash upsert for
+        genuinely new URLs.
         """
+        # Deduplicate by URI first — same URL should always reuse the
+        # existing source regardless of snippet content.
+        existing = (
+            await self._session.execute(select(WriteRawSource).where(WriteRawSource.uri == uri).limit(1))
+        ).scalar_one_or_none()
+        if existing is not None:
+            return existing
+
         if content_hash is None:
             content_hash = self.compute_hash(raw_content or "")
         if source_id is None:

--- a/libs/kt-db/src/kt_db/write_models.py
+++ b/libs/kt-db/src/kt_db/write_models.py
@@ -36,6 +36,7 @@ class WriteRawSource(WriteBase):
     __table_args__ = (
         Index("ix_write_raw_sources_updated_at", "updated_at"),
         Index("ix_write_raw_sources_content_hash", "content_hash", unique=True),
+        Index("ix_write_raw_sources_uri", "uri"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/services/worker-sync/src/kt_worker_sync/sync_engine.py
+++ b/services/worker-sync/src/kt_worker_sync/sync_engine.py
@@ -244,7 +244,10 @@ class SyncEngine:
                                     "is_full_text": wrs.is_full_text,
                                     "content_type": wrs.content_type,
                                     "provider_metadata": wrs.provider_metadata,
-                                    "fact_count": wrs.fact_count,
+                                    # fact_count intentionally excluded — managed
+                                    # by _sync_one_fact_source increments only.
+                                    # write-db never updates fact_count, so
+                                    # re-syncing would reset it to 0.
                                     "prohibited_chunk_count": wrs.prohibited_chunk_count,
                                     "fetch_attempted": wrs.fetch_attempted,
                                 },
@@ -1796,7 +1799,8 @@ class SyncEngine:
                                     "is_full_text": wrs.is_full_text,
                                     "content_type": wrs.content_type,
                                     "provider_metadata": wrs.provider_metadata,
-                                    "fact_count": wrs.fact_count,
+                                    # fact_count intentionally excluded — managed
+                                    # by _sync_one_fact_source increments only.
                                     "prohibited_chunk_count": wrs.prohibited_chunk_count,
                                     "fetch_attempted": wrs.fetch_attempted,
                                 },


### PR DESCRIPTION
## Summary

- **Source URI dedup**: `WriteSourceRepository.create_or_get()` now checks for an existing source by URI before the content_hash upsert. This prevents duplicate `WriteRawSource` rows when search engines return different snippets for the same URL across queries — the root cause of many sources showing "fetch failed" with 0 facts.
- **fact_count sync fix**: Removed `fact_count` from `_sync_raw_sources`'s `on_conflict_do_update` set, since write-db `fact_count` is never incremented. Previously, any re-sync of a `WriteRawSource` would overwrite the graph-db `fact_count` (maintained by `_sync_one_fact_source`) back to 0.
- **Migration w031**: Adds `ix_write_raw_sources_uri` index for fast URI lookups.

## Root cause

1. `create_or_get()` deduped by `content_hash` only. Different search queries return different snippets for the same URL → different hashes → new source row. Full-text `update_content()` then hit a hash collision with the original and returned `False`, leaving the duplicate with snippet content, `fetch_attempted=True`, `is_full_text=False` → UI shows "fetch failed" + 0 facts.
2. Sync engine blindly copied `wrs.fact_count` (always 0 in write-db) to graph-db on every raw source re-sync, wiping out the fact count that `_sync_one_fact_source` had correctly incremented.

## Test plan

- [x] `uv run --project libs/kt-db pytest libs/kt-db/tests/ -x -v` — 150 passed
- [x] `uv run --project services/worker-sync pytest services/worker-sync/tests/ -x -v` — 8 passed
- [ ] After deploy: verify no new duplicate URI sources are created
- [ ] After deploy: verify existing sources retain fact_count across sync cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)