### PR TITLE
fix(helm): use /about for wiki-frontend liveness probe

### DIFF
--- a/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
+++ b/helm/knowledge-tree/templates/wiki-frontend-deployment.yaml
@@ -42,16 +42,19 @@ spec:
                   key: api-token
           livenessProbe:
             httpGet:
-              path: /
+              path: /about
               port: {{ .Values.wikiFrontend.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /
+              path: /about
               port: {{ .Values.wikiFrontend.port }}
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.wikiFrontend.resources | nindent 12 }}
 {{- end }}


### PR DESCRIPTION
## Summary

- Change wiki-frontend liveness/readiness probe from `/` to `/about` (static page, no API calls)
- Increase timeout from 1s to 5s and failureThreshold from 3 to 5
- Prevents wiki crashloop during research when the API is under load

The `/` path triggers SSR which calls the backend API. Under cluster load (decomposition waves), the API response exceeds the 1s timeout, the probe fails 3 times, and kubelet kills the pod — causing CrashLoopBackOff with 50+ restarts.

## Test plan

- [x] Verified `/about` is a static page with zero API calls
- [x] Patched in prod — wiki immediately recovered from CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)