### PR TITLE
docs(mcp): document OAuth 2.1 as primary auth protocol

### DIFF
--- a/docs-site/docs/mcp/connecting.md
+++ b/docs-site/docs/mcp/connecting.md
@@ -7,10 +7,14 @@ title: Connecting
 
 ## Prerequisites
 
-1. An API token generated from the Research App ([research.openktree.com](https://research.openktree.com)) under **Profile > API Tokens**
+1. A Knowledge Tree account at [research.openktree.com](https://research.openktree.com)
 2. An MCP-compatible client (Claude Desktop, Claude Code, or another MCP client)
 
-## Claude Desktop
+## OAuth 2.1 (recommended)
+
+MCP clients that support OAuth handle authentication automatically. You only need to provide the server URL — the client discovers OAuth endpoints, registers itself, and prompts you to log in.
+
+### Claude Desktop
 
 Add the following to your Claude Desktop configuration file:
 
@@ -21,7 +25,72 @@ Add the following to your Claude Desktop configuration file:
 {
   "mcpServers": {
     "knowledge-tree": {
-      "url": "https://mcp.openktree.com/sse",
+      "url": "https://mcp.openktree.com/mcp"
+    }
+  }
+}
+```
+
+On first use, Claude Desktop will open a browser window where you log in with your Knowledge Tree account. Tokens are refreshed automatically.
+
+### Claude Code
+
+Add to your Claude Code settings or project `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "knowledge-tree": {
+      "type": "http",
+      "url": "https://mcp.openktree.com/mcp"
+    }
+  }
+}
+```
+
+Or via the CLI:
+
+```bash
+claude mcp add --transport http --scope user knowledge-tree https://mcp.openktree.com/mcp
+```
+
+### Other MCP clients
+
+Any client that supports MCP OAuth can connect. Point it at:
+
+```
+https://mcp.openktree.com/mcp
+```
+
+The client will discover the OAuth configuration from `/.well-known/oauth-authorization-server` and handle the flow.
+
+## API tokens (fallback)
+
+For scripts, CI pipelines, or clients that don't support OAuth, you can authenticate with a static API token. Generate one from the Research App under **Profile > API Tokens** or via `POST /api/v1/auth/tokens`.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "knowledge-tree": {
+      "url": "https://mcp.openktree.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_TOKEN"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+```json
+{
+  "mcpServers": {
+    "knowledge-tree": {
+      "type": "http",
+      "url": "https://mcp.openktree.com/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_API_TOKEN"
       }
@@ -32,23 +101,6 @@ Add the following to your Claude Desktop configuration file:
 
 Replace `YOUR_API_TOKEN` with the token from your profile page.
 
-## Claude Code
-
-Add to your Claude Code settings or project `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "knowledge-tree": {
-      "url": "https://mcp.openktree.com/sse",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_TOKEN"
-      }
-    }
-  }
-}
-```
-
 ## Local development
 
 If you're running the Knowledge Tree stack locally, the MCP server runs on port 8001:
@@ -57,26 +109,16 @@ If you're running the Knowledge Tree stack locally, the MCP server runs on port 
 {
   "mcpServers": {
     "knowledge-tree-local": {
-      "url": "http://localhost:8001/sse",
-      "headers": {
-        "Authorization": "Bearer YOUR_LOCAL_TOKEN"
-      }
+      "type": "http",
+      "url": "http://localhost:8001/mcp"
     }
   }
 }
 ```
 
-You can bypass authentication in development by setting `SKIP_AUTH=true` in the MCP server's environment.
+OAuth works the same way locally — you'll be prompted to log in at `http://localhost:8001/oauth/login`.
 
-## Other MCP clients
-
-Any client that supports the MCP SSE transport can connect. The server URL is:
-
-```
-https://mcp.openktree.com/sse
-```
-
-Pass the API token as a Bearer token in the `Authorization` header.
+You can bypass authentication entirely in development by setting `SKIP_AUTH=true` in the MCP server's environment.
 
 ## Verifying the connection
 

--- a/docs-site/docs/mcp/overview.md
+++ b/docs-site/docs/mcp/overview.md
@@ -30,7 +30,10 @@ All tools are **read-only** — they query the graph but never modify it.
 
 ## Authentication
 
-The MCP server uses **Bearer token authentication**. You generate an API token from the Research App's profile page, then include it in your MCP client configuration.
+The MCP server supports two authentication methods:
+
+- **OAuth 2.1 with PKCE (primary)** — The recommended method for interactive clients like Claude Desktop and Claude Web. Clients that support MCP OAuth handle the entire flow automatically — you just log in with your Knowledge Tree account when prompted. No manual token management required.
+- **API tokens (fallback)** — For scripts, non-interactive clients, or environments that don't support OAuth. Generate a token from the Research App's profile page and pass it as a Bearer token.
 
 ## Getting started
 

--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -19,7 +19,45 @@ just mcp-dev
 
 The server starts on `http://127.0.0.1:8001` with the MCP endpoint at `/mcp`.
 
-## Connecting Claude Code
+## Authentication
+
+The MCP server supports two authentication methods. OAuth 2.1 is the primary protocol; API tokens are available as a fallback for simpler clients.
+
+### OAuth 2.1 with PKCE (primary)
+
+The server implements a full OAuth 2.1 authorization flow with PKCE, designed for interactive clients like Claude Desktop and Claude Web. The flow is automatic for clients that support MCP OAuth — they discover endpoints, register, and handle the token exchange without manual configuration.
+
+**How it works:**
+
+1. The client discovers OAuth endpoints via `/.well-known/oauth-authorization-server`
+2. The client dynamically registers itself via `/register` (RFC 7591)
+3. The client redirects the user to `/authorize` with a PKCE code challenge
+4. The user authenticates at the login page (`/oauth/login`) with their email and password
+5. An authorization code is returned to the client's redirect URI
+6. The client exchanges the code + PKCE verifier for access and refresh tokens at `/token`
+7. The client uses the access token as a Bearer token for all MCP requests
+
+**Token lifetimes:**
+
+| Token | Lifetime |
+|---|---|
+| Authorization code | 5 minutes (single-use) |
+| Access token | 1 hour |
+| Refresh token | 30 days |
+
+Tokens are stored as SHA-256 hashes — plaintext is never persisted. Expired tokens are cleaned up automatically.
+
+**Connecting Claude Code (OAuth):**
+
+```bash
+claude mcp add --transport http --scope user knowledge-tree http://127.0.0.1:8001/mcp
+```
+
+Claude Code handles the OAuth flow automatically. You'll be prompted to log in on first use.
+
+### API tokens (fallback)
+
+For non-interactive clients, scripts, or environments that don't support OAuth, you can authenticate with a static API token. Generate one from the Research App under **Profile > API Tokens** or via the API (`POST /api/v1/auth/tokens`).
 
 ```bash
 claude mcp add --transport http --scope user knowledge-tree http://127.0.0.1:8001/mcp \
@@ -28,6 +66,10 @@ claude mcp add --transport http --scope user knowledge-tree http://127.0.0.1:800
 
 Verify with `/mcp` inside Claude Code.
 
-## Auth
+### Development
 
-All requests require a bearer token matching a valid entry in the `api_tokens` table. Create a token via the API (`POST /api/v1/auth/tokens`). Auth is bypassed when `SKIP_AUTH=true`.
+Auth is bypassed entirely when `SKIP_AUTH=true` is set in the environment.
+
+### Configuration
+
+Set `MCP_OAUTH_BASE_URL` to the public-facing URL of the MCP server (defaults to `http://localhost:8001`). This is used to construct OAuth redirect URLs.


### PR DESCRIPTION
## Summary
- Updated MCP docs to present OAuth 2.1 with PKCE as the primary authentication method
- Repositioned API tokens as a fallback for non-interactive clients (scripts, CI)
- Updated all connection examples from `/sse` to `/mcp` endpoint
- Added OAuth flow details (endpoint discovery, PKCE, token lifetimes) to the MCP README

## Files changed
- `services/mcp/README.md` — Expanded auth section with OAuth flow, token lifetimes, config
- `docs-site/docs/mcp/overview.md` — Auth section lists both methods with clear primary/fallback labels
- `docs-site/docs/mcp/connecting.md` — Restructured: OAuth first (just URL, no token), API tokens second

## Test plan
- [ ] Docs render correctly in the docs site
- [ ] OAuth connection examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)