### PR TITLE
feat(frontend,wiki-frontend): mobile responsive layout

### DIFF
--- a/frontend/src/components/edge/EdgeDetailPanel.tsx
+++ b/frontend/src/components/edge/EdgeDetailPanel.tsx
@@ -76,7 +76,7 @@ export function EdgeDetailPanel({ edgeId, onClose }: EdgeDetailPanelProps) {
   return (
     <div
       className={cn(
-        "fixed top-0 right-0 bottom-0 w-[32rem] max-w-full bg-background border-l shadow-xl z-50 overflow-hidden",
+        "fixed inset-0 md:left-auto w-full md:w-[32rem] bg-background border-l shadow-xl z-50 overflow-hidden",
         "flex flex-col",
         "animate-in slide-in-from-right duration-200",
       )}

--- a/frontend/src/components/edge/EdgeListView.tsx
+++ b/frontend/src/components/edge/EdgeListView.tsx
@@ -82,8 +82,8 @@ export function EdgeListView() {
   return (
     <div className="flex flex-col h-full relative">
       {/* Search + filter + count */}
-      <div className="flex items-center gap-3 p-4 border-b">
-        <div className="relative flex-1">
+      <div className="flex flex-wrap items-center gap-3 p-4 border-b">
+        <div className="relative flex-1 min-w-[200px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <Input
             placeholder="Search by justification..."

--- a/frontend/src/components/fact/FactDetailPanel.tsx
+++ b/frontend/src/components/fact/FactDetailPanel.tsx
@@ -87,7 +87,7 @@ export function FactDetailPanel({ factId, onClose }: FactDetailPanelProps) {
   return (
     <div
       className={cn(
-        "fixed top-0 right-0 bottom-0 w-[32rem] max-w-full bg-background border-l shadow-xl z-50 overflow-hidden",
+        "fixed inset-0 md:left-auto w-full md:w-[32rem] bg-background border-l shadow-xl z-50 overflow-hidden",
         "flex flex-col",
         "animate-in slide-in-from-right duration-200",
       )}

--- a/frontend/src/components/fact/FactListView.tsx
+++ b/frontend/src/components/fact/FactListView.tsx
@@ -124,8 +124,8 @@ export function FactListView() {
   return (
     <div className="flex flex-col h-full relative">
       {/* Search + filter + count */}
-      <div className="flex items-center gap-3 p-4 border-b">
-        <div className="relative flex-1">
+      <div className="flex flex-wrap items-center gap-3 p-4 border-b">
+        <div className="relative flex-1 min-w-[200px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <Input
             placeholder="Search facts..."
@@ -178,7 +178,7 @@ export function FactListView() {
           ) : (
             <Upload className="size-4" />
           )}
-          <span className="ml-1">Import JSON</span>
+          <span className="ml-1 hidden sm:inline">Import JSON</span>
         </Button>
         <Button
           variant="outline"
@@ -191,7 +191,7 @@ export function FactListView() {
           ) : (
             <Download className="size-4" />
           )}
-          <span className="ml-1">Export JSON</span>
+          <span className="ml-1 hidden sm:inline">Export JSON</span>
         </Button>
       </div>
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -4,16 +4,22 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { CircleDot, ArrowLeftRight, FileText, PanelLeftClose, PanelLeft, TreePine, Upload, Globe, Sprout, GitPullRequestArrow, BarChart3, Users, Settings, Search, ExternalLink } from "lucide-react";
+import { CircleDot, ArrowLeftRight, FileText, PanelLeftClose, PanelLeft, TreePine, Upload, Globe, Sprout, GitPullRequestArrow, BarChart3, Users, Settings, Search, ExternalLink, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { UserMenu } from "@/components/auth/UserMenu";
 import { ThemeToggle } from "@/components/theme/ThemeToggle";
 import { useAuth } from "@/contexts/auth";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { cn } from "@/lib/utils";
 
 const WORKFLOW_ITEMS = [
@@ -45,16 +51,194 @@ const EXTERNAL_LINKS = [
   { href: `https://wiki.${SITE_DOMAIN}`, label: "Wiki" },
 ];
 
+function NavContent({
+  collapsed,
+  isAdmin,
+  isActive,
+  onNavigate,
+}: {
+  collapsed: boolean;
+  isAdmin: boolean;
+  isActive: (href: string) => boolean;
+  onNavigate?: () => void;
+}) {
+  return (
+    <>
+      {/* Navigation */}
+      <nav className="flex-1 flex flex-col gap-1 p-2">
+        {[...WORKFLOW_ITEMS, ...DATA_ITEMS].map((item, index) => {
+          const active = isActive(item.href);
+          const showDivider = index === WORKFLOW_ITEMS.length;
+          const linkContent = (
+            <Link
+              href={item.href}
+              onClick={onNavigate}
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                active
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                collapsed && "justify-center px-0",
+              )}
+            >
+              <item.icon className="size-4 shrink-0" />
+              {!collapsed && <span>{item.label}</span>}
+            </Link>
+          );
+
+          const element = collapsed ? (
+            <Tooltip key={item.href}>
+              <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+              <TooltipContent side="right">{item.label}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <div key={item.href}>{linkContent}</div>
+          );
+
+          if (showDivider) {
+            return (
+              <div key={item.href}>
+                <div className={cn("border-t border-border my-1", collapsed && "mx-1")} />
+                {element}
+              </div>
+            );
+          }
+
+          return element;
+        })}
+
+        {isAdmin && (
+          <>
+            <div className={cn("border-t border-border my-1", collapsed && "mx-1")} />
+            {ADMIN_NAV_ITEMS.map((item) => {
+              const active = isActive(item.href);
+              const linkContent = (
+                <Link
+                  href={item.href}
+                  onClick={onNavigate}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                    active
+                      ? "bg-accent text-accent-foreground font-medium"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    collapsed && "justify-center px-0",
+                  )}
+                >
+                  <item.icon className="size-4 shrink-0" />
+                  {!collapsed && <span>{item.label}</span>}
+                </Link>
+              );
+
+              if (collapsed) {
+                return (
+                  <Tooltip key={item.href}>
+                    <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+                    <TooltipContent side="right">{item.label}</TooltipContent>
+                  </Tooltip>
+                );
+              }
+
+              return <div key={item.href}>{linkContent}</div>;
+            })}
+          </>
+        )}
+      </nav>
+
+      {/* External links */}
+      <div className={cn("border-t border-border p-2 flex flex-col gap-1", collapsed && "px-1")}>
+        {EXTERNAL_LINKS.map((item) => {
+          const linkContent = (
+            <a
+              key={item.href}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                collapsed && "justify-center px-0",
+              )}
+            >
+              <ExternalLink className="size-4 shrink-0" />
+              {!collapsed && <span>{item.label}</span>}
+            </a>
+          );
+
+          if (collapsed) {
+            return (
+              <Tooltip key={item.href}>
+                <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+                <TooltipContent side="right">{item.label}</TooltipContent>
+              </Tooltip>
+            );
+          }
+
+          return <div key={item.href}>{linkContent}</div>;
+        })}
+      </div>
+    </>
+  );
+}
+
 export function SidebarLayout({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
   const { user } = useAuth();
   const isAdmin = user?.is_superuser ?? false;
+  const isMobile = useIsMobile();
 
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/";
     return pathname.startsWith(href);
   };
+
+  if (isMobile) {
+    return (
+      <div className="flex flex-col h-screen">
+        {/* Mobile top bar */}
+        <div className="flex items-center gap-2 px-3 py-2 border-b bg-card shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setMobileOpen(true)}
+            className="px-2"
+          >
+            <Menu className="size-5" />
+          </Button>
+          <Image src="/logo.svg" alt="Knowledge Tree" width={20} height={20} className="size-5 shrink-0" />
+          <span className="text-sm font-semibold truncate">Knowledge Tree</span>
+        </div>
+
+        {/* Mobile drawer */}
+        <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+          <SheetContent side="left" className="w-[260px] p-0 flex flex-col">
+            <SheetTitle className="sr-only">Navigation</SheetTitle>
+            {/* Logo */}
+            <div className="flex items-center gap-2 px-3 py-4 border-b">
+              <Image src="/logo.svg" alt="Knowledge Tree" width={20} height={20} className="size-5 shrink-0" />
+              <span className="text-sm font-semibold truncate">Knowledge Tree</span>
+            </div>
+
+            <NavContent
+              collapsed={false}
+              isAdmin={isAdmin}
+              isActive={isActive}
+              onNavigate={() => setMobileOpen(false)}
+            />
+
+            {/* User menu + theme */}
+            <div className="border-t p-2 flex flex-col gap-1">
+              <ThemeToggle collapsed={false} />
+              <UserMenu collapsed={false} />
+            </div>
+          </SheetContent>
+        </Sheet>
+
+        {/* Main content */}
+        <main className="flex-1 min-w-0 overflow-auto">{children}</main>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen">
@@ -73,115 +257,11 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
           )}
         </div>
 
-        {/* Navigation */}
-        <nav className="flex-1 flex flex-col gap-1 p-2">
-          {[...WORKFLOW_ITEMS, ...DATA_ITEMS].map((item, index) => {
-            const active = isActive(item.href);
-            const showDivider = index === WORKFLOW_ITEMS.length;
-            const linkContent = (
-              <Link
-                href={item.href}
-                className={cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
-                  active
-                    ? "bg-accent text-accent-foreground font-medium"
-                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  collapsed && "justify-center px-0",
-                )}
-              >
-                <item.icon className="size-4 shrink-0" />
-                {!collapsed && <span>{item.label}</span>}
-              </Link>
-            );
-
-            const element = collapsed ? (
-              <Tooltip key={item.href}>
-                <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
-                <TooltipContent side="right">{item.label}</TooltipContent>
-              </Tooltip>
-            ) : (
-              <div key={item.href}>{linkContent}</div>
-            );
-
-            if (showDivider) {
-              return (
-                <div key={item.href}>
-                  <div className={cn("border-t border-border my-1", collapsed && "mx-1")} />
-                  {element}
-                </div>
-              );
-            }
-
-            return element;
-          })}
-
-          {isAdmin && (
-            <>
-              <div className={cn("border-t border-border my-1", collapsed && "mx-1")} />
-              {ADMIN_NAV_ITEMS.map((item) => {
-                const active = isActive(item.href);
-                const linkContent = (
-                  <Link
-                    href={item.href}
-                    className={cn(
-                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
-                      active
-                        ? "bg-accent text-accent-foreground font-medium"
-                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                      collapsed && "justify-center px-0",
-                    )}
-                  >
-                    <item.icon className="size-4 shrink-0" />
-                    {!collapsed && <span>{item.label}</span>}
-                  </Link>
-                );
-
-                if (collapsed) {
-                  return (
-                    <Tooltip key={item.href}>
-                      <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
-                      <TooltipContent side="right">{item.label}</TooltipContent>
-                    </Tooltip>
-                  );
-                }
-
-                return <div key={item.href}>{linkContent}</div>;
-              })}
-            </>
-          )}
-        </nav>
-
-        {/* External links */}
-        <div className={cn("border-t border-border p-2 flex flex-col gap-1", collapsed && "px-1")}>
-          {EXTERNAL_LINKS.map((item) => {
-            const linkContent = (
-              <a
-                key={item.href}
-                href={item.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  collapsed && "justify-center px-0",
-                )}
-              >
-                <ExternalLink className="size-4 shrink-0" />
-                {!collapsed && <span>{item.label}</span>}
-              </a>
-            );
-
-            if (collapsed) {
-              return (
-                <Tooltip key={item.href}>
-                  <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
-                  <TooltipContent side="right">{item.label}</TooltipContent>
-                </Tooltip>
-              );
-            }
-
-            return <div key={item.href}>{linkContent}</div>;
-          })}
-        </div>
+        <NavContent
+          collapsed={collapsed}
+          isAdmin={isAdmin}
+          isActive={isActive}
+        />
 
         {/* User menu + theme + collapse toggle */}
         <div className="border-t p-2 flex flex-col gap-1">

--- a/frontend/src/components/node/NodeDetailPanel.tsx
+++ b/frontend/src/components/node/NodeDetailPanel.tsx
@@ -70,7 +70,7 @@ export default function NodeDetailPanel({
   return (
     <div
       className={cn(
-        "fixed top-0 right-0 bottom-0 w-[32rem] max-w-full bg-background border-l shadow-xl z-50 overflow-hidden",
+        "fixed inset-0 md:left-auto w-full md:w-[32rem] bg-background border-l shadow-xl z-50 overflow-hidden",
         "flex flex-col",
         "animate-in slide-in-from-right duration-200"
       )}

--- a/frontend/src/components/node/NodeListView.tsx
+++ b/frontend/src/components/node/NodeListView.tsx
@@ -121,8 +121,8 @@ export function NodeListView({ onViewInGraph }: NodeListViewProps) {
   return (
     <div className="flex flex-col h-full relative">
       {/* Search + count */}
-      <div className="flex items-center gap-3 p-4 border-b">
-        <div className="relative flex-1">
+      <div className="flex flex-wrap items-center gap-3 p-4 border-b">
+        <div className="relative flex-1 min-w-[200px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <Input
             placeholder="Search nodes..."
@@ -150,7 +150,7 @@ export function NodeListView({ onViewInGraph }: NodeListViewProps) {
           ) : (
             <Upload className="size-4" />
           )}
-          <span className="ml-1">Import JSON</span>
+          <span className="ml-1 hidden sm:inline">Import JSON</span>
         </Button>
         <Button
           variant="outline"
@@ -163,12 +163,12 @@ export function NodeListView({ onViewInGraph }: NodeListViewProps) {
           ) : (
             <Download className="size-4" />
           )}
-          <span className="ml-1">Export JSON</span>
+          <span className="ml-1 hidden sm:inline">Export JSON</span>
         </Button>
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-3 px-4 py-2 border-b">
+      <div className="flex flex-wrap items-center gap-3 px-4 py-2 border-b">
         <Filter className="size-4 text-muted-foreground shrink-0" />
         <Select value={nodeType} onValueChange={setNodeType}>
           <SelectTrigger className="w-[150px] h-8 text-xs">

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,22 @@
+import { useSyncExternalStore } from "react";
+
+const MOBILE_BREAKPOINT = 767;
+const QUERY = `(max-width: ${MOBILE_BREAKPOINT}px)`;
+
+function subscribe(callback: () => void): () => void {
+  const mql = window.matchMedia(QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+export function useIsMobile(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/wiki-frontend/src/layouts/WikiLayout.astro
+++ b/wiki-frontend/src/layouts/WikiLayout.astro
@@ -55,6 +55,12 @@ const siteDomain = import.meta.env.SITE_DOMAIN || "openktree.com";
         <button type="submit">Search</button>
       </form>
 
+      <button class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+        <span class="nav-toggle-bar"></span>
+      </button>
+
       <div class="header-actions">
         <a href={`https://${siteDomain}`} class="header-about-link">Home</a>
         <a href={`https://research.${siteDomain}`} class="header-about-link">Research</a>
@@ -87,6 +93,13 @@ const siteDomain = import.meta.env.SITE_DOMAIN || "openktree.com";
         const next = current === "dark" ? "light" : "dark";
         document.documentElement.setAttribute("data-theme", next);
         localStorage.setItem("kt-theme", next);
+      });
+
+      const navToggle = document.getElementById("nav-toggle");
+      const header = document.querySelector(".site-header");
+      navToggle?.addEventListener("click", () => {
+        const open = header?.classList.toggle("nav-open");
+        navToggle.setAttribute("aria-expanded", String(!!open));
       });
     </script>
   </body>

--- a/wiki-frontend/src/styles/global.css
+++ b/wiki-frontend/src/styles/global.css
@@ -2199,6 +2199,32 @@ a.fact-group-title:hover {
   border-radius: var(--radius-sm);
 }
 
+/* ── Mobile Nav Toggle ─────────────────────────────────────── */
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  width: 34px;
+  height: 34px;
+  background: none;
+  border: 1px solid var(--color-nav-search-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  padding: 6px;
+  margin-left: auto;
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: var(--color-nav-text-dim);
+  border-radius: 1px;
+  transition: transform var(--t-fast), opacity var(--t-fast);
+}
+
 /* ── Responsive ────────────────────────────────────────────── */
 
 @media (max-width: 720px) {
@@ -2206,7 +2232,37 @@ a.fact-group-title:hover {
 
   .site-header { gap: 1rem; padding: 0 1rem; }
 
-  .header-search { max-width: 280px; }
+  .header-search { max-width: none; flex: 1; }
+
+  .nav-toggle { display: flex; }
+
+  .header-actions {
+    position: absolute;
+    top: var(--header-height);
+    left: 0;
+    right: 0;
+    background: var(--color-nav-bg);
+    border-bottom: 1px solid var(--color-nav-border);
+    flex-direction: column;
+    padding: 0.75rem 1rem;
+    gap: 0.25rem;
+    display: none;
+    z-index: 99;
+  }
+
+  .site-header.nav-open .header-actions {
+    display: flex;
+  }
+
+  .header-actions .header-about-link {
+    padding: 0.5rem 0.75rem;
+    width: 100%;
+    border-radius: var(--radius-sm);
+  }
+
+  .header-actions .header-about-link:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
 
   .node-grid {
     grid-template-columns: 1fr;
@@ -2622,6 +2678,8 @@ a.fact-group-title:hover {
 
 @media (max-width: 480px) {
   .header-search { display: none; }
+  .site-title { font-size: 1rem; }
   .node-grid { grid-template-columns: 1fr; }
   .tab { padding: 0.5rem 0.8rem; font-size: 0.82rem; }
+  .synthesis-body { max-width: 100%; }
 }


### PR DESCRIPTION
## Summary
- **Sidebar drawer on mobile**: Converts the fixed sidebar to a Sheet drawer (hamburger menu) on screens <768px. Desktop layout unchanged.
- **Responsive list views**: Fact, Node, and Edge list headers now wrap controls on narrow screens. Import/Export buttons show icon-only on mobile.
- **Full-screen detail panels**: Fact, Node, and Edge detail panels go full-screen on mobile instead of fixed 32rem width.
- **Wiki hamburger menu**: Wiki frontend header nav collapses into a hamburger toggle at 720px. Search bar fills available space on medium screens.

## Test plan
- [ ] Open frontend in browser DevTools at 375px, 480px, 768px, 1024px widths
- [ ] Verify sidebar becomes a drawer with hamburger button on mobile
- [ ] Verify list view controls wrap properly and buttons show icon-only on small screens
- [ ] Verify detail panels (fact/node/edge) go full-screen on mobile
- [ ] Verify desktop layout is completely unchanged at 1024px+
- [ ] Open wiki frontend and verify hamburger menu appears at ≤720px
- [ ] Verify wiki search bar hidden at ≤480px, nav links in dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)