### PR TITLE
fix(mcp): serialize AnyUrl in OAuth client registration

### DIFF
--- a/services/mcp/src/kt_mcp/oauth_provider.py
+++ b/services/mcp/src/kt_mcp/oauth_provider.py
@@ -93,6 +93,7 @@ class KnowledgeTreeOAuthProvider(OAuthProvider):
                 raise ValueError(f"Invalid scopes: {', '.join(invalid)}")
 
         metadata = client_info.model_dump(
+            mode="json",
             exclude={"client_id", "client_secret", "client_id_issued_at", "client_secret_expires_at"},
             exclude_none=True,
         )


### PR DESCRIPTION
## Summary
- Fix `TypeError: Object of type AnyUrl is not JSON serializable` when Claude registers as an OAuth client via `POST /register`
- Add `mode="json"` to `model_dump()` in `register_client` so Pydantic `AnyUrl` fields (like `redirect_uris`) are converted to plain strings before storing in the JSONB column

## Root cause
The MCP SDK's `OAuthClientInformationFull` model uses `AnyUrl` for fields like `redirect_uris`. When `model_dump()` is called without `mode="json"`, these remain as `AnyUrl` objects which SQLAlchemy's JSON serializer can't handle.

## Test plan
- [x] All 36 MCP OAuth tests pass
- [ ] Verify Claude Web can complete OAuth registration after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)