### PR TITLE
fix(helm): preserve CNPG DB credentials across Helm upgrades

### DIFF
--- a/helm/knowledge-tree/templates/cnpg-graph-db.yaml
+++ b/helm/knowledge-tree/templates/cnpg-graph-db.yaml
@@ -22,7 +22,7 @@ spec:
       database: knowledge_tree
       owner: kt
       secret:
-        name: {{ include "knowledge-tree.graphDbName" . }}-credentials
+        name: {{ .Values.graphDb.credentialsSecret | default (printf "%s-credentials" (include "knowledge-tree.graphDbName" .)) }}
       postInitSQL:
         - CREATE EXTENSION IF NOT EXISTS vector
         - CREATE EXTENSION IF NOT EXISTS pg_trgm
@@ -35,14 +35,26 @@ spec:
 
   resources:
     {{- toYaml .Values.graphDb.resources | nindent 4 }}
+{{- if not .Values.graphDb.credentialsSecret }}
 ---
+{{- $credSecretName := printf "%s-credentials" (include "knowledge-tree.graphDbName" .) }}
+{{- $existingCred := lookup "v1" "Secret" .Release.Namespace $credSecretName }}
+{{- $password := "" }}
+{{- if $existingCred }}
+  {{- $password = index (default dict $existingCred.data) "password" | default "" }}
+  {{- if $password }}
+    {{- $password = $password | b64dec }}
+  {{- end }}
+{{- end }}
+{{- $password = $password | default .Values.secrets.graphDbPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "knowledge-tree.graphDbName" . }}-credentials
+  name: {{ $credSecretName }}
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 stringData:
   username: kt
-  password: {{ .Values.secrets.graphDbPassword | quote }}
+  password: {{ $password | quote }}
+{{- end }}

--- a/helm/knowledge-tree/templates/cnpg-hatchet-db.yaml
+++ b/helm/knowledge-tree/templates/cnpg-hatchet-db.yaml
@@ -19,7 +19,7 @@ spec:
       database: hatchet
       owner: hatchet
       secret:
-        name: {{ include "knowledge-tree.hatchetDbName" . }}-credentials
+        name: {{ .Values.hatchetDb.credentialsSecret | default (printf "%s-credentials" (include "knowledge-tree.hatchetDbName" .)) }}
 
   storage:
     size: {{ .Values.hatchetDb.storage.size }}
@@ -29,14 +29,26 @@ spec:
 
   resources:
     {{- toYaml .Values.hatchetDb.resources | nindent 4 }}
+{{- if not .Values.hatchetDb.credentialsSecret }}
 ---
+{{- $credSecretName := printf "%s-credentials" (include "knowledge-tree.hatchetDbName" .) }}
+{{- $existingCred := lookup "v1" "Secret" .Release.Namespace $credSecretName }}
+{{- $password := "" }}
+{{- if $existingCred }}
+  {{- $password = index (default dict $existingCred.data) "password" | default "" }}
+  {{- if $password }}
+    {{- $password = $password | b64dec }}
+  {{- end }}
+{{- end }}
+{{- $password = $password | default .Values.secrets.hatchetDbPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "knowledge-tree.hatchetDbName" . }}-credentials
+  name: {{ $credSecretName }}
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 stringData:
   username: hatchet
-  password: {{ .Values.secrets.hatchetDbPassword | quote }}
+  password: {{ $password | quote }}
+{{- end }}

--- a/helm/knowledge-tree/templates/cnpg-write-db.yaml
+++ b/helm/knowledge-tree/templates/cnpg-write-db.yaml
@@ -19,7 +19,7 @@ spec:
       database: knowledge_tree_write
       owner: kt
       secret:
-        name: {{ include "knowledge-tree.writeDbName" . }}-credentials
+        name: {{ .Values.writeDb.credentialsSecret | default (printf "%s-credentials" (include "knowledge-tree.writeDbName" .)) }}
 
   storage:
     size: {{ .Values.writeDb.storage.size }}
@@ -29,14 +29,26 @@ spec:
 
   resources:
     {{- toYaml .Values.writeDb.resources | nindent 4 }}
+{{- if not .Values.writeDb.credentialsSecret }}
 ---
+{{- $credSecretName := printf "%s-credentials" (include "knowledge-tree.writeDbName" .) }}
+{{- $existingCred := lookup "v1" "Secret" .Release.Namespace $credSecretName }}
+{{- $password := "" }}
+{{- if $existingCred }}
+  {{- $password = index (default dict $existingCred.data) "password" | default "" }}
+  {{- if $password }}
+    {{- $password = $password | b64dec }}
+  {{- end }}
+{{- end }}
+{{- $password = $password | default .Values.secrets.writeDbPassword }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "knowledge-tree.writeDbName" . }}-credentials
+  name: {{ $credSecretName }}
   labels:
     {{- include "knowledge-tree.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 stringData:
   username: kt
-  password: {{ .Values.secrets.writeDbPassword | quote }}
+  password: {{ $password | quote }}
+{{- end }}


### PR DESCRIPTION
## Summary

- CNPG credential secrets were unconditionally recreated on every Helm upgrade, overwriting any manually rotated passwords back to the `values.yaml` default (`changeme`)
- Now uses Helm `lookup` to preserve existing passwords across upgrades (same pattern as `secret.yaml` uses for JWT)
- Supports `credentialsSecret` field (already in `values.yaml` but unused) for externally managed secrets — when set, no secret is created by the chart

## Changes

All 3 CNPG templates (`cnpg-graph-db.yaml`, `cnpg-write-db.yaml`, `cnpg-hatchet-db.yaml`):
1. Secret creation is now conditional on `credentialsSecret` being empty
2. If the secret already exists in the cluster, its password is preserved via `lookup`
3. Falls back to `values.yaml` password only on first install
4. CNPG Cluster `bootstrap.initdb.secret.name` respects `credentialsSecret` override

## Test plan

- [ ] Verify `helm template` renders correctly with default values (no `credentialsSecret`)
- [ ] Verify `helm template` with `--set graphDb.credentialsSecret=my-secret` omits the auto-generated secret
- [ ] Deploy to dev and confirm existing rotated passwords are preserved after Flux reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)