### PR TITLE
fix(worker-sync): fix SQL syntax error in node stats refresh

### DIFF
--- a/services/worker-sync/src/kt_worker_sync/sync_engine.py
+++ b/services/worker-sync/src/kt_worker_sync/sync_engine.py
@@ -206,7 +206,7 @@ class SyncEngine:
                 UPDATE nodes SET fact_count = COALESCE(sub.cnt, 0)
                 FROM (
                     SELECT u.id AS node_id, COUNT(nf.fact_id) AS cnt
-                    FROM UNNEST(:ids::uuid[]) AS u(id)
+                    FROM UNNEST(CAST(:ids AS uuid[])) AS u(id)
                     LEFT JOIN node_facts nf ON nf.node_id = u.id
                     GROUP BY u.id
                 ) sub
@@ -223,7 +223,7 @@ class SyncEngine:
                 UPDATE nodes SET edge_count = COALESCE(sub.cnt, 0)
                 FROM (
                     SELECT u.id AS node_id, COALESCE(SUM(e.cnt), 0)::int AS cnt
-                    FROM UNNEST(:ids::uuid[]) AS u(id)
+                    FROM UNNEST(CAST(:ids AS uuid[])) AS u(id)
                     LEFT JOIN (
                         SELECT source_node_id AS node_id, COUNT(*) AS cnt
                         FROM edges WHERE source_node_id = ANY(:ids)
@@ -248,7 +248,7 @@ class SyncEngine:
                 UPDATE nodes SET child_count = COALESCE(sub.cnt, 0)
                 FROM (
                     SELECT u.id AS node_id, COUNT(c.id) AS cnt
-                    FROM UNNEST(:ids::uuid[]) AS u(id)
+                    FROM UNNEST(CAST(:ids AS uuid[])) AS u(id)
                     LEFT JOIN nodes c ON c.parent_id = u.id
                     GROUP BY u.id
                 ) sub
@@ -265,7 +265,7 @@ class SyncEngine:
                 UPDATE nodes SET dimension_count = COALESCE(sub.cnt, 0)
                 FROM (
                     SELECT u.id AS node_id, COUNT(d.id) AS cnt
-                    FROM UNNEST(:ids::uuid[]) AS u(id)
+                    FROM UNNEST(CAST(:ids AS uuid[])) AS u(id)
                     LEFT JOIN dimensions d ON d.node_id = u.id
                     GROUP BY u.id
                 ) sub


### PR DESCRIPTION
## Summary

- Fix `syntax error at or near ":"` in `_refresh_node_stats`
- asyncpg can't parse `:ids::uuid[]` — the `::` cast after a bind param is ambiguous
- Replace with `CAST(:ids AS uuid[])` which is unambiguous

## Test plan

- [x] SQL syntax is valid PostgreSQL
- [ ] Verify sync worker completes write_nodes sync without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)