### PR TITLE
fix(kt-graph): fall back to write-db in search_nodes when graph-db unavailable

### DIFF
--- a/libs/kt-graph/src/kt_graph/engine.py
+++ b/libs/kt-graph/src/kt_graph/engine.py
@@ -182,6 +182,34 @@ class GraphEngine:
             self._require_graph_session()  # will raise
         return self._fact_repo  # type: ignore[return-value]
 
+    @staticmethod
+    def _write_node_to_node(wn: Any, **overrides: Any) -> Node:
+        """Convert a WriteNode to a graph-db Node model instance.
+
+        Centralises the WriteNode → Node mapping so every call-site stays
+        consistent.  Pass ``**overrides`` to replace specific fields (e.g.
+        ``metadata_=custom_meta``).
+        """
+        from kt_db.keys import key_to_uuid
+
+        fields: dict[str, Any] = {
+            "id": wn.node_uuid,
+            "concept": wn.concept,
+            "node_type": wn.node_type,
+            "entity_subtype": wn.entity_subtype,
+            "parent_id": key_to_uuid(wn.parent_key) if wn.parent_key else None,
+            "stale_after": wn.stale_after,
+            "definition": wn.definition,
+            "definition_source": wn.definition_source,
+            "metadata_": wn.metadata_,
+            "access_count": 0,
+            "update_count": 0,
+            "created_at": wn.created_at,
+            "updated_at": wn.updated_at,
+        }
+        fields.update(overrides)
+        return Node(**fields)
+
     async def _get_cached_or_db(self, node_id: uuid.UUID) -> Node | None:
         """Look up a node from cache, then write-db, then graph-db.
 
@@ -195,20 +223,7 @@ class GraphEngine:
         if self._write_node_repo is not None:
             wn = await self._write_node_repo.get_by_uuid(node_id)
             if wn is not None:
-                from kt_db.keys import key_to_uuid
-
-                parent_id = key_to_uuid(wn.parent_key) if wn.parent_key else None
-                return Node(
-                    id=wn.node_uuid,
-                    concept=wn.concept,
-                    node_type=wn.node_type,
-                    definition=wn.definition,
-                    metadata_=wn.metadata_,
-                    parent_id=parent_id,
-                    stale_after=wn.stale_after,
-                    created_at=wn.created_at,
-                    updated_at=wn.updated_at,
-                )
+                return self._write_node_to_node(wn)
         if self._node_repo is not None:
             return await self._node_repo.get_by_id(node_id)
         return None
@@ -451,13 +466,7 @@ class GraphEngine:
             if wn is not None:
                 await self._write_node_repo.update_metadata(wn.key, kwargs["metadata_"])  # type: ignore[arg-type]
                 await self._write_session.commit()  # type: ignore[union-attr]
-                return Node(
-                    id=wn.node_uuid,
-                    concept=wn.concept,
-                    node_type=wn.node_type,
-                    definition=wn.definition,
-                    metadata_=kwargs["metadata_"],  # type: ignore[arg-type]
-                )
+                return self._write_node_to_node(wn, metadata_=kwargs["metadata_"])
         await self._node_repo.update_fields(node_id, **kwargs)
         node = await self._node_repo.get_by_id(node_id)
         if node is None:
@@ -481,26 +490,8 @@ class GraphEngine:
             return await self._node_repo.search_by_concept(query, limit=limit, node_type=node_type)
 
         if self._write_node_repo is not None:
-            from kt_db.keys import key_to_uuid
-
             write_nodes = await self._write_node_repo.search_by_trigram(query, limit=limit, node_type=node_type)
-            return [
-                Node(
-                    id=wn.node_uuid,
-                    concept=wn.concept,
-                    node_type=wn.node_type,
-                    entity_subtype=wn.entity_subtype,
-                    parent_id=key_to_uuid(wn.parent_key) if wn.parent_key else None,
-                    stale_after=wn.stale_after,
-                    definition=wn.definition,
-                    definition_source=wn.definition_source,
-                    access_count=0,
-                    update_count=0,
-                    created_at=wn.created_at,
-                    updated_at=wn.updated_at,
-                )
-                for wn in write_nodes
-            ]
+            return [self._write_node_to_node(wn) for wn in write_nodes]
 
         raise ValueError("search_nodes requires either a graph-db or write-db session")
 
@@ -721,16 +712,7 @@ class GraphEngine:
             parent_wn = await self._write_node_repo.get_by_uuid(parent_id)
             if parent_wn is not None:
                 children_wn = await self._write_node_repo.get_children_by_parent_key(parent_wn.key)
-                return [
-                    Node(
-                        id=wn.node_uuid,
-                        concept=wn.concept,
-                        node_type=wn.node_type,
-                        definition=wn.definition,
-                        metadata_=wn.metadata_,
-                    )
-                    for wn in children_wn
-                ]
+                return [self._write_node_to_node(wn) for wn in children_wn]
             return []
         return await self._node_repo.get_children(parent_id)
 
@@ -780,7 +762,7 @@ class GraphEngine:
         """
         if self._write_node_repo is not None:
             write_nodes = await self._write_node_repo.get_by_uuids(node_ids)
-            return [Node(id=wn.node_uuid, concept=wn.concept, node_type=wn.node_type) for wn in write_nodes]
+            return [self._write_node_to_node(wn) for wn in write_nodes]
         return await self._node_repo.get_by_ids(node_ids)
 
     async def delete_edge(self, edge_id: uuid.UUID) -> bool:
@@ -1480,9 +1462,7 @@ class GraphEngine:
                     _WN.node_type == "perspective",
                 )
                 result = await self._write_session.execute(stmt)  # type: ignore[union-attr]
-                return [
-                    Node(id=wn.node_uuid, concept=wn.concept, node_type=wn.node_type) for wn in result.scalars().all()
-                ]
+                return [self._write_node_to_node(wn) for wn in result.scalars().all()]
             return []
         return await self._node_repo.get_perspectives_for_concept(concept_node_id)
 
@@ -1701,28 +1681,13 @@ class GraphEngine:
         during concurrent pipeline fan-out.
         """
         if self._write_node_repo is not None:
-            from kt_db.keys import key_to_uuid
-
             write_nodes = await self._write_node_repo.search_by_trigram(
                 query,
                 threshold=threshold,
                 limit=limit,
                 node_type=node_type,
             )
-            return [
-                Node(
-                    id=wn.node_uuid,
-                    concept=wn.concept,
-                    node_type=wn.node_type,
-                    definition=wn.definition,
-                    metadata_=wn.metadata_,
-                    parent_id=key_to_uuid(wn.parent_key) if wn.parent_key else None,
-                    stale_after=wn.stale_after,
-                    created_at=wn.created_at,
-                    updated_at=wn.updated_at,
-                )
-                for wn in write_nodes
-            ]
+            return [self._write_node_to_node(wn) for wn in write_nodes]
         return await self._require_node_repo().search_by_trigram(
             query,
             threshold=threshold,

--- a/libs/kt-graph/tests/test_write_node_conversion.py
+++ b/libs/kt-graph/tests/test_write_node_conversion.py
@@ -1,0 +1,93 @@
+"""Unit tests for WriteNode → Node conversion in GraphEngine."""
+
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kt_graph.engine import GraphEngine
+
+
+def _make_write_node(**overrides):
+    """Create a mock WriteNode with sensible defaults."""
+    defaults = {
+        "node_uuid": uuid.uuid4(),
+        "concept": "test concept",
+        "node_type": "concept",
+        "entity_subtype": None,
+        "parent_key": None,
+        "stale_after": 30,
+        "definition": "A test definition",
+        "definition_source": "test",
+        "metadata_": {"key": "value"},
+        "created_at": datetime(2026, 1, 1),
+        "updated_at": datetime(2026, 1, 2),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+class TestWriteNodeToNode:
+    def test_basic_conversion(self):
+        wn = _make_write_node()
+        node = GraphEngine._write_node_to_node(wn)
+
+        assert node.id == wn.node_uuid
+        assert node.concept == wn.concept
+        assert node.node_type == wn.node_type
+        assert node.entity_subtype == wn.entity_subtype
+        assert node.parent_id is None
+        assert node.stale_after == wn.stale_after
+        assert node.definition == wn.definition
+        assert node.definition_source == wn.definition_source
+        assert node.metadata_ == wn.metadata_
+        assert node.access_count == 0
+        assert node.update_count == 0
+        assert node.created_at == wn.created_at
+        assert node.updated_at == wn.updated_at
+
+    def test_parent_key_resolves_to_uuid(self):
+        wn = _make_write_node(parent_key="concept:parent-topic")
+        node = GraphEngine._write_node_to_node(wn)
+
+        assert node.parent_id is not None
+        # key_to_uuid is deterministic — same key always produces same UUID
+        from kt_db.keys import key_to_uuid
+
+        assert node.parent_id == key_to_uuid("concept:parent-topic")
+
+    def test_overrides_applied(self):
+        wn = _make_write_node(metadata_={"original": True})
+        node = GraphEngine._write_node_to_node(wn, metadata_={"overridden": True})
+
+        assert node.metadata_ == {"overridden": True}
+
+
+class TestSearchNodesFallback:
+    @pytest.mark.asyncio
+    async def test_falls_back_to_write_db(self):
+        """search_nodes uses write-db when graph-db session is None."""
+        wn = _make_write_node(concept="sleep")
+
+        mock_write_node_repo = AsyncMock()
+        mock_write_node_repo.search_by_trigram.return_value = [wn]
+
+        engine = GraphEngine(session=None, write_session=None)
+        engine._write_node_repo = mock_write_node_repo
+
+        nodes = await engine.search_nodes("sleep", limit=5)
+
+        mock_write_node_repo.search_by_trigram.assert_awaited_once_with("sleep", limit=5, node_type=None)
+        assert len(nodes) == 1
+        assert nodes[0].concept == "sleep"
+        assert nodes[0].id == wn.node_uuid
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_session_available(self):
+        """search_nodes raises ValueError when neither DB is available."""
+        engine = GraphEngine(session=None, write_session=None)
+
+        with pytest.raises(ValueError, match="requires either a graph-db or write-db session"):
+            await engine.search_nodes("anything")


### PR DESCRIPTION
## Summary
- The bottom-up worker's `_open_sessions` yields `session=None` to avoid holding long-lived graph-db connections during pipelines, but `GraphEngine.search_nodes` unconditionally called `_node_repo.search_by_concept()` which is `None` without a graph-db session
- Added write-db fallback using existing `WriteNodeRepository.search_by_trigram`, converting `WriteNode` results to `Node` objects — matches the pattern already used by `get_node_facts` and `get_dimensions`

## Test plan
- [ ] Verify bottom-up scout no longer crashes with `AttributeError: 'NoneType' object has no attribute 'search_by_concept'`
- [ ] Verify graph search matches are returned correctly in scout results
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)