### PR TITLE
fix(kt-agents-core): guard session for None in BaseAgent after GraphEngine split

### DIFF
--- a/libs/kt-agents-core/src/kt_agents_core/base.py
+++ b/libs/kt-agents-core/src/kt_agents_core/base.py
@@ -124,8 +124,11 @@ class BaseAgent(ABC, Generic[S]):
             )
             logger.info("[%s] tool_call: %s(%s)", self.emit_tool_label, name, args_summary)
             try:
-                async with self.ctx.session.begin_nested():
-                    tool_fn = tools_by_name[name]
+                tool_fn = tools_by_name[name]
+                if self.ctx.session is not None:
+                    async with self.ctx.session.begin_nested():
+                        result = await tool_fn.ainvoke(tc["args"])
+                else:
                     result = await tool_fn.ainvoke(tc["args"])
                 result_str = str(result)
                 result_preview = result_str[:200] + "..." if len(result_str) > 200 else result_str
@@ -147,10 +150,11 @@ class BaseAgent(ABC, Generic[S]):
                     )
                 )
 
-        try:
-            await self.ctx.session.flush()
-        except Exception:
-            logger.exception("Error flushing after tool execution")
+        if self.ctx.session is not None:
+            try:
+                await self.ctx.session.flush()
+            except Exception:
+                logger.exception("Error flushing after tool execution")
 
         return tool_messages
 

--- a/services/worker-synthesis/src/kt_worker_synthesis/workflows/super_synthesizer.py
+++ b/services/worker-synthesis/src/kt_worker_synthesis/workflows/super_synthesizer.py
@@ -58,6 +58,7 @@ async def reconnaissance(input: SuperSynthesizerInput, ctx: Context) -> dict[str
         model_gateway=worker_state.model_gateway,
         embedding_service=worker_state.embedding_service,
         session=None,
+        qdrant_client=worker_state.qdrant_client,
     )
 
     # Search broadly to map the landscape


### PR DESCRIPTION
## Summary

- Guards `session.begin_nested()` and `session.flush()` in `BaseAgent.execute_tool_calls()` to handle `session=None` — fixes crash in synthesizer workflow after the GraphEngine split into ReadGraphEngine + WorkerGraphEngine
- Adds missing `qdrant_client` param to `AgentContext()` in `super_synthesizer.py` (caught by existing wiring test)

## Root cause

The recent GraphEngine split correctly passes `session=None` to `AgentContext` for the synthesizer (which uses `ReadGraphEngine` with `session_factory` for short-lived per-call sessions). But `BaseAgent.execute_tool_calls()` unconditionally called `self.ctx.session.begin_nested()` and `self.ctx.session.flush()`, causing every tool call to fail with `AttributeError: 'NoneType' object has no attribute 'begin_nested'`.

## Test plan

- [x] `kt-agents-core` tests pass (wiring tests)
- [ ] CI pipeline checks pass
- [ ] Verify synthesis workflow runs without `AttributeError` in Hatchet UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)