### PR TITLE
fix(worker-ingest, frontend): plumb graph_id + public-cache toggles UI (PR8)

### DIFF
--- a/frontend/src/app/graphs/[slug]/page.tsx
+++ b/frontend/src/app/graphs/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { Loader2, Plus, UserPlus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
   TooltipContent,
@@ -83,6 +84,31 @@ export default function GraphDetailPage() {
       refreshGraphContext();
     } catch (err) {
       console.error("Graph operation failed:", err);
+    }
+  };
+
+  const [togglesSaving, setTogglesSaving] = useState(false);
+  const [togglesError, setTogglesError] = useState<string | null>(null);
+
+  const handleTogglePublicCache = async (
+    field: "contribute_to_public" | "use_public_cache",
+    value: boolean,
+  ) => {
+    if (!graph) return;
+    // Optimistic update so the switch flips immediately; rolled back
+    // on failure. Saves a re-render flicker on the slow API path.
+    const previous = graph;
+    setGraph({ ...graph, [field]: value });
+    setTogglesError(null);
+    setTogglesSaving(true);
+    try {
+      const updated = await updateGraph(slug, { [field]: value });
+      setGraph(updated);
+    } catch (err) {
+      setGraph(previous);
+      setTogglesError(err instanceof Error ? err.message : "Failed to update toggle");
+    } finally {
+      setTogglesSaving(false);
     }
   };
 
@@ -256,6 +282,67 @@ export default function GraphDetailPage() {
           </div>
         </div>
       </div>
+
+      {/* Public cache settings — non-default graphs only.
+          The default graph has no upstream so the API rejects toggle
+          edits there with HTTP 400; rendering them on the default graph
+          would just be a misleading affordance. */}
+      {!graph.is_default && (
+        <div className="rounded-xl border border-border bg-card p-4 mb-6">
+          <div className="mb-3">
+            <h2 className="text-base font-medium">Public knowledge sharing</h2>
+            <p className="text-xs text-muted-foreground mt-1">
+              Connect this graph to the shared public knowledge pool to save
+              decomposition cost on URLs other graphs have already processed,
+              and to grow the public pool with new ones you ingest. File
+              uploads are always private regardless of these settings.
+            </p>
+          </div>
+
+          <div className="space-y-3 divide-y divide-border">
+            <label className="flex items-start gap-3 pt-3 first:pt-0">
+              <Switch
+                checked={graph.use_public_cache}
+                onCheckedChange={(checked) =>
+                  handleTogglePublicCache("use_public_cache", checked)
+                }
+                disabled={!isAdmin || togglesSaving}
+                aria-label="Use public knowledge cache"
+              />
+              <div className="flex-1">
+                <p className="text-sm font-medium">Use public cache</p>
+                <p className="text-xs text-muted-foreground">
+                  Before decomposing a fetched URL, check the public graph for
+                  an existing decomposition. On a hit, facts and concept nodes
+                  are imported into this graph and the LLM cost is skipped.
+                </p>
+              </div>
+            </label>
+
+            <label className="flex items-start gap-3 pt-3">
+              <Switch
+                checked={graph.contribute_to_public}
+                onCheckedChange={(checked) =>
+                  handleTogglePublicCache("contribute_to_public", checked)
+                }
+                disabled={!isAdmin || togglesSaving}
+                aria-label="Contribute to public knowledge cache"
+              />
+              <div className="flex-1">
+                <p className="text-sm font-medium">Contribute to public graph</p>
+                <p className="text-xs text-muted-foreground">
+                  After decomposing a fetched URL, push the source and
+                  extracted facts upstream so the public pool grows with use.
+                </p>
+              </div>
+            </label>
+          </div>
+
+          {togglesError && (
+            <p className="mt-3 text-xs text-destructive">{togglesError}</p>
+          )}
+        </div>
+      )}
 
       {/* Members */}
       <div className="flex items-center justify-between mb-3">

--- a/frontend/src/components/research/SourceUploadForm.tsx
+++ b/frontend/src/components/research/SourceUploadForm.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -727,20 +728,23 @@ export function SourceUploadForm() {
 
           {/* Public-cache opt-out — hidden when only files were uploaded
               (the API forces share=false server-side in that case so the
-              checkbox would be a misleading affordance). */}
+              switch would be a misleading affordance). */}
           {hasLinkSources && (
-            <label className="flex items-start gap-2 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
-                checked={!shareWithPublicGraph}
-                onChange={(e) => setShareWithPublicGraph(!e.target.checked)}
-                className="mt-0.5"
+            <label className="flex items-start gap-3">
+              <Switch
+                checked={shareWithPublicGraph}
+                onCheckedChange={setShareWithPublicGraph}
+                size="sm"
+                aria-label="Share with public knowledge graph"
               />
-              <span>
-                Do not share with public knowledge graph. The extracted facts
-                will stay private to this graph and won&apos;t help other
-                graphs save decomposition cost on the same URLs.
-              </span>
+              <div className="flex-1">
+                <p className="text-sm font-medium">Share with public graph</p>
+                <p className="text-xs text-muted-foreground">
+                  Contribute extracted facts to the shared public knowledge
+                  pool so other graphs save decomposition cost on the same
+                  URLs.
+                </p>
+              </div>
             </label>
           )}
 

--- a/frontend/src/components/research/SourceUploadForm.tsx
+++ b/frontend/src/components/research/SourceUploadForm.tsx
@@ -90,6 +90,12 @@ export function SourceUploadForm() {
     null,
   );
 
+  // Multigraph public-cache opt-out (PR8). Defaults to "share with public
+  // graph" since that's how the public pool grows. The toggle is hidden
+  // in the file-only case because the API forces False server-side
+  // there anyway — file uploads can never participate.
+  const [shareWithPublicGraph, setShareWithPublicGraph] = useState(true);
+
   // Review state (proposals)
   const [proposals, setProposals] = useState<IngestProposalsResponse | null>(
     null,
@@ -167,6 +173,15 @@ export function SourceUploadForm() {
   }, [prepareResult]);
 
   const selectedChunkCount = selectedChunks.size;
+
+  // Whether the prepared ingest has any link sources at all. Drives the
+  // visibility of the public-cache opt-out toggle — file-only ingests
+  // hide it because the API forces ``share_with_public_graph=false``
+  // server-side regardless of the client value.
+  const hasLinkSources = useMemo(
+    () => prepareResult?.sources.some((s) => s.source_type === "link") ?? false,
+    [prepareResult],
+  );
 
   // Step 1: Analyze sources (prepare)
   const handleAnalyze = async () => {
@@ -276,6 +291,7 @@ export function SourceUploadForm() {
       const result = await api.research.decompose(
         prepareResult.conversation_id,
         allSelected,
+        shareWithPublicGraph,
       );
       setDecomposeMessageId(result.message_id);
     } catch (err) {
@@ -403,6 +419,7 @@ export function SourceUploadForm() {
         prepareResult.conversation_id,
         50, // default nav budget for legacy path
         allSelected,
+        shareWithPublicGraph,
       );
       router.push(`/grow-graph`);
     } catch (err) {
@@ -707,6 +724,25 @@ export function SourceUploadForm() {
               </div>
             </div>
           </div>
+
+          {/* Public-cache opt-out — hidden when only files were uploaded
+              (the API forces share=false server-side in that case so the
+              checkbox would be a misleading affordance). */}
+          {hasLinkSources && (
+            <label className="flex items-start gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={!shareWithPublicGraph}
+                onChange={(e) => setShareWithPublicGraph(!e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                Do not share with public knowledge graph. The extracted facts
+                will stay private to this graph and won&apos;t help other
+                graphs save decomposition cost on the same URLs.
+              </span>
+            </label>
+          )}
 
           {/* Error display */}
           {error && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -842,6 +842,7 @@ export const api = {
       conversationId: string,
       navBudget: number,
       selectedChunks?: number[] | null,
+      shareWithPublicGraph: boolean = true,
     ): Promise<ConversationResponse> {
       return graphRequest<ConversationResponse>(
         `/research/${encodeURIComponent(conversationId)}/confirm`,
@@ -850,6 +851,10 @@ export const api = {
           body: JSON.stringify({
             nav_budget: navBudget,
             selected_chunks: selectedChunks ?? null,
+            // Per-ingest opt-out for the multigraph public-cache
+            // contribute hook. The API forces this to ``false``
+            // server-side for file-only ingests regardless of value.
+            share_with_public_graph: shareWithPublicGraph,
           }),
         },
       );
@@ -868,6 +873,7 @@ export const api = {
     decompose(
       conversationId: string,
       selectedChunks?: number[] | null,
+      shareWithPublicGraph: boolean = true,
     ): Promise<{ conversation_id: string; message_id: string; status: string }> {
       return graphRequest<{ conversation_id: string; message_id: string; status: string }>(
         `/research/${encodeURIComponent(conversationId)}/decompose`,
@@ -875,6 +881,7 @@ export const api = {
           method: "POST",
           body: JSON.stringify({
             selected_chunks: selectedChunks ?? null,
+            share_with_public_graph: shareWithPublicGraph,
           }),
         },
       );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1419,6 +1419,10 @@ export interface GraphResponse {
   updated_at: string;
   member_count: number;
   node_count: number;
+  // Multigraph public-cache toggles. Both default to true for new
+  // non-default graphs; the default graph itself ignores them.
+  contribute_to_public: boolean;
+  use_public_cache: boolean;
 }
 
 export interface CreateGraphRequest {
@@ -1430,11 +1434,17 @@ export interface CreateGraphRequest {
   // "default" or omitted = system DB; otherwise a config_key from
   // listDatabaseConnections() (an external DB provisioned in the infra layer).
   database_connection_config_key?: string;
+  contribute_to_public?: boolean;
+  use_public_cache?: boolean;
 }
 
 export interface UpdateGraphRequest {
   name?: string;
   description?: string;
+  // Use ``null``/omit to leave the existing value unchanged. The API
+  // rejects toggle edits on the default graph with HTTP 400.
+  contribute_to_public?: boolean;
+  use_public_cache?: boolean;
 }
 
 export interface GraphMemberResponse {

--- a/services/worker-ingest/src/kt_worker_ingest/workflows/ingest.py
+++ b/services/worker-ingest/src/kt_worker_ingest/workflows/ingest.py
@@ -267,16 +267,19 @@ async def handle_ingest(input: IngestConfirmInput, ctx: DurableContext) -> dict:
             },
         )
 
-        async with _open_sessions(worker_state) as (_, write_session):
+        async with _open_sessions(worker_state, input.graph_id) as (_, write_session):
             agent_ctx = await _build_agent_context(
                 worker_state,
                 emit_event=emit_cb,
                 write_session=write_session,
                 user_id=input.user_id,
+                graph_id=input.graph_id,
             )
 
             # process_ingest_sources needs graph-db for IngestSource table;
-            # open a short-lived session just for that.
+            # open a short-lived session just for that. IngestSource is a
+            # control-plane table living in the public schema, so it stays
+            # on the system session factory regardless of graph_id.
             async with worker_state.session_factory() as graph_session:
                 processed = await process_ingest_sources(
                     conv_uuid,
@@ -540,6 +543,7 @@ async def handle_ingest(input: IngestConfirmInput, ctx: DurableContext) -> dict:
                             fact_type_counts=decomp_summary.fact_type_counts,
                             all_titles=all_titles,
                             partition_facts=partition.total_facts_in_partition,
+                            graph_id=input.graph_id,
                         ),
                         options=child_meta,
                     )
@@ -579,9 +583,13 @@ async def handle_ingest(input: IngestConfirmInput, ctx: DurableContext) -> dict:
             # Build subgraph from merged results
             from kt_agents_core.results import build_ingest_subgraph
 
-            async with _open_sessions(worker_state) as (_, merge_ws):
+            async with _open_sessions(worker_state, input.graph_id) as (_, merge_ws):
                 merge_ctx = await _build_agent_context(
-                    worker_state, emit_event=emit_cb, write_session=merge_ws, user_id=input.user_id
+                    worker_state,
+                    emit_event=emit_cb,
+                    write_session=merge_ws,
+                    user_id=input.user_id,
+                    graph_id=input.graph_id,
                 )
                 subgraph = await build_ingest_subgraph(all_created_nodes, all_created_edges, merge_ctx)
 
@@ -608,12 +616,13 @@ async def handle_ingest(input: IngestConfirmInput, ctx: DurableContext) -> dict:
 
         else:
             # Small document or no index — single agent (existing path)
-            async with _open_sessions(worker_state) as (_, write_session):
+            async with _open_sessions(worker_state, input.graph_id) as (_, write_session):
                 agent_ctx = await _build_agent_context(
                     worker_state,
                     emit_event=emit_cb,
                     write_session=write_session,
                     user_id=input.user_id,
+                    graph_id=input.graph_id,
                 )
 
                 result = await IngestWorker(agent_ctx).run(
@@ -772,11 +781,12 @@ async def run_ingest_partition(input: IngestPartitionInput, ctx: DurableContext)
         processed_sources = await reconstruct_processed_sources(conv_uuid, session)
 
     # Run the ingest agent scoped to this partition
-    async with _open_sessions(worker_state) as (_, write_session):
+    async with _open_sessions(worker_state, input.graph_id) as (_, write_session):
         agent_ctx = await _build_agent_context(
             worker_state,
             emit_event=emit_cb,
             write_session=write_session,
+            graph_id=input.graph_id,
         )
 
         result = await IngestWorker(agent_ctx).run(
@@ -868,16 +878,17 @@ async def handle_decompose(input: IngestDecomposeInput, ctx: DurableContext) -> 
             },
         )
 
-        async with _open_sessions(worker_state) as (_, write_session):
+        async with _open_sessions(worker_state, input.graph_id) as (_, write_session):
             agent_ctx = await _build_agent_context(
                 worker_state,
                 emit_event=emit_cb,
                 write_session=write_session,
                 user_id=input.user_id,
+                graph_id=input.graph_id,
             )
 
-            # process_ingest_sources needs graph-db for IngestSource table;
-            # open a short-lived session just for that.
+            # IngestSource is a control-plane table — stays on the
+            # system session factory regardless of graph_id.
             async with worker_state.session_factory() as graph_session:
                 processed = await process_ingest_sources(
                     conv_uuid,
@@ -992,7 +1003,7 @@ async def handle_decompose(input: IngestDecomposeInput, ctx: DurableContext) -> 
 
         proposed_nodes: list[ProposedNode] = []
         try:
-            async with _open_sessions(worker_state) as (_, write_session):
+            async with _open_sessions(worker_state, input.graph_id) as (_, write_session):
                 if write_session is not None:
                     seed_repo = WriteSeedRepository(write_session)
                     seeds = await seed_repo.list_seeds(
@@ -1157,6 +1168,7 @@ async def handle_build(input: IngestBuildInput, ctx: DurableContext) -> dict:
                         existing_node_id=node.existing_node_id,
                         message_id=input.message_id,
                         conversation_id=input.conversation_id,
+                        graph_id=input.graph_id,
                     ),
                     options=node_meta,
                 )


### PR DESCRIPTION
## Summary

Two prerequisites for actually flipping the multigraph public-cache feature on for users — the graph_id propagation gap and the missing UI. Both blocked end-to-end usage even with PRs 1-7 merged.

## 1. graph_id propagation through every ingest workflow phase

PR5 wired the cache hooks into Phase 2 of \`ingest_confirm_wf\` and \`ingest_decompose_wf\`, but pre-existing code in Phase 1 (and the partition / merge / build phases) opened sessions via \`_open_sessions(worker_state)\` with **no graph_id**, so for non-default graphs the \`WriteRawSource\` rows landed in the **default** schema and Phase 2 then queried the per-graph schema and found nothing.

Now propagated to every \`_open_sessions\` and \`_build_agent_context\` call site:
- \`handle_ingest\` (\`ingest_confirm_wf\`) — Phase 1, parallel-merge, single-agent fallback
- \`run_ingest_partition\` (\`ingest_partition_wf\`)
- \`handle_decompose\` (\`ingest_decompose_wf\`) — Phase 1, seed-proposal build phase
- \`handle_ingest\` parallel fan-out — \`IngestPartitionInput\` now forwards graph_id to child workflows
- \`handle_build\` (\`ingest_build_wf\`) — \`node_pipeline_wf\` dispatch now forwards graph_id

The \`IngestSource\` control-plane reads stay on \`worker_state.session_factory()\` (graph-db public schema) since that table is per-deployment, not per-graph.

## 2. Public-cache toggles UI

End-user surface for the feature so people don't need to curl the API.

- **Types** (\`frontend/src/types/index.ts\`): \`GraphResponse\` / \`CreateGraphRequest\` / \`UpdateGraphRequest\` gain \`contribute_to_public\` + \`use_public_cache\`.
- **API client** (\`frontend/src/lib/api.ts\`): \`api.research.confirm\` and \`api.research.decompose\` accept and forward \`shareWithPublicGraph\` (default true).
- **Graph settings page** (\`frontend/src/app/graphs/[slug]/page.tsx\`): new "Public knowledge sharing" section with two Switch toggles (use cache, contribute) and copy explaining the cost/privacy tradeoff. Hidden on the default graph (the API rejects toggle edits there). Optimistic update + error rollback. Admin-only.
- **Ingest review step** (\`SourceUploadForm.tsx\`): new "Do not share with public knowledge graph" checkbox on the chunk-review step. Hidden when only files were uploaded — the API forces \`share=false\` server-side in that case so the checkbox would lie to the user about its effect.

## Test plan

- [x] \`uv run --project services/worker-ingest pytest services/worker-ingest/tests/ -q\` — 25 passing
- [x] \`pnpm lint\` — clean
- [x] \`pnpm type-check\` — clean
- [x] \`pnpm test\` — 123/123 vitest tests passing
- [ ] CI green
- [ ] **End-to-end smoke against a real two-graph stack** — next prerequisite for shipping the feature, out of scope for a code-only PR.

## What's still missing before users can use it

After this PR, the only remaining blockers from my "is the feature ready" review are:

3. Qdrant collection-ensure on graphs created mid-run (small)
4. End-to-end smoke test (manual, or a PR that adds a Hatchet-driven integration test)

Refresh-on-stale workflow (deferred from PR7) is still optional — the bridge serves stale immediately, so it's a freshness improvement rather than a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)