### PR TITLE
fix(helm): auto-derive MCP_OAUTH_BASE_URL from ingress host

### DIFF
--- a/helm/knowledge-tree/templates/mcp-deployment.yaml
+++ b/helm/knowledge-tree/templates/mcp-deployment.yaml
@@ -35,6 +35,10 @@ spec:
               protocol: TCP
           env:
             {{- include "knowledge-tree.sharedEnv" . | nindent 12 }}
+            {{- if .Values.mcp.ingress.enabled }}
+            - name: MCP_OAUTH_BASE_URL
+              value: "{{ if .Values.mcp.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.mcp.ingress.host }}"
+            {{- end }}
           volumeMounts:
             {{- include "knowledge-tree.configVolumeMount" . | nindent 12 }}
           livenessProbe:


### PR DESCRIPTION
## Summary

- Auto-set `MCP_OAUTH_BASE_URL` from the MCP ingress host when ingress is enabled
- Uses `https://` when TLS is configured, `http://` otherwise
- Fixes OAuth discovery advertising `http://localhost:8001` endpoints that external clients can't reach

## Test plan

- [ ] Verify MCP OAuth metadata at `/.well-known/oauth-authorization-server` returns `https://mcp.openktree.com` URLs
- [ ] Verify Claude Desktop can complete OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)