### PR TITLE
fix(kt-providers,frontend): DOI full-text extraction + prepare graph-scoping

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,7 +135,9 @@ async function request<T>(
 
   const res = await fetch(url, {
     headers: {
-      "Content-Type": "application/json",
+      ...(!(options.body instanceof FormData) && {
+        "Content-Type": "application/json",
+      }),
       ...getAuthHeader(),
       ...options.headers,
     },
@@ -821,20 +823,9 @@ export const api = {
   // -------------------------------------------------------------------------
   research: {
     prepare(formData: FormData): Promise<IngestPrepareResponse> {
-      const url = `${BASE_URL}${API_PREFIX}/research/prepare`;
-      return fetch(url, {
+      return graphRequest<IngestPrepareResponse>("/research/prepare", {
         method: "POST",
-        headers: { ...getAuthHeader() },
         body: formData,
-        // Do NOT set Content-Type — browser sets multipart boundary automatically
-      }).then(async (res) => {
-        if (!res.ok) {
-          const body = await res.text().catch(() => "");
-          throw new Error(
-            `API error ${res.status} ${res.statusText}: ${body}`.trim(),
-          );
-        }
-        return res.json() as Promise<IngestPrepareResponse>;
       });
     },
 
@@ -867,7 +858,10 @@ export const api = {
     },
 
     getSourceDownloadUrl(conversationId: string, sourceId: string): string {
-      return `${BASE_URL}${API_PREFIX}/research/${encodeURIComponent(conversationId)}/sources/${encodeURIComponent(sourceId)}/download`;
+      const path = graphPath(
+        `/research/${encodeURIComponent(conversationId)}/sources/${encodeURIComponent(sourceId)}/download`,
+      );
+      return `${BASE_URL}${API_PREFIX}${path}`;
     },
 
     decompose(

--- a/libs/kt-providers/src/kt_providers/fetch/doi_provider.py
+++ b/libs/kt-providers/src/kt_providers/fetch/doi_provider.py
@@ -34,7 +34,11 @@ import httpx
 from kt_config.settings import get_settings
 from kt_providers.fetch.base import ContentFetcherProvider
 from kt_providers.fetch.canonical import DOI_REGEX
-from kt_providers.fetch.extract import extract_html_metadata
+from kt_providers.fetch.extract import (
+    classify_content_type,
+    extract_html_metadata,
+    extract_pdf,
+)
 from kt_providers.fetch.types import MIN_EXTRACTED_LENGTH, FetchResult
 from kt_providers.fetch.url_safety import UnsafeUrlError, validate_fetch_url
 
@@ -140,15 +144,12 @@ class DoiContentFetcher(ContentFetcherProvider):
                 content_type="application/json",
             )
 
-        # Best-effort: try to enrich with an Unpaywall OA PDF link.
+        # Best-effort: try to enrich with full-text from an Unpaywall OA PDF.
         oa_url = None
         try:
             oa_url = await self._fetch_unpaywall_oa(doi)
         except Exception:
             logger.debug("Unpaywall lookup failed for %s", doi, exc_info=True)
-
-        if oa_url:
-            body = f"{body}\n\nOpen-access PDF: {oa_url}"
 
         meta_out: dict[str, str | None] = {"doi": doi, "oa_pdf_url": oa_url}
         title_value = metadata.get("title")
@@ -160,10 +161,56 @@ class DoiContentFetcher(ContentFetcherProvider):
         if isinstance(publisher, str):
             meta_out["publisher"] = publisher
 
+        # If we have an OA PDF URL, download and extract full text.
+        if oa_url:
+            pdf_result = await self._try_fetch_pdf(uri, oa_url, body, meta_out)
+            if pdf_result is not None:
+                return pdf_result
+
         return FetchResult(
             uri=uri,
             content=body,
             content_type="text/plain",
+            html_metadata=meta_out,
+        )
+
+    async def _try_fetch_pdf(
+        self,
+        uri: str,
+        oa_url: str,
+        metadata_body: str,
+        meta_out: dict[str, str | None],
+    ) -> FetchResult | None:
+        """Download an OA PDF and extract full text, returning None on failure."""
+        try:
+            client = await self._client_()
+            response = await client.get(oa_url, headers={"Accept": "application/pdf, */*"})
+        except Exception:
+            logger.debug("OA PDF download failed for %s", oa_url, exc_info=True)
+            return None
+
+        if response.status_code >= 400:
+            logger.debug("OA PDF returned %s for %s", response.status_code, oa_url)
+            return None
+
+        ct = response.headers.get("content-type", "")
+        if classify_content_type(ct) != "pdf":
+            logger.debug("OA URL returned non-PDF content-type %s for %s", ct, oa_url)
+            return None
+
+        pdf_result = extract_pdf(uri, response.content, ct)
+        if not pdf_result.success:
+            logger.debug("PDF extraction failed for %s: %s", oa_url, pdf_result.error)
+            return None
+
+        # Combine Crossref metadata header with extracted PDF text.
+        combined = f"{metadata_body}\n\n---\n\n{pdf_result.content}"
+        return FetchResult(
+            uri=uri,
+            content=combined,
+            content_type="application/pdf",
+            page_count=pdf_result.page_count,
+            pdf_metadata=pdf_result.pdf_metadata,
             html_metadata=meta_out,
         )
 

--- a/libs/kt-providers/tests/fetch/test_doi_provider.py
+++ b/libs/kt-providers/tests/fetch/test_doi_provider.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from kt_providers.fetch.doi_provider import DoiContentFetcher, _format_metadata
+from kt_providers.fetch.types import FetchResult
 
 
 @pytest.mark.asyncio
@@ -156,3 +157,136 @@ async def test_extract_doi_from_meta_tag(monkeypatch: pytest.MonkeyPatch):
 
     doi = await p._extract_doi("https://www.cell.com/some/page")
     assert doi == "10.5555/found-doi"
+
+
+# ── OA PDF download & extraction tests ──────────────────────────
+
+
+def _crossref_message() -> dict[str, object]:
+    return {
+        "DOI": "10.1234/abcd",
+        "title": ["A great paper"],
+        "author": [{"given": "Ada", "family": "Lovelace"}],
+        "publisher": "Test Press",
+        "abstract": "<jats:p>Abstract text.</jats:p>",
+    }
+
+
+@pytest.mark.asyncio
+async def test_doi_fetcher_downloads_oa_pdf(monkeypatch: pytest.MonkeyPatch):
+    """When Unpaywall provides an OA URL and the PDF downloads successfully,
+    the result should contain both metadata and extracted PDF text."""
+    p = DoiContentFetcher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return _crossref_message()
+
+    async def fake_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return "https://arxiv.org/pdf/1234.pdf"
+
+    pdf_response = MagicMock()
+    pdf_response.status_code = 200
+    pdf_response.headers = {"content-type": "application/pdf"}
+    pdf_response.content = b"%PDF-fake-bytes"
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=pdf_response)
+    client.is_closed = False
+
+    async def fake_client(self):  # type: ignore[no-untyped-def]
+        return client
+
+    def fake_extract_pdf(uri: str, pdf_bytes: bytes, ct: str) -> FetchResult:
+        return FetchResult(
+            uri=uri,
+            content="Full paper text extracted from PDF. " * 10,
+            content_type="application/pdf",
+            page_count=12,
+            pdf_metadata={"title": "A great paper"},
+        )
+
+    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_provider.extract_pdf", fake_extract_pdf)
+
+    result = await p.fetch("https://doi.org/10.1234/abcd")
+    assert result.success is True
+    assert result.content_type == "application/pdf"
+    assert result.page_count == 12
+    assert result.pdf_metadata == {"title": "A great paper"}
+    # Should contain both metadata header and PDF text
+    assert "A great paper" in (result.content or "")
+    assert "Full paper text extracted from PDF." in (result.content or "")
+    assert "---" in (result.content or "")
+    # html_metadata should still have DOI and OA URL
+    assert result.html_metadata is not None
+    assert result.html_metadata["doi"] == "10.1234/abcd"
+    assert result.html_metadata["oa_pdf_url"] == "https://arxiv.org/pdf/1234.pdf"
+
+
+@pytest.mark.asyncio
+async def test_doi_fetcher_falls_back_on_pdf_download_failure(monkeypatch: pytest.MonkeyPatch):
+    """When OA PDF download fails, fall back to metadata-only result."""
+    p = DoiContentFetcher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return _crossref_message()
+
+    async def fake_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return "https://arxiv.org/pdf/1234.pdf"
+
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=Exception("connection refused"))
+    client.is_closed = False
+
+    async def fake_client(self):  # type: ignore[no-untyped-def]
+        return client
+
+    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
+
+    result = await p.fetch("https://doi.org/10.1234/abcd")
+    assert result.success is True
+    assert result.content_type == "text/plain"
+    assert "A great paper" in (result.content or "")
+    assert result.html_metadata is not None
+    assert result.html_metadata["oa_pdf_url"] == "https://arxiv.org/pdf/1234.pdf"
+
+
+@pytest.mark.asyncio
+async def test_doi_fetcher_falls_back_when_pdf_extraction_fails(monkeypatch: pytest.MonkeyPatch):
+    """When PDF downloads but extraction fails, fall back to metadata-only."""
+    p = DoiContentFetcher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return _crossref_message()
+
+    async def fake_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return "https://arxiv.org/pdf/1234.pdf"
+
+    pdf_response = MagicMock()
+    pdf_response.status_code = 200
+    pdf_response.headers = {"content-type": "application/pdf"}
+    pdf_response.content = b"not-a-real-pdf"
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=pdf_response)
+    client.is_closed = False
+
+    async def fake_client(self):  # type: ignore[no-untyped-def]
+        return client
+
+    def fake_extract_pdf(uri: str, pdf_bytes: bytes, ct: str) -> FetchResult:
+        return FetchResult(uri=uri, error="corrupt PDF")
+
+    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_provider.extract_pdf", fake_extract_pdf)
+
+    result = await p.fetch("https://doi.org/10.1234/abcd")
+    assert result.success is True
+    assert result.content_type == "text/plain"
+    assert "A great paper" in (result.content or "")


### PR DESCRIPTION
## Summary

- **DOI fetcher now downloads full paper content**: When Unpaywall returns an OA PDF URL, the `DoiContentFetcher` now actually downloads and extracts the PDF text (via `extract_pdf`) instead of just appending the URL as a string. Falls back gracefully to Crossref metadata (abstract-only) on any failure.
- **Frontend `prepare()` now uses graph-scoped routing**: `prepare()` and `getSourceDownloadUrl()` were bypassing `graphRequest`, causing a 404 "Conversation not found" on non-default graphs. Both now route through `graphRequest`/`graphPath` correctly. The `request()` helper was updated to skip `Content-Type: application/json` for `FormData` bodies.

## Test plan

- [x] All 10 DOI provider unit tests pass (3 new tests for PDF download, download failure fallback, extraction failure fallback)
- [x] Frontend lint, type-check, and all 123 tests pass
- [ ] Manual: ingest a PubMed/Cell.com URL and verify content includes full paper text
- [ ] Manual: on a non-default graph, run prepare → decompose flow without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)