### PR TITLE
fix(docker): include worker source packages in API Dockerfile

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -19,8 +19,12 @@ COPY services/worker-search/pyproject.toml services/worker-search/pyproject.toml
 COPY services/worker-sync/pyproject.toml services/worker-sync/pyproject.toml
 COPY services/worker-synthesis/pyproject.toml services/worker-synthesis/pyproject.toml
 
-# Copy this service's source
+# Copy this service's source + worker packages imported by the API
+# (research.py imports kt_worker_ingest; prompt_transparency.py imports kt_worker_synthesis, kt_worker_nodes)
 COPY services/api/ services/api/
+COPY services/worker-ingest/ services/worker-ingest/
+COPY services/worker-synthesis/ services/worker-synthesis/
+COPY services/worker-nodes/ services/worker-nodes/
 
 # Install dependencies
 RUN uv sync --frozen --no-dev --package kt-api


### PR DESCRIPTION
## Summary
- The API service imports from `kt_worker_ingest` (prepare endpoint), `kt_worker_synthesis`, and `kt_worker_nodes` (prompt transparency endpoint)
- The API Dockerfile only copied these workers' `pyproject.toml` for workspace resolution, but **not their source code**
- This caused `ModuleNotFoundError: No module named 'kt_worker_ingest'` at runtime, resulting in a **500 on `POST /api/v1/research/prepare`** — all link/file ingestion was broken in production
- The prompt transparency endpoint (`GET /api/v1/prompts`) silently degraded (try/except), returning fewer prompts than expected

## Fix
Copy the three worker source directories (`worker-ingest/`, `worker-synthesis/`, `worker-nodes/`) in the API Dockerfile so `uv sync --package kt-api` can install them as workspace dependencies.

## Test plan
- [ ] Docker build succeeds: `docker build -f services/api/Dockerfile .`
- [ ] `POST /api/v1/research/prepare` with a link no longer returns 500
- [ ] `GET /api/v1/prompts` returns the full set of prompts (synthesis, node pipeline, composite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)