### PR TITLE
fix(worker-search): persist fetch error on reingest failure

### DIFF
--- a/services/worker-search/src/kt_worker_search/workflows/decompose.py
+++ b/services/worker-search/src/kt_worker_search/workflows/decompose.py
@@ -606,6 +606,8 @@ async def reingest_source_task(input: ReingestSourceInput, ctx: Context) -> dict
         if not result.success:
             message = f"Failed to fetch source content: {result.error}"
             ctx.log(message)
+            await write_source_repo.mark_fetch_attempted(source.id, error=result.error)
+            await write_session.commit()
             return ReingestSourceOutput(message=message).model_dump()
 
         # Step 2: Force-update content (bypass hash dedup)
@@ -625,6 +627,7 @@ async def reingest_source_task(input: ReingestSourceInput, ctx: Context) -> dict
             values["content_type"] = result.content_type
 
         await write_session.execute(sa_update(WriteRawSource).where(WriteRawSource.id == source.id).values(**values))
+        await write_source_repo.mark_fetch_attempted(source.id, error=None)
         await write_session.commit()
         content_updated = True
         ctx.log("Source content updated, starting decomposition")


### PR DESCRIPTION
## Summary
- `reingest_source_task` now calls `mark_fetch_attempted()` on both success and failure paths
- Previously, when fetch failed (e.g. Facebook video pages that trafilatura can't extract), the source's `fetch_error` and `fetch_attempted` fields were never updated — the UI showed no indication of failure
- Also marks successful fetches so `fetch_attempted=True` is set after reingest

Fixes the issue where reingesting `https://www.facebook.com/WSMVTV/videos/...` silently failed with "Extraction produced insufficient content" but the source showed only a snippet with no error.

## Test plan
- [ ] Reingest a source that fails to fetch — verify `fetch_error` is set in DB
- [ ] Reingest a source that succeeds — verify `fetch_attempted=True`, `fetch_error=None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)