### PR TITLE
fix(api,quickstart): address PR #71 review issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Knowledge Tree — Quickstart Environment
 #
 # Copy this file to .env and fill in your API keys:
-#   cp .env.quickstart .env
+#   cp .env.example .env
 #
 # At minimum you need OPENROUTER_API_KEY for LLM calls.
 # HATCHET_CLIENT_TOKEN is generated automatically on first startup.

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -191,8 +191,10 @@ services:
     environment:
       <<: *common-env
     depends_on:
-      api:
-        condition: service_started
+      hatchet:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -204,8 +206,10 @@ services:
     environment:
       <<: *common-env
     depends_on:
-      api:
-        condition: service_started
+      hatchet:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -217,8 +221,10 @@ services:
     environment:
       <<: *common-env
     depends_on:
-      api:
-        condition: service_started
+      hatchet:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -230,8 +236,10 @@ services:
     environment:
       <<: *common-env
     depends_on:
-      api:
-        condition: service_started
+      hatchet:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -243,8 +251,10 @@ services:
     environment:
       <<: *common-env
     depends_on:
-      api:
-        condition: service_started
+      hatchet:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:
@@ -256,8 +266,10 @@ services:
     environment:
       <<: *common-env
     depends_on:
-      api:
-        condition: service_started
+      hatchet:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     deploy:
       resources:
         limits:

--- a/scripts/quickstart-init.sh
+++ b/scripts/quickstart-init.sh
@@ -15,7 +15,14 @@ echo "==> Starting infrastructure..."
 docker compose -f "$COMPOSE_FILE" up -d postgres postgres-write pgbouncer-write redis qdrant hatchet-db hatchet
 
 echo "==> Waiting for Hatchet to be ready..."
+RETRIES=0
+MAX_RETRIES=30
 until docker compose -f "$COMPOSE_FILE" exec -T hatchet wget -q --spider http://localhost:8080/api/live 2>/dev/null; do
+    RETRIES=$((RETRIES + 1))
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+        echo "ERROR: Hatchet not ready after 60 seconds"
+        exit 1
+    fi
     sleep 2
 done
 
@@ -30,8 +37,9 @@ if [ -z "$TOKEN" ]; then
 fi
 
 # Update .env — replace existing line or append
+# Use a temp file for portability (sed -i behaves differently on macOS)
 if grep -q '^HATCHET_CLIENT_TOKEN=' .env 2>/dev/null; then
-    sed -i "s|^HATCHET_CLIENT_TOKEN=.*|HATCHET_CLIENT_TOKEN=${TOKEN}|" .env
+    sed "s|^HATCHET_CLIENT_TOKEN=.*|HATCHET_CLIENT_TOKEN=${TOKEN}|" .env > .env.tmp && mv .env.tmp .env
 else
     echo "HATCHET_CLIENT_TOKEN=${TOKEN}" >> .env
 fi

--- a/services/api/src/kt_api/auth/manager.py
+++ b/services/api/src/kt_api/auth/manager.py
@@ -78,8 +78,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         if user_count == 1:
             user.is_superuser = True
             session.add(user)
-            await session.commit()
             logger.info("First user %s auto-promoted to admin", user.email)
+
+        # fastapi-users commits user creation in its own transaction, so any
+        # changes made here (invite redemption, admin promotion) are in a new
+        # implicit transaction that must be committed explicitly.
+        await session.commit()
 
 
 async def get_user_manager(user_db=Depends(get_user_db)) -> AsyncGenerator[UserManager, None]:


### PR DESCRIPTION
## Summary

- **Fix invite redemption commit bug**: `session.commit()` was inside the `if user_count == 1` block, so invite redemptions for non-first users were never committed. Moved commit to end of `on_after_register` so both invite redemption and admin promotion are persisted.
- **Quickstart init script hardening**: Added timeout (60s) to the Hatchet readiness poll loop so it fails gracefully instead of spinning forever. Replaced `sed -i` with a portable temp-file pattern for macOS compatibility.
- **Worker dependency fix**: Workers depend on Hatchet (their actual dependency) + migrate, not on the API service.
- **Doc fix**: Corrected stale `cp .env.quickstart .env` reference in `.env.example`.

## Test plan

- [x] API tests pass (93/93, excluding 1 pre-existing failure)
- [ ] Verify invite redemption persists for non-first users
- [ ] Test quickstart-init.sh on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)