### PR TITLE
fix(mcp): use pwdlib for password verification to match argon2id hashes

### DIFF
--- a/services/mcp/pyproject.toml
+++ b/services/mcp/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi>=0.129.0",
     "uvicorn>=0.40.0",
     "kt-auth",
+    "pwdlib[argon2,bcrypt]>=0.3.0",
 ]
 
 [build-system]

--- a/services/mcp/src/kt_mcp/oauth_login.py
+++ b/services/mcp/src/kt_mcp/oauth_login.py
@@ -16,7 +16,6 @@ import secrets
 import time
 from collections import defaultdict
 
-import bcrypt
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from mcp.server.auth.provider import construct_redirect_uri
@@ -215,8 +214,13 @@ async def login_submit(
 
 
 def _verify_password(plain: str, hashed: str) -> bool:
-    """Verify a password against a bcrypt hash (same algorithm as fastapi-users)."""
+    """Verify a password hash using pwdlib (supports argon2id and bcrypt, matching fastapi-users)."""
+    from pwdlib import PasswordHash
+    from pwdlib.hashers.argon2 import Argon2Hasher
+    from pwdlib.hashers.bcrypt import BcryptHasher
+
+    ph = PasswordHash((Argon2Hasher(), BcryptHasher()))
     try:
-        return bcrypt.checkpw(plain.encode(), hashed.encode())
-    except (ValueError, TypeError):
+        return ph.verify(plain, hashed)
+    except Exception:
         return False

--- a/services/mcp/tests/test_oauth.py
+++ b/services/mcp/tests/test_oauth.py
@@ -7,13 +7,15 @@ import secrets
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import bcrypt
 import pytest
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
 
 
 def _hash_password(plain: str) -> str:
-    """Hash a password with bcrypt (matching fastapi-users format)."""
-    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
+    """Hash a password with argon2id (matching fastapi-users format)."""
+    ph = PasswordHash((Argon2Hasher(),))
+    return ph.hash(plain)
 
 
 def _hash_token(token: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -1629,7 +1629,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-tree-workspace"
-version = "0.18.1"
+version = "0.20.3"
 source = { virtual = "." }
 
 [package.dev-dependencies]
@@ -1880,6 +1880,7 @@ dependencies = [
     { name = "kt-db" },
     { name = "kt-graph" },
     { name = "kt-qdrant" },
+    { name = "pwdlib", extra = ["argon2", "bcrypt"] },
     { name = "uvicorn" },
 ]
 
@@ -1892,6 +1893,7 @@ requires-dist = [
     { name = "kt-db", editable = "libs/kt-db" },
     { name = "kt-graph", editable = "libs/kt-graph" },
     { name = "kt-qdrant", editable = "libs/kt-qdrant" },
+    { name = "pwdlib", extras = ["argon2", "bcrypt"], specifier = ">=0.3.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
 


### PR DESCRIPTION
## Summary
- MCP OAuth login was using raw `bcrypt.checkpw()` but fastapi-users stores passwords as **argon2id** hashes, causing all login attempts to fail with 401
- Replaced bcrypt with `pwdlib[argon2,bcrypt]` which supports both hash formats, matching what fastapi-users uses internally
- Updated tests to hash passwords with argon2id instead of bcrypt

## Test plan
- [x] All 76 MCP tests pass (`pytest services/mcp/tests/ -x -v`)
- [ ] Deploy to prod and verify MCP OAuth login works at https://mcp.openktree.com/

🤖 Generated with [Claude Code](https://claude.com/claude-code)