### PR TITLE
fix(wiki): stack investigation links on mobile for tappability

### DIFF
--- a/wiki-frontend/src/styles/global.css
+++ b/wiki-frontend/src/styles/global.css
@@ -2312,6 +2312,25 @@ a.fact-group-title:hover {
 
   .index-search-form { max-width: 100%; }
 
+  /* ── Mobile: Stack link + meta on separate lines so links are tappable ── */
+  .node-flat-list li {
+    flex-wrap: wrap;
+  }
+
+  .node-flat-list li .node-flat-link {
+    flex-basis: 100%;
+    white-space: normal;
+  }
+
+  .synthesis-group-children li {
+    flex-wrap: wrap;
+  }
+
+  .synthesis-group-children li .node-flat-link {
+    flex-basis: 100%;
+    white-space: normal;
+  }
+
   /* ── Mobile: Prevent horizontal overflow ── */
   html, body {
     overflow-x: hidden;


### PR DESCRIPTION
## Summary
- On mobile (<720px), investigation links in the All Knowledge view were untappable because the link, sentence count, and date shared a single flex row — the link truncated to near-zero width
- Wraps the flex container at the 720px breakpoint so the link gets its own full-width line, with metadata below

## Test plan
- [ ] Open wiki All Knowledge page on a mobile viewport (~375px width)
- [ ] Verify investigation links are fully visible and tappable
- [ ] Verify grouped synthesis children links are also tappable
- [ ] Confirm desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)