### PR TITLE
chore: update Claude model to Sonnet 4.6

### DIFF
--- a/frontend/src/config/model-pricing.json
+++ b/frontend/src/config/model-pricing.json
@@ -8,11 +8,7 @@
       "inputPerMillion": 0.30,
       "outputPerMillion": 0.50
     },
-    "openrouter/anthropic/claude-3.5-sonnet": {
-      "inputPerMillion": 3.00,
-      "outputPerMillion": 15.00
-    },
-    "openrouter/anthropic/claude-sonnet-4": {
+    "openrouter/anthropic/claude-sonnet-4.6": {
       "inputPerMillion": 3.00,
       "outputPerMillion": 15.00
     },

--- a/frontend/src/lib/__tests__/cost-estimator.test.ts
+++ b/frontend/src/lib/__tests__/cost-estimator.test.ts
@@ -12,7 +12,7 @@ function makeModel(model_id: string): ModelConfig {
 
 const DEFAULT_MODELS: ModelConfig[] = [
   makeModel("openrouter/x-ai/grok-4.1-fast"),
-  makeModel("openrouter/anthropic/claude-3.5-sonnet"),
+  makeModel("openrouter/anthropic/claude-sonnet-4.6"),
 ];
 
 const SAMPLE_ROLES: ModelRoles = {
@@ -43,7 +43,7 @@ describe("estimateCost", () => {
     expect(result.breakdown.model_calls).toBeGreaterThan(0);
     expect(result.models).toEqual([
       "openrouter/x-ai/grok-4.1-fast",
-      "openrouter/anthropic/claude-3.5-sonnet",
+      "openrouter/anthropic/claude-sonnet-4.6",
     ]);
     // Should have categories
     expect(result.categories.length).toBeGreaterThan(0);

--- a/services/api/src/kt_api/config_api.py
+++ b/services/api/src/kt_api/config_api.py
@@ -22,9 +22,9 @@ async def get_models() -> list[dict[str, Any]]:
             "display_name": "Grok 4.1 Fast",
         },
         {
-            "model_id": "openrouter/anthropic/claude-3.5-sonnet",
+            "model_id": "openrouter/anthropic/claude-sonnet-4.6",
             "provider": "openrouter",
-            "display_name": "Claude 3.5 Sonnet",
+            "display_name": "Claude Sonnet 4.6",
         },
         {
             "model_id": "openrouter/openai/gpt-4o-mini",


### PR DESCRIPTION
## Summary
- Replace Claude 3.5 Sonnet (`claude-3.5-sonnet`) and Claude Sonnet 4 (`claude-sonnet-4`) with Claude Sonnet 4.6 (`claude-sonnet-4.6`)
- Updated in API model list, frontend pricing config, and cost estimator tests

## Test plan
- [x] Frontend tests pass (cost-estimator, all 123 tests green)
- [x] Frontend lint and typecheck pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)