### PR TITLE
feat: hide Google login button when OAuth is not configured

### DIFF
--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/contexts/auth";
 import { api } from "@/lib/api";
@@ -12,6 +12,11 @@ export function LoginForm() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [googleEnabled, setGoogleEnabled] = useState(false);
+
+  useEffect(() => {
+    api.auth.authFeatures().then((f) => setGoogleEnabled(f.google_oauth_enabled)).catch(() => {});
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -77,19 +82,23 @@ export function LoginForm() {
         {loading ? "Signing in…" : "Sign in"}
       </button>
 
-      <div className="relative my-2 flex items-center">
-        <div className="flex-1 border-t border-border" />
-        <span className="mx-3 text-xs text-muted-foreground">or</span>
-        <div className="flex-1 border-t border-border" />
-      </div>
+      {googleEnabled && (
+        <>
+          <div className="relative my-2 flex items-center">
+            <div className="flex-1 border-t border-border" />
+            <span className="mx-3 text-xs text-muted-foreground">or</span>
+            <div className="flex-1 border-t border-border" />
+          </div>
 
-      <button
-        type="button"
-        onClick={handleGoogle}
-        className="rounded-md border border-border px-4 py-2 text-sm font-medium hover:bg-accent"
-      >
-        Continue with Google
-      </button>
+          <button
+            type="button"
+            onClick={handleGoogle}
+            className="rounded-md border border-border px-4 py-2 text-sm font-medium hover:bg-accent"
+          >
+            Continue with Google
+          </button>
+        </>
+      )}
 
       <p className="text-center text-sm text-muted-foreground">
         No account?{" "}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1005,6 +1005,10 @@ export const api = {
     registrationStatus(): Promise<RegistrationStatusResponse> {
       return request<RegistrationStatusResponse>("/auth/registration-status");
     },
+
+    authFeatures(): Promise<{ google_oauth_enabled: boolean }> {
+      return request<{ google_oauth_enabled: boolean }>("/auth/features");
+    },
   },
 
   // -------------------------------------------------------------------------

--- a/services/api/src/kt_api/auth/router.py
+++ b/services/api/src/kt_api/auth/router.py
@@ -182,6 +182,22 @@ async def api_key_status(
     )
 
 
+# ---- Auth features (public) ----
+
+
+class AuthFeaturesResponse(BaseModel):
+    google_oauth_enabled: bool
+
+
+@router.get("/features", response_model=AuthFeaturesResponse)
+async def auth_features() -> AuthFeaturesResponse:
+    """Public endpoint: check which auth features are available."""
+    settings = get_settings()
+    return AuthFeaturesResponse(
+        google_oauth_enabled=bool(settings.google_oauth_client_id),
+    )
+
+
 # ---- Registration status (public) ----
 
 


### PR DESCRIPTION
## Summary
- Adds a public `GET /api/v1/auth/features` endpoint that returns `{ google_oauth_enabled: bool }` based on whether `GOOGLE_OAUTH_CLIENT_ID` is set
- LoginForm fetches auth features on mount and conditionally renders the "Continue with Google" button + divider only when Google OAuth is enabled
- When OAuth is not configured, the login page shows only email/password without the misleading Google button

## Test plan
- [ ] Verify with `GOOGLE_OAUTH_CLIENT_ID` unset: Google button should not appear on login page
- [ ] Verify with `GOOGLE_OAUTH_CLIENT_ID` set: Google button should appear and work as before
- [ ] Verify `GET /api/v1/auth/features` returns correct value without authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)