### PR TITLE
fix(kt-db): merge write-db heads and add per-graph migrations to job

### DIFF
--- a/helm/knowledge-tree/templates/migration-job.yaml
+++ b/helm/knowledge-tree/templates/migration-job.yaml
@@ -69,7 +69,11 @@ spec:
               echo "Running write-db migrations..."
               uv run alembic -c alembic_write.ini upgrade heads
 
-              echo "Migrations complete"
+              echo "Running per-graph schema migrations..."
+              cd /app
+              uv run --project libs/kt-db python -m kt_db.migrate
+
+              echo "All migrations complete"
           env:
             - name: GRAPH_DB_PASSWORD
               valueFrom:

--- a/libs/kt-db/alembic_write/versions/750a40fc98be_merge_write_db_heads.py
+++ b/libs/kt-db/alembic_write/versions/750a40fc98be_merge_write_db_heads.py
@@ -1,0 +1,23 @@
+"""merge write-db heads
+
+Revision ID: 750a40fc98be
+Revises: 3f7a2b289e43, e8909148c815
+Create Date: 2026-04-12 14:17:19.095932
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "750a40fc98be"
+down_revision: Union[str, None] = ("3f7a2b289e43", "e8909148c815")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/libs/kt-db/src/kt_db/migrate.py
+++ b/libs/kt-db/src/kt_db/migrate.py
@@ -80,7 +80,7 @@ def _run_alembic(
     graph_slug: str,
     db_label: str,
 ) -> None:
-    """Run alembic upgrade head for a specific config."""
+    """Run alembic upgrade heads for a specific config."""
     cmd = [
         sys.executable,
         "-m",
@@ -88,7 +88,7 @@ def _run_alembic(
         "-c",
         str(_KT_DB_ROOT / ini_file),
         "upgrade",
-        "head",
+        "heads",
     ]
     logger.info("  [%s/%s] %s", graph_slug, db_label, " ".join(cmd[-3:]))
     result = subprocess.run(cmd, env=env, capture_output=True, text=True, cwd=str(_KT_DB_ROOT))


### PR DESCRIPTION
## Summary
- Merges two divergent write-db alembic heads (`3f7a2b289e43` and `e8909148c815`) into a single head
- Updates the Helm migration job to also run `python -m kt_db.migrate` which iterates all active graph schemas and runs per-schema migrations
- Fixes `migrate.py` to use `upgrade heads` instead of `upgrade head` for resilience

## Context
The shared graph-db's `graph_scientific` schema was never migrated because the migration job only ran `alembic upgrade heads` on the public schema. This caused `raw_sources.canonical_url does not exist` errors when ingesting sources (e.g. PubMed links returning 0 chunks).

The shared databases have been manually migrated on prod to unblock immediately. This PR prevents the issue from recurring on future deployments.

## Test plan
- [ ] CI passes
- [ ] Verify `uv run alembic -c alembic_write.ini heads` shows single head
- [ ] Deploy to dev and confirm migration job logs show per-graph schema migrations running

🤖 Generated with [Claude Code](https://claude.com/claude-code)