### PR TITLE
feat(kt-qdrant): scalar int8 quantization + threshold 0.945

### DIFF
--- a/helm/knowledge-tree/values.yaml
+++ b/helm/knowledge-tree/values.yaml
@@ -445,8 +445,8 @@ configYaml:
     model: "openrouter/minimax/minimax-m2.5:nitro"
 
   facts:
-    dedup_atomic_threshold: 0.95
-    dedup_compound_threshold: 0.95
+    dedup_atomic_threshold: 0.945
+    dedup_compound_threshold: 0.945
 
   edges:
     resolution_model: "openrouter/x-ai/grok-4.1-fast"

--- a/libs/kt-config/src/kt_config/settings.py
+++ b/libs/kt-config/src/kt_config/settings.py
@@ -683,8 +683,8 @@ class Settings(BaseSettings):
     enrichment_edge_justification_sample_size: int = 50
 
     # Facts
-    fact_dedup_atomic_threshold: float = 0.95
-    fact_dedup_compound_threshold: float = 0.95
+    fact_dedup_atomic_threshold: float = 0.945
+    fact_dedup_compound_threshold: float = 0.945
 
     # Seeds
     seed_dedup_embedding_threshold: float = 0.82

--- a/libs/kt-facts/tests/test_dedup.py
+++ b/libs/kt-facts/tests/test_dedup.py
@@ -90,7 +90,7 @@ async def test_insert_pending_requires_write_fact_repo() -> None:
 
 
 def testthreshold_for_type_atomic_vs_compound() -> None:
-    # Both default to 0.95 (configurable via Settings)
-    assert threshold_for_type("quote") == 0.95  # compound
-    assert threshold_for_type("measurement") == 0.95  # atomic
-    assert threshold_for_type("claim") == 0.95  # atomic
+    # Both default to 0.945 (configurable via Settings, widened for quantization margin)
+    assert threshold_for_type("quote") == 0.945  # compound
+    assert threshold_for_type("measurement") == 0.945  # atomic
+    assert threshold_for_type("claim") == 0.945  # atomic

--- a/libs/kt-qdrant/src/kt_qdrant/repositories/facts.py
+++ b/libs/kt-qdrant/src/kt_qdrant/repositories/facts.py
@@ -23,6 +23,9 @@ from qdrant_client.models import (
     MatchValue,
     PointStruct,
     Prefetch,
+    ScalarQuantization,
+    ScalarQuantizationConfig,
+    ScalarType,
     TextIndexParams,
     TextIndexType,
     TokenizerType,
@@ -60,7 +63,12 @@ class QdrantFactRepository:
         self._collection_name = collection_name
 
     async def ensure_collection(self) -> None:
-        """Create the facts collection if it doesn't exist."""
+        """Create the facts collection if it doesn't exist.
+
+        New collections are created with scalar int8 quantization
+        (``always_ram=True``) for faster search. Existing collections
+        get quantization applied via :meth:`ensure_quantization`.
+        """
         settings = get_settings()
         collections = await self._client.get_collections()
         existing = {c.name for c in collections.collections}
@@ -71,8 +79,39 @@ class QdrantFactRepository:
                     size=settings.embedding_dimensions,
                     distance=Distance.COSINE,
                 ),
+                quantization_config=ScalarQuantization(
+                    scalar=ScalarQuantizationConfig(
+                        type=ScalarType.INT8,
+                        always_ram=True,
+                    ),
+                ),
             )
-            logger.info("Created Qdrant collection '%s' (dim=%d)", self._collection_name, settings.embedding_dimensions)
+            logger.info(
+                "Created Qdrant collection '%s' (dim=%d, quantization=int8)",
+                self._collection_name,
+                settings.embedding_dimensions,
+            )
+        else:
+            await self.ensure_quantization()
+
+    async def ensure_quantization(self) -> None:
+        """Enable scalar int8 quantization on an existing collection if not already set."""
+        try:
+            info = await self._client.get_collection(self._collection_name)
+            if info.config.quantization_config is not None:
+                return  # already configured
+            await self._client.update_collection(
+                collection_name=self._collection_name,
+                quantization_config=ScalarQuantization(
+                    scalar=ScalarQuantizationConfig(
+                        type=ScalarType.INT8,
+                        always_ram=True,
+                    ),
+                ),
+            )
+            logger.info("Enabled scalar int8 quantization on '%s'", self._collection_name)
+        except Exception:
+            logger.warning("Failed to enable quantization on '%s'", self._collection_name, exc_info=True)
 
     async def ensure_text_index(self) -> None:
         """Create a full-text index on the 'content' payload field if not present."""


### PR DESCRIPTION
## Summary

- Enable scalar int8 quantization on Qdrant facts collection (`always_ram=true`, rescore with full-precision vectors)
- `ensure_collection` creates new collections with quantization; `ensure_quantization` applies it to existing ones on startup
- Lower dedup thresholds from 0.95 to 0.945 to compensate for quantization's candidate selection margin (<0.005 precision loss)
- Update Helm chart default configYaml

Companion infra PR bumps Qdrant to 8Gi memory / 2 CPU and sets 0.945 thresholds in prod+dev values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)