### PR TITLE
fix(mcp): add unique() for User query in OAuth login

### DIFF
--- a/services/mcp/src/kt_mcp/oauth_login.py
+++ b/services/mcp/src/kt_mcp/oauth_login.py
@@ -166,7 +166,7 @@ async def login_submit(
 
         # Verify user credentials
         result = await session.execute(select(User).where(User.email == email))
-        user = result.scalar_one_or_none()
+        user = result.unique().scalar_one_or_none()
 
         if user is None or not _verify_password(password, user.hashed_password):
             _record_failed_attempt(client_ip)

--- a/services/mcp/tests/test_oauth.py
+++ b/services/mcp/tests/test_oauth.py
@@ -725,7 +725,7 @@ class TestLoginFlow:
         user.is_active = True
 
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
+        mock_result.unique.return_value.scalar_one_or_none.return_value = user
 
         session = _make_mock_session()
         session.get = AsyncMock(return_value=row)
@@ -773,7 +773,7 @@ class TestLoginFlow:
         user.is_active = True
 
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
+        mock_result.unique.return_value.scalar_one_or_none.return_value = user
 
         session = _make_mock_session()
         session.get = AsyncMock(return_value=row)
@@ -807,7 +807,7 @@ class TestLoginFlow:
         user.is_active = False
 
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = user
+        mock_result.unique.return_value.scalar_one_or_none.return_value = user
 
         session = _make_mock_session()
         session.get = AsyncMock(return_value=row)


### PR DESCRIPTION
## Summary
- Fix `InvalidRequestError: The unique() method must be invoked on this Result` crash during OAuth login
- The `User` model has `oauth_accounts` with `lazy="joined"`, which requires `.unique()` before `.scalar_one_or_none()`

## Test plan
- [x] All 14 login-related OAuth tests pass
- [ ] Verify OAuth login flow completes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)