### PR TITLE
feat(frontend): add markdown table rendering support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-cytoscapejs": "^2.0.0",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.3)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2739,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-config-next@16.1.6:
     resolution: {integrity: sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==}
     peerDependencies:
@@ -3634,12 +3641,36 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -3685,6 +3716,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -4186,11 +4238,17 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7561,6 +7619,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.6
@@ -8545,7 +8605,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -8561,6 +8630,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8665,6 +8791,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -9307,6 +9491,17 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -9323,6 +9518,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 

--- a/frontend/src/components/synthesis/ExportPDF.tsx
+++ b/frontend/src/components/synthesis/ExportPDF.tsx
@@ -252,6 +252,9 @@ function buildExportHTML(
   sup.fact-ref a:hover { text-decoration: underline; }
   ul, ol { padding-left: 1.5rem; margin-bottom: 0.8rem; }
   li { margin-bottom: 0.3rem; }
+  table { width: 100%; border-collapse: collapse; font-size: 9.5pt; margin: 1rem 0; }
+  th { text-align: left; font-weight: 600; padding: 0.4rem 0.6rem; border-bottom: 2px solid #d4cdc2; background: #faf8f5; }
+  td { padding: 0.35rem 0.6rem; border-bottom: 1px solid #e8e3d8; vertical-align: top; }
   strong { font-weight: 700; }
   em { font-style: italic; }
   hr { border: none; border-top: 1px solid #d4cdc2; margin: 2rem 0; }
@@ -516,13 +519,32 @@ function markdownToHTML(md: string): string {
     }
   );
 
+  // Tables — convert pipe tables to HTML before paragraph wrapping
+  html = html.replace(
+    /(^\|.+\|$\n?)+/gm,
+    (match) => {
+      const lines = match.trim().split("\n").filter((l) => l.trim());
+      const dataLines = lines.filter(
+        (l) => !/^\|[\s:?-]+(\|[\s:?-]+)*\|$/.test(l.trim())
+      );
+      if (dataLines.length === 0) return match;
+      const parseRow = (line: string) =>
+        line.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim());
+      const headerCells = parseRow(dataLines[0]).map((c) => `<th>${c}</th>`).join("");
+      const bodyRows = dataLines.slice(1).map(
+        (line) => `<tr>${parseRow(line).map((c) => `<td>${c}</td>`).join("")}</tr>`
+      ).join("");
+      return `<table><thead><tr>${headerCells}</tr></thead><tbody>${bodyRows}</tbody></table>`;
+    }
+  );
+
   // Paragraphs — wrap lines not already in tags
   html = html
     .split("\n\n")
     .map((block) => {
       block = block.trim();
       if (!block) return "";
-      if (block.startsWith("<h") || block.startsWith("<ul") || block.startsWith("<ol") || block.startsWith("<hr")) {
+      if (block.startsWith("<h") || block.startsWith("<ul") || block.startsWith("<ol") || block.startsWith("<hr") || block.startsWith("<table")) {
         return block;
       }
       return `<p>${block.replace(/\n/g, " ")}</p>`;

--- a/frontend/src/components/synthesis/SynthesisDocument.tsx
+++ b/frontend/src/components/synthesis/SynthesisDocument.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
@@ -422,6 +423,34 @@ export function SynthesisDocument({ document }: SynthesisDocumentProps) {
           {children}
         </em>
       ),
+      table: ({ children }: { children?: React.ReactNode }) => (
+        <div className="overflow-x-auto my-4 -mx-1">
+          <table className="w-full border-collapse text-[0.88rem] leading-relaxed">
+            {children}
+          </table>
+        </div>
+      ),
+      thead: ({ children }: { children?: React.ReactNode }) => (
+        <thead className="border-b-2 border-border">{children}</thead>
+      ),
+      tbody: ({ children }: { children?: React.ReactNode }) => (
+        <tbody>{children}</tbody>
+      ),
+      tr: ({ children }: { children?: React.ReactNode }) => (
+        <tr className="border-b border-border/50 hover:bg-secondary/50">
+          {children}
+        </tr>
+      ),
+      th: ({ children }: { children?: React.ReactNode }) => (
+        <th className="text-left font-semibold text-foreground px-3 py-2 bg-secondary/50 whitespace-nowrap">
+          {children}
+        </th>
+      ),
+      td: ({ children }: { children?: React.ReactNode }) => (
+        <td className="px-3 py-2 text-foreground/85 align-top">
+          {children}
+        </td>
+      ),
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedParaKey, paragraphMap, getSectionInfo]
@@ -508,7 +537,7 @@ export function SynthesisDocument({ document }: SynthesisDocumentProps) {
         {/* Body */}
         <div className="mb-10">
           {hasDefinition ? (
-            <Markdown components={markdownComponents}>
+            <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
               {document.definition!}
             </Markdown>
           ) : (

--- a/wiki-frontend/src/lib/justification.ts
+++ b/wiki-frontend/src/lib/justification.ts
@@ -149,17 +149,52 @@ export function parseRichText(
   return segments;
 }
 
-/** A block of parsed markdown content (header, paragraph, or list item). */
+/** A block of parsed markdown content (header, paragraph, list item, or table). */
 export interface MarkdownBlock {
-  kind: "heading" | "paragraph" | "list-item";
+  kind: "heading" | "paragraph" | "list-item" | "table";
   level?: number; // 1-6 for headings
   segments: RichTextSegment[];
+  rawHtml?: string; // Pre-rendered HTML for table blocks
+}
+
+/** Check if a line looks like a markdown table row: | cell | cell | */
+function isTableLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith("|") && trimmed.endsWith("|") && trimmed.length > 1;
+}
+
+/** Check if a line is the separator row: |---|---|---| */
+function isTableSeparator(line: string): boolean {
+  return /^\|[\s:?-]+(\|[\s:?-]+)*\|$/.test(line.trim());
+}
+
+/** Parse accumulated table lines into an HTML <table> string. */
+function tableLinesToHtml(tableLines: string[]): string {
+  const rows = tableLines
+    .filter((l) => !isTableSeparator(l))
+    .map((l) =>
+      l
+        .trim()
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split("|")
+        .map((c) => c.trim())
+    );
+  if (rows.length === 0) return "";
+
+  const headerCells = rows[0].map((c) => `<th>${c}</th>`).join("");
+  const bodyRows = rows
+    .slice(1)
+    .map((row) => `<tr>${row.map((c) => `<td>${c}</td>`).join("")}</tr>`)
+    .join("");
+
+  return `<div class="table-scroll"><table><thead><tr>${headerCells}</tr></thead><tbody>${bodyRows}</tbody></table></div>`;
 }
 
 /**
- * Parse markdown text into blocks (headings and paragraphs) with rich text
- * segments inside each block. Handles #/##/### headings and groups
- * consecutive non-empty lines into paragraphs.
+ * Parse markdown text into blocks (headings, paragraphs, list items, and tables)
+ * with rich text segments inside each block. Handles #/##/### headings, pipe
+ * tables, and groups consecutive non-empty lines into paragraphs.
  */
 export function parseMarkdownBlocks(
   text: string | null | undefined
@@ -169,6 +204,7 @@ export function parseMarkdownBlocks(
   const lines = text.split("\n");
   const blocks: MarkdownBlock[] = [];
   let paragraphLines: string[] = [];
+  let tableLines: string[] = [];
 
   function flushParagraph() {
     if (paragraphLines.length === 0) return;
@@ -179,7 +215,26 @@ export function parseMarkdownBlocks(
     paragraphLines = [];
   }
 
+  function flushTable() {
+    if (tableLines.length === 0) return;
+    const rawHtml = tableLinesToHtml(tableLines);
+    if (rawHtml) {
+      blocks.push({ kind: "table", segments: [], rawHtml });
+    }
+    tableLines = [];
+  }
+
   for (const line of lines) {
+    if (isTableLine(line)) {
+      flushParagraph();
+      tableLines.push(line);
+      continue;
+    }
+
+    if (tableLines.length > 0) {
+      flushTable();
+    }
+
     const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
     const listMatch = line.match(/^(\s*)([-*]|\d+\.)\s+(.+)$/);
     if (headingMatch) {
@@ -202,6 +257,7 @@ export function parseMarkdownBlocks(
       paragraphLines.push(line);
     }
   }
+  flushTable();
   flushParagraph();
 
   return blocks;

--- a/wiki-frontend/src/pages/nodes/[id].astro
+++ b/wiki-frontend/src/pages/nodes/[id].astro
@@ -224,6 +224,8 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                         block.level === 1 ? <h2 class="perspective-h1"><RichSegments segments={block.segments} /></h2> :
                         block.level === 2 ? <h3 class="perspective-h2"><RichSegments segments={block.segments} /></h3> :
                         <h4 class="perspective-h3"><RichSegments segments={block.segments} /></h4>
+                      ) : block.kind === "table" ? (
+                        <Fragment set:html={block.rawHtml} />
                       ) : block.kind === "list-item" ? (
                         <li class="perspective-paragraph"><RichSegments segments={block.segments} /></li>
                       ) : (
@@ -238,6 +240,8 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                         block.level === 1 ? <h2><RichSegments segments={block.segments} /></h2> :
                         block.level === 2 ? <h3><RichSegments segments={block.segments} /></h3> :
                         <h4><RichSegments segments={block.segments} /></h4>
+                      ) : block.kind === "table" ? (
+                        <Fragment set:html={block.rawHtml} />
                       ) : block.kind === "list-item" ? (
                         <li><RichSegments segments={block.segments} /></li>
                       ) : (

--- a/wiki-frontend/src/pages/syntheses/[id].astro
+++ b/wiki-frontend/src/pages/syntheses/[id].astro
@@ -114,6 +114,9 @@ const blockMetas: BlockMeta[] = blocks.map((block) => {
                 </Tag>
               );
             }
+            if (block.kind === "table") {
+              return <Fragment set:html={block.rawHtml} />;
+            }
             if (block.kind === "list-item") {
               return (
                 <li class={blockCls} {...dataAttrs}>

--- a/wiki-frontend/src/styles/global.css
+++ b/wiki-frontend/src/styles/global.css
@@ -2494,6 +2494,48 @@ a.fact-group-title:hover {
   border-bottom-color: var(--ocean);
 }
 
+/* ── Markdown Tables ──────────────────────────────────────── */
+
+.table-scroll {
+  overflow-x: auto;
+  margin: 1rem 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+.synthesis-body table,
+.node-definition table,
+.perspective-definition table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+.synthesis-body th,
+.node-definition th,
+.perspective-definition th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 2px solid var(--color-border);
+  background: var(--color-surface-2);
+  white-space: nowrap;
+}
+
+.synthesis-body td,
+.node-definition td,
+.perspective-definition td {
+  padding: 0.45rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light);
+  vertical-align: top;
+}
+
+.synthesis-body tbody tr:hover,
+.node-definition tbody tr:hover,
+.perspective-definition tbody tr:hover {
+  background: var(--color-surface-2);
+}
+
 /* ── Synthesis List (Investigations Tab) ────────────────────── */
 
 .synthesis-meta {


### PR DESCRIPTION
## Summary
- Wiki frontend: extended custom `parseMarkdownBlocks()` parser to detect GFM pipe tables and emit `<table>` HTML, rendered via `set:html` in synthesis and node definition pages
- Main frontend: added `remark-gfm` plugin to `react-markdown` with styled `table`/`thead`/`tbody`/`tr`/`th`/`td` component overrides
- PDF export: added pipe-table-to-HTML conversion in `markdownToHTML()` + print-friendly table CSS

## Test plan
- [ ] View a synthesis with a markdown table in the wiki frontend — table renders with headers, borders, hover rows
- [ ] View the same synthesis in the main frontend — same table renders with Tailwind styling
- [ ] Export as PDF/HTML — table appears with print-friendly styling
- [ ] View a node definition containing a table in the wiki — renders correctly
- [ ] Check table horizontal scroll on mobile (narrow viewport)
- [ ] Verify non-table content (headings, paragraphs, lists) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)