### PR TITLE
fix(worker-nodes,kt-db): fix session.commit on None and write_sources deadlock

### DIFF
--- a/libs/kt-db/src/kt_db/repositories/write_sources.py
+++ b/libs/kt-db/src/kt_db/repositories/write_sources.py
@@ -10,6 +10,7 @@ import uuid
 
 from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from kt_db.write_models import WriteRawSource
@@ -74,6 +75,9 @@ class WriteSourceRepository:
             content_hash = self.compute_hash(raw_content or "")
         source_id = uri_to_source_id(uri)
 
+        # Use ON CONFLICT (id) DO NOTHING to avoid cross-index deadlocks.
+        # The deterministic id (from URI) means same-URI concurrent inserts
+        # conflict only on the PK — no multi-index lock ordering issues.
         stmt = (
             pg_insert(WriteRawSource)
             .values(
@@ -85,18 +89,34 @@ class WriteSourceRepository:
                 provider_id=provider_id,
                 provider_metadata=provider_metadata,
             )
-            .on_conflict_do_update(
-                index_elements=["content_hash"],
-                set_={"content_hash": pg_insert(WriteRawSource).excluded.content_hash},
-            )
+            .on_conflict_do_nothing(index_elements=["id"])
             .returning(WriteRawSource.id)
         )
-        result = await self._session.execute(stmt)
-        returned_id = result.scalar_one()
 
-        source = await self.get_by_id(returned_id)
-        assert source is not None  # noqa: S101
-        return source
+        returned_id = None
+        try:
+            async with self._session.begin_nested():
+                result = await self._session.execute(stmt)
+                returned_id = result.scalar_one_or_none()
+        except IntegrityError:
+            # content_hash collision from a different URI — savepoint
+            # rolls back the INSERT, fall through to lookup below.
+            pass
+
+        if returned_id is not None:
+            source = await self.get_by_id(returned_id)
+            assert source is not None  # noqa: S101
+            return source
+
+        # Row already exists — look up by deterministic id first, then content_hash
+        existing = await self.get_by_id(source_id)
+        if existing is not None:
+            return existing
+        existing = await self.get_by_content_hash(content_hash)
+        if existing is not None:
+            return existing
+
+        raise RuntimeError(f"create_or_get: could not insert or find source for uri={uri}")
 
     async def update_content(
         self,

--- a/services/api/src/kt_api/prompt_transparency.py
+++ b/services/api/src/kt_api/prompt_transparency.py
@@ -153,7 +153,9 @@ def _load_prompts() -> list[PromptEntry]:
         pass
 
     try:
-        from kt_worker_nodes.pipelines.parent.pipeline import _SYSTEM_PROMPT as PARENT_PROMPT
+        from kt_worker_nodes.pipelines.parent.pipeline import (  # type: ignore[import-not-found]
+            _SYSTEM_PROMPT as PARENT_PROMPT,
+        )
 
         entries.append(
             PromptEntry(

--- a/services/worker-nodes/src/kt_worker_nodes/hatchet_pipeline.py
+++ b/services/worker-nodes/src/kt_worker_nodes/hatchet_pipeline.py
@@ -194,8 +194,8 @@ class HatchetPipeline:
             from kt_db.repositories.write_nodes import WriteNodeRepository
 
             nid = uuid.UUID(existing_node_id)
-            async with self._open_sessions() as (session, write_session):
-                ctx = await self._build_ctx(session, write_session=write_session)
+            async with self._open_sessions() as (_, write_session):
+                ctx = await self._build_ctx(None, write_session=write_session)
                 node_pipeline = NodeCreationPipeline(ctx)
 
                 wn = await WriteNodeRepository(write_session).get_by_uuid(nid) if write_session else None
@@ -212,16 +212,16 @@ class HatchetPipeline:
                         await node_pipeline.create_batch([task], orch_state)
 
                 try:
-                    await session.commit()
+                    await write_session.commit()
                 except Exception:
-                    await session.rollback()
+                    await write_session.rollback()
 
             # Extract scalar values while task is still populated
             node_id_str = str(task.node.id) if task.node is not None else existing_node_id
             result_node_type = task.node.node_type if task.node is not None else node_type
         else:
-            async with self._open_sessions() as (session, write_session):
-                ctx = await self._build_ctx(session, write_session=write_session)
+            async with self._open_sessions() as (_, write_session):
+                ctx = await self._build_ctx(None, write_session=write_session)
                 node_pipeline = NodeCreationPipeline(ctx)
 
                 await node_pipeline.classify_and_gather_batch([task], orch_state)
@@ -238,9 +238,9 @@ class HatchetPipeline:
                 # back explicitly so we can still read the task results -- the node
                 # was already committed by create_batch's internal commit.
                 try:
-                    await session.commit()
+                    await write_session.commit()
                 except Exception:
-                    await session.rollback()
+                    await write_session.rollback()
 
             # Extract scalar values before the session closes -- accessing
             # expired ORM attributes after session.close() raises
@@ -273,10 +273,10 @@ class HatchetPipeline:
 
         nid = uuid.UUID(node_id)
 
-        async with self._open_sessions() as (session, write_session):
+        async with self._open_sessions() as (_, write_session):
             if write_session is None:
                 raise RuntimeError("enrich: write_session is required")
-            ctx = await self._build_ctx(session, write_session=write_session)
+            ctx = await self._build_ctx(None, write_session=write_session)
 
             wn = await WriteNodeRepository(write_session).get_by_uuid(nid)
             node = Node(id=nid, concept=wn.concept, node_type=wn.node_type) if wn else None
@@ -316,7 +316,7 @@ class HatchetPipeline:
 
             enricher = PoolEnricher(ctx)
             result = await enricher.enrich(node)
-            await session.commit()
+            await write_session.commit()
 
         return {
             "node_id": node_id,
@@ -339,10 +339,10 @@ class HatchetPipeline:
 
         nid = uuid.UUID(node_id)
 
-        async with self._open_sessions() as (session, write_session):
+        async with self._open_sessions() as (_, write_session):
             if write_session is None:
                 raise RuntimeError("dimensions: write_session is required")
-            ctx = await self._build_ctx(session, write_session=write_session)
+            ctx = await self._build_ctx(None, write_session=write_session)
 
             wn = await WriteNodeRepository(write_session).get_by_uuid(nid)
             node = Node(id=nid, concept=wn.concept, node_type=wn.node_type) if wn else None
@@ -361,7 +361,7 @@ class HatchetPipeline:
             dim_pipeline = DimensionPipeline(ctx)
             dim_result = await dim_pipeline.generate_and_store(node, facts, mode=dim_mode)
 
-            await session.commit()
+            await write_session.commit()
 
             # Track fact count at build time for staleness detection.
             # Committed after graph-db so the watermark only advances
@@ -550,8 +550,8 @@ class HatchetPipeline:
         # earlier create_node task via the Hatchet input.
         node = Node(id=nid, concept=concept, node_type=node_type)
 
-        async with self._open_sessions() as (session, write_session):
-            ctx = await self._build_ctx(session, write_session=write_session)
+        async with self._open_sessions() as (_, write_session):
+            ctx = await self._build_ctx(None, write_session=write_session)
 
             task = CreateNodeTask(name=concept, node_type=node_type, seed_key=f"{node_type}:{concept}")
             task.node = node
@@ -566,7 +566,7 @@ class HatchetPipeline:
             edge_pipeline = EdgePipeline(ctx)
             await edge_pipeline.resolve_from_candidates_batch([task], orch_state)
 
-            await session.commit()
+            await write_session.commit()
 
         edge_ids = [str(eid) for eid in task.result.get("edge_ids", [])]
         return {"edge_ids": edge_ids, "edges_created": task.edges_created}
@@ -593,10 +593,10 @@ class HatchetPipeline:
         nid = __import__("uuid").UUID(node_id)
         node = Node(id=nid, concept=concept, node_type=node_type)
 
-        async with self._open_sessions() as (session, write_session):
-            ctx = await self._build_ctx(session, write_session=write_session)
+        async with self._open_sessions() as (_, write_session):
+            ctx = await self._build_ctx(None, write_session=write_session)
             resolver = EdgeResolver(ctx)
             result = await resolver.refresh_existing_edges(node)
-            await session.commit()
+            await write_session.commit()
 
         return result


### PR DESCRIPTION
## Summary
- **Fix deterministic `AttributeError: 'NoneType' object has no attribute 'commit'`** in 6 methods of `hatchet_pipeline.py` — after the GraphEngine split refactor, `_open_sessions()` always yields `(None, write_session)` but these methods still called `session.commit()` on the `None` value. Changed to `write_session.commit()` matching the pattern already used by `full_dimensions()` and `definition()`.
- **Fix intermittent deadlock in `write_sources.create_or_get()`** (~2.5% failure rate) — switched from `ON CONFLICT (content_hash) DO UPDATE` to `ON CONFLICT (id) DO NOTHING` with savepoint isolation, eliminating cross-index lock ordering issues during concurrent source inserts.
- **Fix pre-existing pyright error** in `prompt_transparency.py` — added `type: ignore` for removed `parent.pipeline` module import.

## Test plan
- [x] worker-nodes tests pass (121 passed)
- [x] kt-db unit tests pass (25 passed)
- [x] kt-providers tests pass (55 passed)
- [x] ruff lint + format clean
- [x] pyright 0 errors
- [ ] CI pipeline checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)