### PR TITLE
fix(api): add missing conversation list and detail endpoints

### DIFF
--- a/services/api/src/kt_api/conversations.py
+++ b/services/api/src/kt_api/conversations.py
@@ -1,0 +1,106 @@
+"""Conversation CRUD endpoints.
+
+Provides listing and retrieval of conversations, used by the research
+history UI to display past bottom-up research sessions.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kt_api.dependencies import get_db_session
+from kt_api.schemas import (
+    ConversationListItem,
+    ConversationMessageResponse,
+    ConversationResponse,
+    PaginatedConversationsResponse,
+    SubgraphResponse,
+)
+from kt_db.repositories.conversations import ConversationRepository
+
+router = APIRouter(prefix="/api/v1", tags=["conversations"])
+
+
+@router.get("/conversations", response_model=PaginatedConversationsResponse)
+async def list_conversations(
+    mode: str | None = Query(None, description="Filter by conversation mode"),
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    session: AsyncSession = Depends(get_db_session),
+) -> PaginatedConversationsResponse:
+    """List conversations, optionally filtered by mode."""
+    repo = ConversationRepository(session)
+    conversations = await repo.list_recent(limit=limit, offset=offset, mode=mode)
+    total = await repo.count(mode=mode)
+
+    items = []
+    for conv in conversations:
+        msg_count = await repo.get_message_count(conv.id)
+        items.append(
+            ConversationListItem(
+                id=str(conv.id),
+                title=conv.title,
+                mode=conv.mode,
+                message_count=msg_count,
+                created_at=conv.created_at,
+                updated_at=conv.updated_at,
+            )
+        )
+
+    return PaginatedConversationsResponse(
+        items=items,
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
+
+
+@router.get("/conversations/{conversation_id}", response_model=ConversationResponse)
+async def get_conversation(
+    conversation_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> ConversationResponse:
+    """Get a single conversation with all messages."""
+    try:
+        conv_uuid = uuid.UUID(conversation_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid conversation ID")
+
+    repo = ConversationRepository(session)
+    conv = await repo.get_with_messages(conv_uuid)
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    messages = [
+        ConversationMessageResponse(
+            id=str(msg.id),
+            turn_number=msg.turn_number,
+            role=msg.role,
+            content=msg.content,
+            nav_budget=msg.nav_budget,
+            explore_budget=msg.explore_budget,
+            nav_used=msg.nav_used,
+            explore_used=msg.explore_used,
+            visited_nodes=msg.visited_nodes,
+            created_nodes=msg.created_nodes,
+            created_edges=msg.created_edges,
+            subgraph=SubgraphResponse(**msg.subgraph) if msg.subgraph else None,
+            status=msg.status,
+            error=msg.error,
+            workflow_run_id=getattr(msg, "workflow_run_id", None),
+            created_at=msg.created_at,
+        )
+        for msg in conv.messages
+    ]
+
+    return ConversationResponse(
+        id=str(conv.id),
+        title=conv.title,
+        mode=conv.mode,
+        messages=messages,
+        created_at=conv.created_at,
+        updated_at=conv.updated_at,
+    )

--- a/services/api/src/kt_api/router.py
+++ b/services/api/src/kt_api/router.py
@@ -8,6 +8,7 @@ from kt_api.admin import router as admin_router
 from kt_api.auth.router import router as auth_router
 from kt_api.auth.tokens import require_auth
 from kt_api.config_api import router as config_router
+from kt_api.conversations import router as conversations_router
 from kt_api.edge_candidates import router as edge_candidates_router
 from kt_api.edges import router as edges_router
 from kt_api.export import router as export_router
@@ -34,6 +35,7 @@ api_router = APIRouter()
 # Auth routes are public (login, register, etc.)
 api_router.include_router(auth_router)
 # All other routes require authentication
+api_router.include_router(conversations_router, dependencies=_auth_dep)
 api_router.include_router(nodes_router, dependencies=_auth_dep)
 api_router.include_router(edges_router, dependencies=_auth_dep)
 api_router.include_router(graph_router, dependencies=_auth_dep)

--- a/services/api/tests/integration/test_conversations.py
+++ b/services/api/tests/integration/test_conversations.py
@@ -1,0 +1,169 @@
+"""Integration tests for conversation list and detail endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from kt_api.dependencies import get_db_session
+from kt_api.main import create_app
+from kt_db.models import Conversation, ConversationMessage
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def session_factory(engine):
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def app(session_factory):
+    application = create_app()
+
+    async def override_get_db_session() -> AsyncGenerator[AsyncSession, None]:
+        async with session_factory() as session:
+            yield session
+
+    application.dependency_overrides[get_db_session] = override_get_db_session
+    return application
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture()
+async def bottom_up_conversations(session_factory):
+    """Create a few conversations with different modes."""
+    async with session_factory() as session:
+        async with session.begin():
+            conv1 = Conversation(id=uuid.uuid4(), title="Web research 1", mode="bottom_up_ingest")
+            session.add(conv1)
+            await session.flush()
+
+            # Add 2 messages (user + assistant)
+            session.add(
+                ConversationMessage(
+                    id=uuid.uuid4(),
+                    conversation_id=conv1.id,
+                    turn_number=0,
+                    role="user",
+                    content="research quantum computing",
+                )
+            )
+            session.add(
+                ConversationMessage(
+                    id=uuid.uuid4(),
+                    conversation_id=conv1.id,
+                    turn_number=1,
+                    role="assistant",
+                    content="",
+                    status="completed",
+                )
+            )
+
+            conv2 = Conversation(id=uuid.uuid4(), title="Web research 2", mode="bottom_up_ingest")
+            session.add(conv2)
+            await session.flush()
+
+            session.add(
+                ConversationMessage(
+                    id=uuid.uuid4(),
+                    conversation_id=conv2.id,
+                    turn_number=0,
+                    role="user",
+                    content="research AI safety",
+                )
+            )
+
+            conv3 = Conversation(id=uuid.uuid4(), title="Document ingest", mode="ingest")
+            session.add(conv3)
+
+        yield conv1, conv2, conv3
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations
+# ---------------------------------------------------------------------------
+
+
+class TestListConversations:
+    async def test_returns_all_conversations(self, client: AsyncClient, bottom_up_conversations):
+        resp = await client.get("/api/v1/conversations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert "total" in data
+        assert data["total"] >= 3
+
+    async def test_filters_by_mode(self, client: AsyncClient, bottom_up_conversations):
+        resp = await client.get("/api/v1/conversations", params={"mode": "bottom_up_ingest"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 2
+        for item in data["items"]:
+            assert item["mode"] == "bottom_up_ingest"
+
+    async def test_includes_message_count(self, client: AsyncClient, bottom_up_conversations):
+        conv1, conv2, _ = bottom_up_conversations
+        resp = await client.get("/api/v1/conversations", params={"mode": "bottom_up_ingest"})
+        assert resp.status_code == 200
+        data = resp.json()
+        items_by_id = {item["id"]: item for item in data["items"]}
+
+        # conv1 has 2 messages, conv2 has 1 message
+        assert items_by_id[str(conv1.id)]["message_count"] == 2
+        assert items_by_id[str(conv2.id)]["message_count"] == 1
+
+    async def test_pagination(self, client: AsyncClient, bottom_up_conversations):
+        resp = await client.get("/api/v1/conversations", params={"limit": 1, "offset": 0})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["items"]) == 1
+        assert data["limit"] == 1
+        assert data["offset"] == 0
+
+    async def test_empty_result_for_unknown_mode(self, client: AsyncClient):
+        resp = await client.get("/api/v1/conversations", params={"mode": "nonexistent_mode"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /conversations/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetConversation:
+    async def test_returns_conversation_with_messages(self, client: AsyncClient, bottom_up_conversations):
+        conv1, _, _ = bottom_up_conversations
+        resp = await client.get(f"/api/v1/conversations/{conv1.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == str(conv1.id)
+        assert data["title"] == "Web research 1"
+        assert data["mode"] == "bottom_up_ingest"
+        assert len(data["messages"]) == 2
+        assert data["messages"][0]["role"] == "user"
+        assert data["messages"][1]["role"] == "assistant"
+
+    async def test_returns_404_for_unknown_id(self, client: AsyncClient):
+        fake_id = str(uuid.uuid4())
+        resp = await client.get(f"/api/v1/conversations/{fake_id}")
+        assert resp.status_code == 404
+
+    async def test_returns_400_for_invalid_id(self, client: AsyncClient):
+        resp = await client.get("/api/v1/conversations/not-a-uuid")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

- The `ResearchHistory` frontend component calls `GET /api/v1/conversations?mode=bottom_up_ingest` to show past bottom-up research tasks, but **this endpoint did not exist** — the call 404'd and was silently caught, leaving the history section permanently empty
- Add `GET /api/v1/conversations` (with `mode` filter, pagination) and `GET /api/v1/conversations/{id}` (with eagerly loaded messages) to the API
- All schemas (`PaginatedConversationsResponse`, `ConversationListItem`, `ConversationResponse`) and repository methods (`list_recent`, `count`, `get_with_messages`) already existed — they just were never wired to endpoints

## Test plan

- [x] 8 new integration tests covering list, filter by mode, message count, pagination, detail, 404/400 cases
- [ ] Manual: start stack, run a bottom-up research, verify "Recent Web Research" history shows the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)