### PR TITLE
fix(helm): nil-safe access for nested email.resend config

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -193,7 +193,7 @@ Outputs a list of env var definitions.
 - name: EMAIL_PROVIDER
   value: "resend"
 - name: EMAIL_FROM_ADDRESS
-  value: {{ .Values.email.resend.fromAddress | quote }}
+  value: {{ ((.Values.email).resend).fromAddress | default "" | quote }}
 - name: RESEND_API_KEY
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
## Summary
- Prevent template error when `email.provider` is set but `email.resend` section is missing
- Triggers a patch release so the provider-scoped email config (from #106) gets deployed

## Test plan
- [ ] Verify helm template renders without error when email.resend is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)