### PR TITLE
docs: remove perspective node type and ancestry references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,7 @@ A knowledge integration system that builds understanding exclusively from raw ex
 **Key design drivers (priority order):**
 
 1. **Knowledge from data, not from models.** Models are reasoning engines, not knowledge sources. All knowledge must trace back to external raw data.
-2. **Integration, not ignoring.** The system never discards coherent information. Contradictory facts produce node splits with alternate perspectives, not suppression.
+2. **Integration, not ignoring.** The system never discards coherent information. Contradictory facts coexist within nodes, surfaced transparently rather than suppressed.
 3. **Extensibility.** Clean interfaces allow new knowledge providers (search engines, databases, APIs), new AI models, and new decomposition strategies without architectural changes.
 4. **Accumulation.** The graph improves with every query. Nodes visited frequently become deeply supported. Budget=0 queries leverage all prior work.
 5. **Transparency.** Users see the graph, the nodes, the facts, the sources, the convergence scores, and the divergences. Nothing is hidden.
@@ -41,12 +41,12 @@ A knowledge integration system that builds understanding exclusively from raw ex
 ### 2.1 Functional Requirements
 
 #### FR-1: Knowledge Graph Management
-- **FR-1.1:** The system SHALL maintain a persistent knowledge graph where nodes represent concepts, perspectives, entities, events, locations, syntheses, or supersyntheses. Nodes have a `node_type` field: `concept` (abstract topics), `entity` (subjects capable of intent — person, organization), `perspective` (debatable claims with a parent concept), `event` (temporal occurrences), `location` (geographic places), `synthesis` (composite document synthesizing multiple source nodes), or `supersynthesis` (meta-synthesis combining multiple synthesis nodes).
-- **FR-1.2:** Nodes SHALL be linked to other nodes via typed, weighted edges. The graph is flat — all nodes are peers. Perspective nodes link to their parent concept via the `parent_id` FK. Circular references are valid and expected.
+- **FR-1.1:** The system SHALL maintain a persistent knowledge graph where nodes represent concepts, entities, events, locations, syntheses, or supersyntheses. Nodes have a `node_type` field: `concept` (abstract topics), `entity` (subjects capable of intent — person, organization), `event` (temporal occurrences), `location` (geographic places), `synthesis` (composite document synthesizing multiple source nodes), or `supersynthesis` (meta-synthesis combining multiple synthesis nodes).
+- **FR-1.2:** Nodes SHALL be linked to other nodes via typed, weighted edges. The graph is flat — all nodes are peers. Circular references are valid and expected.
 - **FR-1.3:** Edges SHALL only be created from shared factual evidence (seed co-occurrence candidates) — semantic proximity alone does NOT create edges. Embedding similarity is a search tool, not a structural mechanism.
 - **FR-1.4:** Nodes SHALL reference facts, and facts SHALL reference their original raw sources with stored links.
 - **FR-1.5:** Node content size SHALL be configurable (default: 500 tokens per dimension).
-- **FR-1.6:** The system SHALL support node splitting when divergent facts form coherent alternate perspectives.
+- **FR-1.6:** The system SHALL support node splitting when divergent facts form coherent, internally consistent clusters.
 - **FR-1.7:** The system SHALL support node merging when independently created nodes describe the same concept.
 
 #### FR-2: Query & Budget System
@@ -81,7 +81,7 @@ A knowledge integration system that builds understanding exclusively from raw ex
 - **FR-6.3:** A super-synthesizer agent SHALL combine multiple synthesis documents into a comprehensive meta-synthesis.
 - **FR-6.4:** Fact gathering (via ingestion/bottom-up workflows) SHALL be separated from synthesis (document creation from existing graph). The graph grows through ingestion; synthesis reads from it.
 - **FR-6.5:** The ingest agent SHALL build nodes from a pre-filled fact pool extracted from uploaded documents, links, and search results.
-- **FR-6.6:** Bottom-up workflows SHALL orchestrate scope-based research: planning scopes, extracting facts, promoting seeds to nodes, and building perspectives.
+- **FR-6.6:** Bottom-up workflows SHALL orchestrate scope-based research: planning scopes, extracting facts, and promoting seeds to nodes.
 
 #### FR-7: Source Tracking
 - **FR-7.1:** All data added to nodes SHALL have stored links to their original sources.
@@ -511,21 +511,18 @@ The atomic unit of the knowledge graph. All nodes are flat peers — structure c
 |-----------|----------|-------------|---------|
 | `concept` | Base | Abstract topic, idea, technique, phenomenon, or subject | "moon", "photosynthesis", "pyramid construction techniques" |
 | `entity` | Base | A subject capable of intent (person, organization) | "NASA" (organization), "Albert Einstein" (person) |
-| `perspective` | Composite | A debatable claim with a parent concept and stance-classified facts | "the moon is an artificial structure placed in orbit" |
 | `event` | Base | A temporal occurrence (historical, scientific, ongoing) | "Apollo 11 Moon Landing", "2024 Solar Eclipse" |
 | `location` | Base | A geographic place (country, city, region, landmark) | "Tokyo", "Amazon Rainforest", "Mediterranean Sea" |
 | `synthesis` | Composite | Composite document synthesizing multiple source nodes | A synthesis combining "solar power", "wind power", and "energy storage" |
 | `supersynthesis` | Composite | Meta-synthesis combining multiple synthesis documents | A supersynthesis combining three synthesis documents on renewable energy |
 
-**Base node types** (`concept`, `entity`, `event`, `location`) are built from raw facts. **Composite node types** (`synthesis`, `supersynthesis`, `perspective`) are built from other nodes and linked via `draws_from` edges.
-
-Perspective nodes have a `parent_id` FK linking them to their parent concept node. Parent-child structure uses this FK, not edges.
+**Base node types** (`concept`, `entity`, `event`, `location`) are built from raw facts. **Composite node types** (`synthesis`, `supersynthesis`) are built from other nodes and linked via `draws_from` edges.
 
 ```
 Node:
   id:                 uuid                # primary key (deterministic via key_to_uuid)
   concept:            string              # human-readable concept label
-  node_type:          string              # "concept" | "perspective" | "entity" | "event" | "location" | "synthesis" | "supersynthesis"
+  node_type:          string              # "concept" | "entity" | "event" | "location" | "synthesis" | "supersynthesis"
   parent_id:          uuid | null         # FK to parent node
   definition:         text | null         # synthesized definition from dimensions
   embedding:          float[]             # averaged across dimension embeddings
@@ -616,7 +613,7 @@ Edge types are limited to 3 well-separated values. The `weight` field is a **sha
 |------|-----------|---------|---------|
 | `related` | Undirected | Connects nodes of the same `node_type`. Created from seed co-occurrence candidates. Canonical UUID ordering enforced (smaller UUID = source). | "solar power" ↔ "wind power" (both concepts) |
 | `cross_type` | Undirected | Connects nodes of different `node_type`s (e.g., entity↔event, concept↔location). Canonical UUID ordering enforced. | "NASA" (entity) ↔ "Apollo 11" (event) |
-| `draws_from` | Directed | Links composite nodes (synthesis, supersynthesis, perspective) to their source nodes. Programmatic — not LLM-created. | synthesis → concept (source material) |
+| `draws_from` | Directed | Links composite nodes (synthesis, supersynthesis) to their source nodes. Programmatic — not LLM-created. | synthesis → concept (source material) |
 
 Edge `weight` = number of shared facts between the two nodes' seeds. The `justification` field contains LLM-generated reasoning with `{fact:uuid}` citation tokens for provenance.
 
@@ -626,7 +623,7 @@ Edge `weight` = number of shared facts between the two nodes' seeds. The `justif
 
 | | Edges | Embedding Similarity |
 |---|-------|---------------------|
-| **Created by** | Seed co-occurrence candidates + LLM justification (edge pipeline), or perspective builder | Computed automatically from content |
+| **Created by** | Seed co-occurrence candidates + LLM justification (edge pipeline) | Computed automatically from content |
 | **Meaning** | "These concepts are meaningfully related — I explored them together" | "These concepts have similar semantic content" |
 | **Used for** | Graph traversal, answer synthesis, UI visualization | Node search, dedup candidate detection, merge candidate detection |
 | **Circular?** | Yes — A→B and B→A are both valid | N/A (similarity is symmetric) |
@@ -774,7 +771,6 @@ Input:  raw_sources: RawSource[], concept: string
 | `get_summary(idx)` | Read the full summary for a section | Free |
 | `browse_facts(query, fact_type, unlinked_only, limit)` | Search the fact pool by topic or browse all | Free |
 | `build_nodes(nodes)` | Batch build up to 10 nodes in one call | 1 per node |
-| `build_perspectives(claims)` | Batch build perspective nodes with stance classification | Free |
 | `read_node(node_id)` | Read an existing node's dimensions and edges | 1 per read |
 | `get_budget()` | Check remaining budget | Free |
 | `finish_ingest(summary)` | End construction and submit summary | Free |
@@ -1229,7 +1225,7 @@ All heavy processing runs as **durable Hatchet workflows**:
 | Workflow | Worker | Purpose |
 |----------|--------|---------|
 | `bottom_up_wf` | worker-bottomup | Top-level research orchestrator: plans scopes, dispatches node building |
-| `bottom_up_scope_wf` | worker-bottomup | Single scope: gather facts, filter, fan-out node pipelines, build perspectives |
+| `bottom_up_scope_wf` | worker-bottomup | Single scope: gather facts, filter, fan-out node pipelines |
 | `node_pipeline_wf` | worker-nodes | Node creation DAG: create → dimensions → definition → parent |
 | `composite_wf` | worker-nodes | Composite node generation (synthesis/supersynthesis node types) |
 | `auto_build_wf` | worker-nodes | Automatic node building from accumulated seeds |
@@ -1303,28 +1299,28 @@ function evaluateSplit(node):
   return NO_SPLIT
 
 function executeSplit(node, clusters):
-  # Create perspective nodes as peers (not children)
-  perspectiveNodes = []
+  # Create child nodes for each coherent cluster
+  childNodes = []
   for cluster in clusters:
-    label = generatePerspectiveLabel(cluster)  # e.g., "Politician X: Governance Record"
-    perspective = createNode(label)
+    label = generateClusterLabel(cluster)  # e.g., "Politician X: Governance Record"
+    child = createNode(label)
     for fact in cluster.facts:
-      linkFactToNode(perspective.id, fact.id)
-    generateDimensions(perspective)
-    perspectiveNodes.append(perspective)
+      linkFactToNode(child.id, fact.id)
+    generateDimensions(child)
+    childNodes.append(child)
 
-  # Link perspective nodes to the original node via parent_id FK
-  for perspective in perspectiveNodes:
-    setParent(perspective.id, node.id)
+  # Link child nodes to the original node via parent_id FK
+  for child in childNodes:
+    setParent(child.id, node.id)
 
-  # Link perspective nodes to each other via related edges
-  for pair in combinations(perspectiveNodes, 2):
+  # Link child nodes to each other via related edges
+  for pair in combinations(childNodes, 2):
     createEdge(pair[0].id, pair[1].id, "related", weight=1.0)
 
   # Update original node to note the split
   updateNodeContent(node, """
-    This topic has divergent perspectives supported by coherent evidence.
-    See linked perspective nodes for each viewpoint.
+    This topic has divergent viewpoints supported by coherent evidence.
+    See linked child nodes for each cluster.
   """)
 ```
 
@@ -1350,7 +1346,7 @@ graph TD
     style B fill:#1a2235,stroke:#f87171,color:#e2e8f0
 ```
 
-All three nodes are peers in the flat graph. The `parent_id` FK indicates that A and B are facets of the original concept. The `related` edge between A and B captures their shared conceptual domain. Other nodes in the graph can link to any of the three independently.
+All three nodes are peers in the flat graph. The `parent_id` FK indicates that A and B are facets of the original concept. The `related` edge between A and B captures their shared domain. Other nodes in the graph can link to any of the three independently.
 
 ---
 
@@ -1846,7 +1842,7 @@ graph TB
 | **SSE Streaming** | Replaced WebSocket with Server-Sent Events for real-time pipeline progress. |
 | **Conversation Model** | Chat-based interaction replacing single-query model. Conversations with multi-turn support. |
 | **Authentication** | fastapi-users with JWT + Google OAuth + API tokens. All routes auth-protected. |
-| **Ontology System** | Wikidata integration, ancestry calculation, crystallization. Redis-cached. |
+| **Ontology System** | Wikidata integration *(deprecated — scheduled for removal)*. |
 | **File/Link Ingestion** | Upload files (PDF, DOCX, etc.) or submit links for decomposition into the knowledge graph. |
 | **Research Reports** | Persisted outcome summaries per orchestrator run (nodes, edges, budgets, scope summaries). |
 | **Wave-Based Exploration** | Multi-wave exploration with LLM-planned scopes and fan-out sub-explorers. |
@@ -1860,7 +1856,7 @@ graph TB
 | **Qdrant Vector Search** | Added Qdrant as dedicated vector database for semantic search, replacing pgvector for primary search workloads. |
 | **MCP Server** | Model Context Protocol server (`services/mcp`) with OAuth 2.1 authentication, exposing read-only graph navigation tools for external AI clients. |
 | **Synthesizer/SuperSynthesizer Agents** | Replaced Orchestrator/Navigation agents with document-focused Synthesizer Agent (graph navigation + synthesis) and SuperSynthesizer Agent (multi-scope meta-synthesis). |
-| **Bottom-up Research Workflows** | Scope-based research: plan scopes → extract facts → promote seeds to nodes → build perspectives. Replaced chat-based exploration model. |
+| **Bottom-up Research Workflows** | Scope-based research: plan scopes → extract facts → promote seeds to nodes. Replaced chat-based exploration model. |
 | **kt-auth Library** | Shared authentication utilities (API token verification, Redis-cached lookup) for API and MCP services. |
 | **kt-qdrant Library** | Qdrant vector search repositories for nodes and facts. |
 | **PgBouncer Connection Pooling** | Connection pools for both graph-db and write-db via PgBouncer. |
@@ -1877,19 +1873,18 @@ graph TB
 
 | Term | Definition |
 |------|------------|
-| **Node** | Atomic unit of the knowledge graph. Typed as `concept`, `entity`, `perspective`, `event`, `location`, `synthesis`, or `supersynthesis`. All nodes are flat peers. |
+| **Node** | Atomic unit of the knowledge graph. Typed as `concept`, `entity`, `event`, `location`, `synthesis`, or `supersynthesis`. All nodes are flat peers. |
 | **Edge** | A typed, weighted relationship between two nodes. Three types: `related` (same-type, undirected), `cross_type` (different-type, undirected), `draws_from` (composite→source, directed). Weight = shared fact count. Created from seed co-occurrence candidates, not automatically from embedding similarity. |
 | **Fact Pool** | The collection of gathered facts extracted from sources. Facts are extracted during ingestion/bottom-up workflows and later linked to nodes during node pipeline execution. |
 | **Seed** | An entity or concept extracted during fact decomposition. Seeds accumulate facts and are promoted to full nodes when they reach a configurable minimum fact count. |
-| **Stance** | Classification of a fact relative to a perspective's claim: `supports`, `challenges`, or `neutral`. |
 | **Synthesizer Agent** | LangGraph agent that navigates the knowledge graph with an exploration budget and produces a standalone synthesis document. Has 8 navigation tools + `finish_synthesis`. |
 | **SuperSynthesizer Agent** | Agent that reads multiple sub-synthesis documents and produces a comprehensive meta-synthesis. |
 | **Ingest Agent** | Agent that builds nodes from a pre-filled fact pool extracted from uploaded documents, links, and search results. |
-| **Dimension** | A single model's perspective on a node's concept, generated from facts. |
+| **Dimension** | A single model's independent analysis of a node's concept, generated from facts. |
 | **Fact** | A typed, attributed piece of information extracted from raw sources. Types: claim, account, measurement, formula, quote, procedure, reference, code, image, perspective. |
 | **Raw Source** | Original data fetched from a knowledge provider, stored append-only. |
 | **Convergence** | Degree of agreement across dimensions (models) within a node. |
-| **Node Split** | When a node's facts form contradictory but internally coherent clusters, creating perspective nodes linked via `parent_id` FK. |
+| **Node Split** | When a node's facts form contradictory but internally coherent clusters, creating child nodes linked via `parent_id` FK. |
 | **Exploration Budget** | Maximum number of nodes the synthesizer agent can visit during graph navigation. Controls investigation depth without limiting free operations like search. |
 | **graph-db** | Read-optimized PostgreSQL database with pgvector and FK constraints. API and synthesis agent read from here. |
 | **write-db** | Write-optimized PostgreSQL database with no FKs and deterministic TEXT keys. Workers write here during pipelines. |
@@ -1929,7 +1924,7 @@ Raw sources may be reprocessed with improved decomposition agents. Today's fact 
 
 ### B.5: Why node splitting instead of just tagging divergence?
 
-Splitting creates navigable structure. A user exploring "Politician X" sees at a glance that there are two coherent perspectives, each with its own evidence base. This is more useful than a single node with a "divergence warning." Split nodes can themselves accumulate facts, develop edges, and participate in the graph as first-class entities.
+Splitting creates navigable structure. A user exploring "Politician X" sees at a glance that there are two coherent viewpoints, each with its own evidence base. This is more useful than a single node with a "divergence warning." Split nodes can themselves accumulate facts, develop edges, and participate in the graph as first-class entities.
 
 ### B.6: Why a flat graph instead of a tree (parent-child)?
 
@@ -1954,7 +1949,7 @@ If edges were created automatically from embedding similarity, the graph would b
 The original design had 16, then 8 edge types with increasingly overlapping semantics that LLMs couldn't reliably distinguish. The current 3-type system (`related`, `cross_type`, `draws_from`) maximizes simplicity:
 - `related` covers all same-type relationships — the weight (shared fact count) captures evidence strength, and the LLM justification explains the nature of the relationship.
 - `cross_type` covers all cross-type relationships (e.g., entity↔event), with eligible pairings defined explicitly. Same weight semantics.
-- `draws_from` is a directed, programmatic edge from composite nodes (synthesis, supersynthesis, perspective) to their source nodes. Not LLM-created — it records structural provenance.
+- `draws_from` is a directed, programmatic edge from composite nodes (synthesis, supersynthesis) to their source nodes. Not LLM-created — it records structural provenance.
 
 The `justification` field with `{fact:uuid}` citation tokens provides the semantic richness that previously required fine-grained type distinctions.
 
@@ -1967,14 +1962,5 @@ In the original agent design, every `explore_concept()` call triggered both an e
 
 The fact pool pattern separates these concerns:
 - `gather_facts()` handles the expensive part (external API calls) and stores facts in a shared pool
-- `build_concept()` and `build_perspective()` handle the cheap part (organizing existing facts into nodes)
+- `build_concept()` handles the cheap part (organizing existing facts into nodes)
 - Facts gathered for one concept can be discovered and linked to other nodes
-- Perspective nodes can share facts with their parent concepts
-
-### B.10: Why stance classification on facts?
-
-When a fact links to a perspective node, classifying its stance (`supports`, `challenges`, `neutral`) enables:
-- Quantitative comparison of evidence for competing perspectives
-- Transparent reporting: "6 facts support this claim, 12 challenge it"
-- Detection of evidence asymmetry (one perspective has much more/less support)
-- The synthesis agent can present each perspective with its strongest supporting evidence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,6 @@ Agents (LangGraph-based) are used **within** Hatchet tasks for LLM reasoning:
 ### Node Types
 - `concept` — Abstract topic, idea, technique, phenomenon
 - `entity` — Subject capable of intent (person, organization)
-- `perspective` — A debatable claim with a parent concept and stance-classified facts
 - `event` — Temporal occurrence (historical, scientific, ongoing)
 - `synthesis` — Composite document synthesizing multiple nodes (has sentences, fact links)
 - `supersynthesis` — Meta-synthesis combining multiple synthesis documents
@@ -190,11 +189,11 @@ Agents (LangGraph-based) are used **within** Hatchet tasks for LLM reasoning:
 ### Edge Types (2 active types)
 All edges are undirected with canonical UUID ordering enforced (smaller UUID always stored as source). One edge per type per node pair is enforced via DB unique constraint.
 - `related` — Connects nodes of the same type. Weight = shared fact count (positive float). Created from seed co-occurrence candidates with LLM-generated justification.
-- `cross_type` — Connects nodes of different types (e.g., entity<->event, perspective<->concept). Same weight semantics.
+- `cross_type` — Connects nodes of different types (e.g., entity<->event, concept<->entity). Same weight semantics.
 
 Weight is a **fact count** (always positive) — higher values mean stronger evidence. Edges are created from `write_edge_candidates` accumulated during seed extraction. The LLM generates a justification only (no weight decision). Relationship type is determined by node types: same type = `related`, different = `cross_type`.
 
-Parent-child structure (e.g., perspective -> parent concept) uses the `parent_id` FK on the Node model, not edges.
+Parent-child structure uses the `parent_id` FK on the Node model, not edges.
 
 ### Facts Layer
 Facts are independent of nodes. A fact can be linked to many nodes. Facts accumulate sources over time (deduplication by embedding similarity). Provenance chain: Node -> Fact -> RawSource.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Knowledge Tree is a **knowledge integration system** that builds understanding e
 ## What makes Knowledge Tree different
 
 - **Knowledge from data, not from models.** AI models are reasoning engines, not knowledge sources. All knowledge traces back to external raw data.
-- **Integration, not ignoring.** The system never discards coherent information. Contradictory facts produce perspectives with alternate viewpoints, not suppression.
+- **Integration, not ignoring.** The system never discards coherent information. Contradictory facts coexist within nodes, surfaced transparently rather than suppressed.
 - **Multi-model convergence.** Multiple AI models analyze the same evidence independently. Consensus reveals genuine truth; divergence reveals where biases determine conclusions.
 - **Transparent provenance.** Every claim traces through facts back to original sources. Nothing is hidden.
 - **Accumulation.** The graph improves with every query. Frequently explored topics become deeply supported over time.

--- a/STACK.md
+++ b/STACK.md
@@ -108,7 +108,7 @@ bottom_up_wf (top-level research)
   |           |-- dimensions (parallel multi-model)
   |           |-- definition
   |           |-- parent selection
-  |     |-- perspective building
+  |     |-- edge resolution
 
 synthesizer_wf (synthesis document creation)
   |-- SynthesizerAgent navigates graph (8 tools)
@@ -280,7 +280,7 @@ Deterministic UUIDs via `key_to_uuid()` (UUID5) bridge the two databases so both
 ### 4.4 Database Schema (Key Tables)
 
 **graph-db (read-optimized) — `kt_db/models.py`:**
-- `nodes` — Concepts, entities, perspectives, events, locations, syntheses, supersyntheses. Vector embeddings (3072d).
+- `nodes` — Concepts, entities, events, locations, syntheses, supersyntheses. Vector embeddings (3072d).
 - `node_counters` — Separate counter table (avoids row-lock contention).
 - `edges` — Typed relationships (`related`, `cross_type`, `draws_from`). Canonical UUID ordering for undirected types. Unique constraint per (source, target, type).
 - `facts` — Independent fact units with embeddings. Linked to nodes via `node_facts`.
@@ -376,7 +376,7 @@ knowledge-tree/
 │   ├── kt-providers/                # Serper, Brave, fetcher, registry (kt_providers)
 │   ├── kt-graph/                    # GraphEngine, convergence, splitting (kt_graph)
 │   ├── kt-facts/                    # Decomposition pipeline, extraction (kt_facts)
-│   ├── kt-ontology/                 # Wikidata, ancestry, crystallization, cache (kt_ontology)
+│   ├── kt-ontology/                 # *(deprecated — scheduled for removal)* (kt_ontology)
 │   ├── kt-hatchet/                  # Hatchet client, lifespan, models (kt_hatchet)
 │   └── kt-agents-core/              # BaseAgent, state, results (kt_agents_core)
 │
@@ -616,10 +616,6 @@ class Settings(BaseSettings):
     # Embeddings
     embedding_model: str = "openrouter/openai/text-embedding-3-large"
     embedding_dimensions: int = 3072
-
-    # Ontology
-    enable_ontology_ancestry: bool = True
-    ontology_model: str = "openrouter/x-ai/grok-4.1-fast"
 
     # Feature flags
     use_hatchet: bool = True

--- a/docs-site/docs/contributing/core-objects.md
+++ b/docs-site/docs/contributing/core-objects.md
@@ -18,8 +18,8 @@ The atomic unit of the knowledge graph. All nodes are flat peers — structure c
 Node:
   id:                 UUID          # Primary key (= key_to_uuid(write_key))
   concept:            str           # Human-readable label
-  node_type:          str           # concept | entity | perspective | event | synthesis
-  parent_id:          UUID | None   # FK to parent (for perspectives → concepts)
+  node_type:          str           # concept | entity | event | synthesis
+  parent_id:          UUID | None   # FK to parent node
   definition:         str | None    # Synthesized from dimensions
   embedding:          float[]       # Averaged across dimension embeddings
   entity_subtype:     str | None    # For entities: person, org, location, publication
@@ -47,7 +47,6 @@ WriteNode:
 |------|-------------|
 | `concept` | Abstract topic, idea, technique, phenomenon |
 | `entity` | Named real-world thing (person, organization, location) |
-| `perspective` | Debatable claim with parent concept and stance-classified facts |
 | `event` | Temporal occurrence (historical, scientific, ongoing) |
 | `synthesis` | Composite document synthesizing multiple nodes |
 | `supersynthesis` | Meta-synthesis combining multiple synthesis documents |
@@ -75,7 +74,7 @@ Edge:
   id:                 UUID
   source_node_id:     UUID          # Smaller UUID (canonical ordering)
   target_node_id:     UUID          # Larger UUID
-  relationship_type:  str           # related | cross_type | contradicts
+  relationship_type:  str           # related | cross_type
   weight:             float         # Shared fact count
   justification:      str | None    # LLM reasoning with fact citations
   metadata_:          JSONB

--- a/docs-site/docs/contributing/services.md
+++ b/docs-site/docs/contributing/services.md
@@ -44,13 +44,12 @@ Synthesis document creation. Contains the two main agent implementations:
 The node creation pipeline. Runs as a DAG:
 
 ```
-create_node → dimensions → definition → parent_selection
+create_node → dimensions → definition
 ```
 
 1. **create_node** — Creates the node in write-db with linked facts
 2. **dimensions** — Runs multi-model analysis (parallel across configured models)
 3. **definition** — Synthesizes a definition from dimensions
-4. **parent_selection** — Assigns parent node for perspectives and specializations
 
 **Workflow:** `node_pipeline_wf`
 

--- a/docs-site/docs/how-it-works/dimensions.md
+++ b/docs-site/docs/how-it-works/dimensions.md
@@ -52,9 +52,6 @@ Different node types get different analysis prompts:
 | **Concept** | What the evidence reveals, patterns, connections |
 | **Entity** | Role, factual details, relationships, involvement |
 | **Event** | Timeline, causes, effects, participants, context |
-| **Perspective** | Build the strongest case, note challenges as obstacles |
-
-For perspective nodes specifically, facts are first **stance-classified** as supporting, challenging, or neutral. The dimension then presents the perspective's case using its supporting facts while acknowledging challenges.
 
 ## Convergence
 

--- a/docs-site/docs/how-it-works/relations-and-edges.md
+++ b/docs-site/docs/how-it-works/relations-and-edges.md
@@ -37,7 +37,6 @@ An edge's **weight** equals the number of facts shared between its two nodes. Hi
 |------|-----------|---------|
 | **related** | Connects nodes of the **same type** (concept-concept, entity-entity) | "solar power" ↔ "wind power" |
 | **cross_type** | Connects nodes of **different types** (entity-event, concept-entity) | "NASA" (entity) ↔ "Apollo 11" (event) |
-| **contradicts** | Links thesis/antithesis perspective pairs | "AI is beneficial" ↔ "AI is dangerous" |
 
 The relationship type is determined automatically by comparing the node types of the two endpoints: same type produces `related`, different types produce `cross_type`.
 
@@ -49,7 +48,7 @@ Each edge stores:
 |-------|-------------|
 | **source_node_id** | One endpoint (canonical: always the smaller UUID) |
 | **target_node_id** | Other endpoint (canonical: always the larger UUID) |
-| **relationship_type** | `related`, `cross_type`, or `contradicts` |
+| **relationship_type** | `related` or `cross_type` |
 | **weight** | Shared fact count (positive float) |
 | **justification** | LLM-generated reasoning with `{fact:uuid}` citation tokens |
 

--- a/docs-site/docs/how-it-works/values-and-principles.md
+++ b/docs-site/docs/how-it-works/values-and-principles.md
@@ -32,7 +32,7 @@ Models analyze, compare, and synthesize facts. They are discouraged from injecti
 
 ### 2. Integration, not ignoring
 
-The system **never discards coherent information**. When sources disagree, contradictory facts don't get suppressed — they produce [perspective nodes](/how-it-works/dimensions) that represent each viewpoint with its supporting evidence.
+The system **never discards coherent information**. When sources disagree, contradictory facts don't get suppressed — they coexist within nodes, and [multi-model dimensional analysis](/how-it-works/dimensions) surfaces where models converge or diverge on the evidence.
 
 This principle means:
 - Minority viewpoints are preserved alongside mainstream ones

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -11,7 +11,7 @@ Knowledge Tree is a **knowledge integration system** that builds understanding e
 ## What makes Knowledge Tree different
 
 - **Knowledge from data, not from models.** AI models are reasoning engines, not knowledge sources. All knowledge traces back to external raw data.
-- **Integration, not ignoring.** The system never discards coherent information. Contradictory facts produce perspectives with alternate viewpoints, not suppression.
+- **Integration, not ignoring.** The system never discards coherent information. Contradictory facts coexist within nodes, surfaced transparently rather than suppressed.
 - **Multi-model convergence.** Multiple AI models analyze the same evidence independently. Consensus reveals genuine truth; divergence reveals where biases determine conclusions.
 - **Transparent provenance.** Every claim traces through facts back to original sources. Nothing is hidden.
 - **Accumulation.** The graph improves with every query. Frequently explored topics become deeply supported over time.

--- a/docs-site/docs/mcp/available-tools.md
+++ b/docs-site/docs/mcp/available-tools.md
@@ -21,7 +21,7 @@ Each result includes `fact_count` — higher counts indicate richer, better-evid
 |------|------|----------|---------|-------------|
 | `query` | string | yes | — | Search term for concept names |
 | `limit` | int | no | 20 | Max results (1-100) |
-| `node_type` | string | no | — | Filter: `concept`, `entity`, `perspective`, `event` |
+| `node_type` | string | no | — | Filter: `concept`, `entity`, `event` |
 
 **Returns:** List of matching nodes with `node_id`, `concept`, `node_type`, `fact_count`, and `also_known_as` aliases.
 

--- a/docs-site/docs/mcp/examples.md
+++ b/docs-site/docs/mcp/examples.md
@@ -95,7 +95,7 @@ Discover how two topics are related through the graph:
    get_facts(node_id="<intermediate-node-uuid>")
    ```
 
-## Compare model perspectives
+## Compare model analyses
 
 See where AI models agree and disagree on a topic:
 
@@ -105,16 +105,6 @@ See where AI models agree and disagree on a topic:
    ```
 
 2. **Compare confidence scores** — high confidence across models suggests strong evidence. Low or divergent confidence suggests uncertainty.
-
-3. **Look for perspective nodes** with different stances:
-   ```
-   search_graph(query="<topic>", node_type="perspective")
-   ```
-
-4. **Check edges** for dialectic pairs (contradicting perspectives):
-   ```
-   get_edges(node_id="<perspective-uuid>")
-   ```
 
 ## Building references for users
 
@@ -129,7 +119,7 @@ Where `slug` = concept name lowercased, non-alphanumeric characters replaced wit
 Examples:
 - "Machine Learning" (concept) → `https://wiki.openktree.com/nodes/concept-machine-learning`
 - "NASA" (entity) → `https://wiki.openktree.com/nodes/entity-nasa`
-- "Climate Change Is Accelerating" (perspective) → `https://wiki.openktree.com/nodes/perspective-climate-change-is-accelerating`
+- "Apollo 11 Moon Landing" (event) → `https://wiki.openktree.com/nodes/event-apollo-11-moon-landing`
 
 **Fact pages:**
 ```

--- a/landing-page/src/components/Benefits.astro
+++ b/landing-page/src/components/Benefits.astro
@@ -3,7 +3,7 @@ const benefits = [
   {
     title: "Complete Knowledge Integration",
     description:
-      "No data is removed or ignored. Every source contributes to the graph. Contradictory evidence produces perspectives, not suppression.",
+      "No data is removed or ignored. Every source contributes to the graph. Contradictory evidence coexists transparently, not suppressed.",
     accent: "ocean",
   },
   {

--- a/wiki-frontend/src/pages/about.astro
+++ b/wiki-frontend/src/pages/about.astro
@@ -36,10 +36,10 @@ import WikiLayout from "../layouts/WikiLayout.astro";
         The judgement is yours to make.
       </p>
       <p>
-        This is what fact provenance is for. When a perspective links to its supporting facts,
-        and those facts link to their original sources, you can see not just <em>what</em> someone
-        believes but <em>why</em> — what they have read, what they take as evidence, and how
-        robust that evidence is. Understanding why someone holds a view is the first step toward
+        This is what fact provenance is for. When a node links to its supporting facts,
+        and those facts link to their original sources, you can see not just <em>what</em> is claimed
+        but <em>why</em> — what evidence exists, where it comes from, and how
+        robust it is. Understanding the evidence behind a view is the first step toward
         genuine dialogue with it.
       </p>
     </section>
@@ -59,11 +59,12 @@ import WikiLayout from "../layouts/WikiLayout.astro";
         neither side could see while standing only on their own.
       </p>
       <p>
-        The structure of this graph reflects that process directly. Perspectives are thesis and
-        antithesis — opposing claims about a concept, each grounded in its own facts. Their parent
-        concept is the synthesis space: the higher idea that contains both, where the contradiction
-        can be examined rather than avoided. As the graph grows, these parent concepts are themselves
-        integrated into broader concepts, moving progressively toward more encompassing common ground.
+        The structure of this graph reflects that process directly. When multiple AI models
+        independently analyse the same evidence, their convergence reveals genuine consensus —
+        and their divergence reveals where biases or assumptions shape conclusions. Contradictory
+        facts coexist within nodes, each grounded in its own sources. Synthesis documents weave
+        these competing threads into coherent narratives, discovering the higher ground where
+        the contradiction becomes intelligible rather than avoided.
       </p>
     </section>
 
@@ -71,7 +72,7 @@ import WikiLayout from "../layouts/WikiLayout.astro";
       <h2>Synthesis as destination</h2>
       <p>
         The ultimate ambition of Knowledge Tree is not to archive disagreement but to find the
-        concepts where disagreement resolves. In a world where opposing perspectives are equally
+        concepts where disagreement resolves. In a world where opposing viewpoints are equally
         valid starting points for inquiry, the question is not which side is right. The question
         is: what is the idea large enough to hold both?
       </p>
@@ -92,22 +93,21 @@ import WikiLayout from "../layouts/WikiLayout.astro";
       </p>
       <p>
         Those facts are assembled into nodes. Each node in the graph represents a concept, an entity,
-        a perspective, or an event. Nodes connect to each other through typed edges that reflect
+        or an event. Nodes connect to each other through typed edges that reflect
         real relationships discovered during exploration — not inferred from similarity alone.
       </p>
       <p>
-        Nodes have four types:
+        Nodes have three core types:
       </p>
       <ul class="about-list">
         <li><strong>Concept</strong> — an abstract topic, idea, or domain of inquiry</li>
-        <li><strong>Entity</strong> — a named person, organisation, or institution with a point of view</li>
-        <li><strong>Perspective</strong> — a debatable claim, linked to a parent concept, with a stance grounded in facts</li>
+        <li><strong>Entity</strong> — a named person, organisation, or institution</li>
         <li><strong>Event</strong> — a temporal occurrence that shapes or is shaped by the concepts around it</li>
       </ul>
       <p>
         The graph grows with every query. Topics that are explored frequently accumulate deeper
-        factual bases, more perspectives, and richer connections. Nothing is discarded; everything
-        integrates into the broader structure over time.
+        factual bases, richer multi-model analyses, and more connections. Nothing is discarded;
+        everything integrates into the broader structure over time.
       </p>
     </section>
 

--- a/wiki-frontend/src/pages/nodes/[id].astro
+++ b/wiki-frontend/src/pages/nodes/[id].astro
@@ -46,10 +46,8 @@ interface Neighbor {
   edges: EdgeResponse[];
 }
 
-const perspectives: Neighbor[] = [];
 const entities: Neighbor[] = [];
 const related: Neighbor[] = [];  // concept + event
-let antithesis: NodeResponse | null = null;
 
 // Use the node's actual UUID for edge matching (id param may be a URL key)
 const nodeUuid: string = node?.id ?? id;
@@ -76,17 +74,7 @@ if (node && subgraph) {
   for (const [neighborId, edges] of neighborEdges) {
     const neighbor = nodeMap.get(neighborId)!;
     const entry: Neighbor = { node: neighbor, edges };
-    // Track antithesis via dialectic_pair_id metadata or negative-weight related edge
-    const pairId = node.metadata?.dialectic_pair_id as string | undefined;
-    if (
-      (pairId && neighborId === pairId) ||
-      (neighbor.node_type === "perspective" && edges.some((e) => e.relationship_type === "related" && e.weight < 0))
-    ) {
-      antithesis = neighbor;
-    }
-    if (neighbor.node_type === "perspective") {
-      perspectives.push(entry);
-    } else if (neighbor.node_type === "entity") {
+    if (neighbor.node_type === "entity") {
       entities.push(entry);
     } else {
       related.push(entry);
@@ -122,7 +110,6 @@ function sortByTypeAndFacts(list: Neighbor[]): void {
   });
 }
 
-sortByTypeAndFacts(perspectives);
 sortByTypeAndFacts(entities);
 
 // Fact lookup map for showing supporting facts when no justification exists
@@ -142,10 +129,6 @@ const uniqueRelNodeTypes = Array.from(relNodeTypeCount.entries())
   .sort((a, b) => b[1] - a[1])
   .map(([type]) => type);
 
-function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: string; cls: string } {
-  if (neighborType !== "perspective") return { label: "", cls: "" };
-  return { label: "perspective of", cls: "stance-supports" };
-}
 ---
 
 <WikiLayout title={node?.concept ?? "Node not found"}>
@@ -213,43 +196,23 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                 <span class={`definition-source-tag ${node.definition_source === "crystallized" ? "crystallized" : "synthesized"}`}>
                   {node.definition_source === "crystallized"
                     ? `crystallized from ${children.length} sub-concept${children.length !== 1 ? "s" : ""}`
-                    : node.node_type === "perspective"
-                      ? "synthesized from nodes"
-                      : "synthesized from dimensions"}
+                    : "synthesized from dimensions"}
                 </span>
-                {node.node_type === "perspective" ? (
-                  <div class="perspective-definition">
-                    {parseMarkdownBlocks(node.definition).map((block) =>
-                      block.kind === "heading" ? (
-                        block.level === 1 ? <h2 class="perspective-h1"><RichSegments segments={block.segments} /></h2> :
-                        block.level === 2 ? <h3 class="perspective-h2"><RichSegments segments={block.segments} /></h3> :
-                        <h4 class="perspective-h3"><RichSegments segments={block.segments} /></h4>
-                      ) : block.kind === "table" ? (
-                        <Fragment set:html={block.rawHtml} />
-                      ) : block.kind === "list-item" ? (
-                        <li class="perspective-paragraph"><RichSegments segments={block.segments} /></li>
-                      ) : (
-                        <p class="perspective-paragraph"><RichSegments segments={block.segments} /></p>
-                      )
-                    )}
-                  </div>
-                ) : (
-                  <div class="node-definition">
-                    {parseMarkdownBlocks(node.definition).map((block) =>
-                      block.kind === "heading" ? (
-                        block.level === 1 ? <h2><RichSegments segments={block.segments} /></h2> :
-                        block.level === 2 ? <h3><RichSegments segments={block.segments} /></h3> :
-                        <h4><RichSegments segments={block.segments} /></h4>
-                      ) : block.kind === "table" ? (
-                        <Fragment set:html={block.rawHtml} />
-                      ) : block.kind === "list-item" ? (
-                        <li><RichSegments segments={block.segments} /></li>
-                      ) : (
-                        <p><RichSegments segments={block.segments} /></p>
-                      )
-                    )}
-                  </div>
-                )}
+                <div class="node-definition">
+                  {parseMarkdownBlocks(node.definition).map((block) =>
+                    block.kind === "heading" ? (
+                      block.level === 1 ? <h2><RichSegments segments={block.segments} /></h2> :
+                      block.level === 2 ? <h3><RichSegments segments={block.segments} /></h3> :
+                      <h4><RichSegments segments={block.segments} /></h4>
+                    ) : block.kind === "table" ? (
+                      <Fragment set:html={block.rawHtml} />
+                    ) : block.kind === "list-item" ? (
+                      <li><RichSegments segments={block.segments} /></li>
+                    ) : (
+                      <p><RichSegments segments={block.segments} /></p>
+                    )
+                  )}
+                </div>
               </>
             ) : dimensions.length > 0 ? (
               <>
@@ -304,85 +267,6 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
                   <li class="relation-row">
                     <a href={`/nodes/${node.parent_key}`} class="relation-row-main" title={node.parent_concept}>{node.parent_concept}</a>
                   </li>
-                </ul>
-              </div>
-            )}
-
-            {antithesis && (
-              <div class="sidebar-box">
-                <div class="sidebar-box-header sidebar-box-header--antithesis sidebar-box-toggle">Antithesis <span class="sidebar-toggle-icon">▾</span></div>
-                <ul class="sidebar-box-list">
-                  <li class="relation-row">
-                    <a href={nodeHref(antithesis)} class="relation-row-main" title={antithesis.concept}>{antithesis.concept}</a>
-                  </li>
-                </ul>
-              </div>
-            )}
-
-            {perspectives.length > 0 && (
-              <div class="sidebar-box">
-                <div class="sidebar-box-header sidebar-box-toggle">
-                  Perspectives ({perspectives.length}) <span class="sidebar-toggle-icon">▾</span>
-                </div>
-                {perspectives.length > 5 && (
-                  <input type="search" class="sidebar-search" data-sidebar-search placeholder="Filter perspectives..." autocomplete="off" />
-                )}
-                <ul class="sidebar-box-list">
-                  {perspectives.map(({ node: n, edges }) => {
-                    const { label, cls } = stanceLabel(edges, n.node_type);
-                    const justifications = edges.filter(e => e.justification);
-                    const factCount = neighborFactCount(edges);
-                    const supportingFacts = edgeSupportingFacts(edges);
-                    const dialogId = `rel-${n.id}`;
-                    return (
-                      <li class="relation-row" data-search-text={n.concept.toLowerCase()}>
-                        <div class="relation-row-main" title={n.concept}>
-                          {label && <span class={`stance-label ${cls}`}>{label}</span>}
-                          <a href={nodeHref(n)}>{n.concept}</a>
-                        </div>
-                        {(justifications.length > 0 || supportingFacts.length > 0) && (
-                          <>
-                            <button class="relation-btn" data-dialog={dialogId}>
-                              relation{factCount > 0 && <span class="relation-btn-count">{factCount}</span>}
-                            </button>
-                            <dialog id={dialogId} class="relation-dialog">
-                              <div class="relation-dialog-inner">
-                                <h3 class="relation-dialog-title">{n.concept}</h3>
-                                {justifications.length > 0 ? (
-                                  justifications.map((e, i) => {
-                                    const edgeFactCount = e.supporting_fact_ids?.length ?? 0;
-                                    const segs = parseJustification(e.justification);
-                                    return (
-                                      <p class="relation-dialog-text">
-                                        {justifications.length > 1 && <strong>[{i + 1}] </strong>}
-                                        {segs.map((s) => s.kind === "text" ? s.text : <a class="citation" href={`/facts/${s.factId}`}>[{s.num}]</a>)}
-                                        {edgeFactCount > 0 && <span class="relation-dialog-fact-count"> — {edgeFactCount} supporting fact{edgeFactCount !== 1 ? "s" : ""}</span>}
-                                      </p>
-                                    );
-                                  })
-                                ) : (
-                                  <>
-                                    <p class="relation-dialog-pending">Justification not yet generated — showing supporting facts</p>
-                                    <ul class="relation-dialog-facts">
-                                      {supportingFacts.map((f) => (
-                                        <li class="relation-dialog-fact-item">
-                                          <a href={`/facts/${f.id}`}>{f.content}</a>
-                                        </li>
-                                      ))}
-                                    </ul>
-                                  </>
-                                )}
-                                <div class="relation-dialog-footer">
-                                  <a class="relation-dialog-detail-link" href={`/edges?source=${nodeUuid}&target=${n.id}`}>view all edge details</a>
-                                  <button class="relation-dialog-close" data-close>Close</button>
-                                </div>
-                              </div>
-                            </dialog>
-                          </>
-                        )}
-                      </li>
-                    );
-                  })}
                 </ul>
               </div>
             )}
@@ -607,7 +491,7 @@ function stanceLabel(_edges: EdgeResponse[], neighborType: string): { label: str
       });
     }
 
-    // ── Sidebar list search (perspectives, entities) ──
+    // ── Sidebar list search (entities) ──
     document.querySelectorAll<HTMLInputElement>("[data-sidebar-search]").forEach((input) => {
       const box = input.closest(".sidebar-box");
       if (!box) return;


### PR DESCRIPTION
## Summary

- Removes all references to `perspective` as a node type and `ancestry`/`crystallization` as features across 15 documentation and wiki files
- Updates node type lists to reflect current reality: `concept`, `entity`, `event`, `location`, `synthesis`, `supersynthesis`
- Removes `contradicts` edge type, antithesis/dialectic sidebar sections, and perspective-specific UI rendering from wiki frontend
- Cleans up stale ontology settings reference in STACK.md

## Context

Perspectives and ancestry were removed from the codebase in PRs #132+ (April 2026) for two reasons:
1. **Simplify the pipeline** — ancestry/crystallization added complexity without proportional value
2. **Nodes already preserve all viewpoints** — concept/entity nodes with multi-model dimensions effectively capture diverse viewpoints without a separate node type

The code was cleaned up but docs still referenced both. This PR aligns documentation with the current architecture.

## What's preserved

- `perspective` as a **fact type** (stance-bearing claims) — this is a valid fact classification, not the removed node type
- General English usage of "perspective" (e.g., "model perspectives", "multiple perspectives coexist")
- "Model Perspectives" label in wiki (refers to dimensions, not node type)

## Files changed (15)

| Area | Files |
|------|-------|
| **Architecture docs** | `ARCHITECTURE.md`, `CLAUDE.md`, `STACK.md`, `README.md` |
| **Docs site** | `index.md`, `values-and-principles.md`, `dimensions.md`, `relations-and-edges.md`, `core-objects.md`, `services.md`, `available-tools.md`, `examples.md` |
| **Wiki frontend** | `about.astro`, `nodes/[id].astro` |
| **Landing page** | `Benefits.astro` |

## Test plan

- [ ] Verify no remaining `perspective` node type references (only fact type + general English)
- [ ] Verify no remaining `ancestry` references in docs (only in deprecated kt-ontology code)
- [ ] Wiki frontend builds successfully
- [ ] Docs site builds successfully
- [ ] Landing page builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)