### PR TITLE
fix(api): use valid openrouter slug for Gemini 3.1 Pro synthesis option

### DIFF
--- a/services/api/src/kt_api/config_api.py
+++ b/services/api/src/kt_api/config_api.py
@@ -69,7 +69,7 @@ async def get_model_roles() -> dict[str, Any]:
 # are added/retired.  To make this configurable without a code change,
 # move the list to Settings and populate from env/YAML.
 SYNTHESIS_MODELS: list[dict[str, str]] = [
-    {"model_id": "openrouter/google/gemini-3.1-pro", "display_name": "Gemini 3.1 Pro", "provider": "google"},
+    {"model_id": "openrouter/google/gemini-3.1-pro-preview", "display_name": "Gemini 3.1 Pro", "provider": "google"},
     {"model_id": "openrouter/z-ai/glm-5v-turbo", "display_name": "GLM 5 Turbo", "provider": "z-ai"},
     {"model_id": "openrouter/minimax/minimax-2.7", "display_name": "MiniMax 2.7", "provider": "minimax"},
     {"model_id": "openrouter/anthropic/claude-sonnet-4", "display_name": "Claude Sonnet", "provider": "anthropic"},


### PR DESCRIPTION
## Summary

- The synthesis model dropdown advertised `openrouter/google/gemini-3.1-pro`, which does not exist on OpenRouter — selecting "Gemini 3.1 Pro" caused synthesis runs to fail with a 404 from the model gateway.
- Fix: switch the curated `SYNTHESIS_MODELS` entry in `services/api/src/kt_api/config_api.py` to the real generic slug `openrouter/google/gemini-3.1-pro-preview`. Display name unchanged.
- Verified other Gemini IDs in `config.yaml`, `kt_config.settings`, frontend pricing, and `knowledge-tree-infra` against OpenRouter — all already valid, no other changes needed.

## Test plan

- [x] `uv run --project services/api pytest services/api/tests/ -k "config or schemas"` — 47 passed
- [ ] Manual: `GET /api/v1/config/synthesis-models` returns the new slug
- [ ] End-to-end: create a synthesis with "Gemini 3.1 Pro" selected and confirm `synthesizer_wf` no longer fails