### PR TITLE
fix(kt-graph): set dedup_status='ready' on bridge-contributed facts

### DIFF
--- a/libs/kt-graph/src/kt_graph/public_bridge.py
+++ b/libs/kt-graph/src/kt_graph/public_bridge.py
@@ -613,6 +613,13 @@ class PublicGraphBridge:
         # Create new write-db fact under the *remote* UUID so the snapshot
         # round-trips cleanly. The remote graph chose this UUID via dedup
         # already, so reusing it just means our local row matches.
+        #
+        # ``dedup_status='ready'`` — the bridge already performed
+        # embedding-based dedup against the target Qdrant collection
+        # above, so these facts are safe to sync immediately. Without
+        # this, the dedup overhaul's sync gate (``WHERE dedup_status =
+        # 'ready'``) would permanently skip bridge-contributed facts
+        # since no ``dedup_pending_facts_wf`` is dispatched for them.
         stmt = (
             pg_insert(WriteFact)
             .values(
@@ -620,6 +627,7 @@ class PublicGraphBridge:
                 content=fact.content,
                 fact_type=fact.fact_type,
                 metadata_=fact.metadata_,
+                dedup_status="ready",
             )
             .on_conflict_do_nothing(index_elements=[WriteFact.id])
         )


### PR DESCRIPTION
## Summary

Fixes a compatibility issue between the multigraph public-cache bridge (PRs 4-8) and the fact deduplication overhaul (#197).

## The problem

The dedup overhaul added a `dedup_status` column to `WriteFact` (default `'pending'`) and gated the sync worker with `WHERE dedup_status = 'ready'`. Facts that stay in `pending` are never pushed to graph-db.

The bridge's `_dedup_or_create_fact` was not updated — it inserts facts without setting `dedup_status`, so they default to `pending` and get stuck forever in two paths:

1. **Contribute** (`contribute_source_and_facts`): facts pushed to the default graph's write-db land as `pending`. No `dedup_pending_facts_wf` is dispatched for them. They never reach graph-db.
2. **Import** (`import_cached_source`): facts imported into a private graph on a full cache hit (decomposition skipped entirely → no dedup job dispatched) also remain stuck.

## The fix

One-line addition: `dedup_status="ready"` in the `pg_insert(WriteFact).values(...)` call inside `_dedup_or_create_fact`. The bridge already performs embedding-based dedup against the target Qdrant collection before creating a new fact, so these facts are already deduplicated and safe to sync immediately.

## Test plan

- [x] kt-graph unit tests (13 passing) — bridge logic
- [x] worker-ingest unit tests (25 passing) — cache helpers + sweeper
- [ ] CI green
- [ ] Integration tests require Postgres (not running locally) — CI covers these

🤖 Generated with [Claude Code](https://claude.com/claude-code)