### PR TITLE
fix(wiki): apply mobile link stacking to super-synthesis headers

### DIFF
--- a/wiki-frontend/src/styles/global.css
+++ b/wiki-frontend/src/styles/global.css
@@ -2331,6 +2331,15 @@ a.fact-group-title:hover {
     white-space: normal;
   }
 
+  .synthesis-group-header {
+    flex-wrap: wrap;
+  }
+
+  .synthesis-group-header .node-flat-link {
+    flex-basis: 100%;
+    white-space: normal;
+  }
+
   /* ── Mobile: Prevent horizontal overflow ── */
   html, body {
     overflow-x: hidden;


### PR DESCRIPTION
## Summary
- The previous mobile tappability fix (f30c68f) wrapped links in `.node-flat-list` and `.synthesis-group-children` so they get their own full-width line on mobile (<720px), making them tappable
- The `.synthesis-group-header` (super-synthesis row on the Investigations tab) was missed — its link, badge, and meta were still crammed on one flex row, causing the title to truncate and become untappable
- Adds the same `flex-wrap: wrap` + `flex-basis: 100%` treatment to `.synthesis-group-header`

## Test plan
- [ ] Open the wiki Investigations tab on a mobile viewport (<720px)
- [ ] Verify super-synthesis titles wrap to their own line and are tappable
- [ ] Verify sub-synthesis and standalone synthesis links still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)