### PR TITLE
feat(helm): add email configuration to Helm chart

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -187,6 +187,15 @@ Outputs a list of env var definitions.
     secretKeyRef:
       name: {{ include "knowledge-tree.secretName" . }}
       key: google-oauth-client-secret
+- name: RESEND_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "knowledge-tree.secretName" . }}
+      key: resend-api-key
+- name: EMAIL_ENABLED
+  value: {{ .Values.email.enabled | quote }}
+- name: EMAIL_FROM_ADDRESS
+  value: {{ .Values.email.fromAddress | quote }}
 - name: CONFIG_PATH
   value: /app/config.yaml
 {{- end }}

--- a/helm/knowledge-tree/templates/secret.yaml
+++ b/helm/knowledge-tree/templates/secret.yaml
@@ -40,4 +40,5 @@ stringData:
   hatchet-admin-email: {{ $hatchetAdminEmail | quote }}
   hatchet-admin-password: {{ $hatchetAdminPassword | quote }}
   api-token: {{ .Values.secrets.apiToken | quote }}
+  resend-api-key: {{ .Values.secrets.resendApiKey | quote }}
 {{- end }}

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -41,6 +41,13 @@ secrets:
   hatchetAdminEmail: ""
   hatchetAdminPassword: ""
 
+  resendApiKey: ""
+
+# -- Email configuration
+email:
+  enabled: false
+  fromAddress: ""
+
 # =============================================================================
 # CloudNativePG Databases
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add `RESEND_API_KEY` (from secret), `EMAIL_ENABLED`, and `EMAIL_FROM_ADDRESS` env vars to the shared env template
- Add `resend-api-key` to the secret template  
- Add `email.enabled` and `email.fromAddress` to values.yaml with safe defaults (disabled)

Per-environment from addresses and enable flags are set via infra repo kustomization patches.

## Test plan
- [ ] Verify helm template renders correctly with email values
- [ ] Verify dev and prod deployments pick up the new env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)