### PR TITLE
fix(kt-db): correct column name in w034 migration

### DIFF
--- a/libs/kt-db/alembic_write/versions/w034_deterministic_source_ids.py
+++ b/libs/kt-db/alembic_write/versions/w034_deterministic_source_ids.py
@@ -69,7 +69,7 @@ def upgrade() -> None:
     # Step 3: Reset sync watermarks so sync rebuilds graph-db with new IDs
     conn.execute(
         text("""
-        UPDATE sync_watermarks SET watermark = '1970-01-01'
+        UPDATE sync_watermarks SET last_synced_at = '1970-01-01'
         WHERE table_name IN ('write_raw_sources', 'write_fact_sources')
     """)
     )


### PR DESCRIPTION
## Summary
- Fix `UndefinedColumnError` in w034 migration: `sync_watermarks` column is `last_synced_at`, not `watermark`
- This is blocking prod deployment — migration job crashes on every Helm upgrade attempt
- Graph-db migration (zzah) already applied; sources deleted and waiting for sync rebuild

## Urgency
**Prod is degraded** — graph-db sources were cleared by zzah but w034 can't complete to reset watermarks and re-ID write-db sources. Sync worker can't rebuild until this lands.

## Test plan
- [ ] CI passes
- [ ] After merge+deploy: w034 migration completes successfully
- [ ] Sync worker rebuilds graph-db sources with deterministic IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)