### PR TITLE
fix(worker-search): increase decompose_source timeout from 10m to 30m

### DIFF
--- a/services/worker-search/src/kt_worker_search/workflows/decompose.py
+++ b/services/worker-search/src/kt_worker_search/workflows/decompose.py
@@ -45,7 +45,7 @@ _schedule_timeout = timedelta(minutes=get_settings().hatchet_schedule_timeout_mi
 @hatchet.task(
     name="decompose_source",
     input_validator=DecomposeSourceInput,
-    execution_timeout=timedelta(minutes=10),
+    execution_timeout=timedelta(minutes=30),
     schedule_timeout=_schedule_timeout,
     concurrency=ConcurrencyExpression(
         expression="'decompose_source'",
@@ -542,7 +542,7 @@ reingest_source_wf = hatchet.workflow(
 
 
 @reingest_source_wf.task(
-    execution_timeout=timedelta(minutes=10),
+    execution_timeout=timedelta(minutes=30),
     schedule_timeout=_schedule_timeout,
 )
 async def reingest_source_task(input: ReingestSourceInput, ctx: Context) -> dict:


### PR DESCRIPTION
## Summary
- Increased `execution_timeout` from 10 minutes to 30 minutes for both `decompose_source` and `reingest_source_task` in the worker-search decompose workflow
- Large sources were timing out during fact decomposition, causing pipeline failures

## Test plan
- [ ] Verify large source ingestion completes without timeout errors
- [ ] Monitor Hatchet UI for decompose_source task completion times

🤖 Generated with [Claude Code](https://claude.com/claude-code)