### PR TITLE
feat(helm): add EMAIL_VERIFICATION env var

### DIFF
--- a/helm/knowledge-tree/templates/_helpers.tpl
+++ b/helm/knowledge-tree/templates/_helpers.tpl
@@ -192,6 +192,8 @@ Outputs a list of env var definitions.
   value: "true"
 - name: EMAIL_PROVIDER
   value: "resend"
+- name: EMAIL_VERIFICATION
+  value: {{ .Values.email.verification | default false | quote }}
 - name: EMAIL_FROM_ADDRESS
   value: {{ ((.Values.email).resend).fromAddress | default "" | quote }}
 - name: RESEND_API_KEY

--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -46,6 +46,7 @@ secrets:
 # -- Email configuration (provider-scoped)
 email:
   provider: ""  # set to "resend" to enable
+  verification: false
   resend:
     fromAddress: ""
 


### PR DESCRIPTION
## Summary
- Adds `EMAIL_VERIFICATION` environment variable to the Helm email config block in `_helpers.tpl`
- Adds `verification` field to base `values.yaml` (defaults to `false`)

The template was setting `EMAIL_ENABLED` but never passing `EMAIL_VERIFICATION`, making it impossible to enable verification via Helm values.

## Test plan
- [ ] `helm template` renders `EMAIL_VERIFICATION` when `email.provider=resend`
- [ ] Existing deployments unaffected (defaults to `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)