### PR TITLE
refactor(helm): scope email config by provider

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -187,15 +187,19 @@ Outputs a list of env var definitions.
     secretKeyRef:
       name: {{ include "knowledge-tree.secretName" . }}
       key: google-oauth-client-secret
+{{- if eq (.Values.email.provider | default "") "resend" }}
+- name: EMAIL_ENABLED
+  value: "true"
+- name: EMAIL_PROVIDER
+  value: "resend"
+- name: EMAIL_FROM_ADDRESS
+  value: {{ .Values.email.resend.fromAddress | quote }}
 - name: RESEND_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ include "knowledge-tree.secretName" . }}
       key: resend-api-key
-- name: EMAIL_ENABLED
-  value: {{ .Values.email.enabled | quote }}
-- name: EMAIL_FROM_ADDRESS
-  value: {{ .Values.email.fromAddress | quote }}
+{{- end }}
 - name: CONFIG_PATH
   value: /app/config.yaml
 {{- end }}

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -43,10 +43,11 @@ secrets:
 
   resendApiKey: ""
 
-# -- Email configuration
+# -- Email configuration (provider-scoped)
 email:
-  enabled: false
-  fromAddress: ""
+  provider: ""  # set to "resend" to enable
+  resend:
+    fromAddress: ""
 
 # =============================================================================
 # CloudNativePG Databases


### PR DESCRIPTION
## Summary
- Gate email env vars behind `email.provider == "resend"` check
- When provider is empty (default), no email env vars are injected at all
- Provider-specific config lives under `email.resend.*`, making it easy to add future providers (e.g. `email.sendgrid.*`)
- Replaces the flat `email.enabled` / `email.fromAddress` from #105

## Test plan
- [ ] Verify no email env vars when `email.provider` is unset
- [ ] Verify email env vars injected when `email.provider: "resend"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)