### PR TITLE
fix(worker-ingest): register missing workflows in prod entry point

### DIFF
--- a/services/worker-ingest/src/kt_worker_ingest/__main__.py
+++ b/services/worker-ingest/src/kt_worker_ingest/__main__.py
@@ -7,7 +7,13 @@ import logging
 
 from kt_hatchet.client import get_hatchet
 from kt_hatchet.lifespan import worker_lifespan
-from kt_worker_ingest.workflows.ingest import ingest_confirm_wf, ingest_partition_wf
+from kt_worker_ingest.workflows.ingest import (
+    ingest_build_wf,
+    ingest_confirm_wf,
+    ingest_decompose_wf,
+    ingest_partition_wf,
+)
+from kt_worker_ingest.workflows.public_cache_sweeper import public_cache_sweep_wf
 
 
 def main() -> None:
@@ -22,7 +28,13 @@ def main() -> None:
     worker = hatchet.worker(
         "ingest",
         slots=10,
-        workflows=[ingest_confirm_wf, ingest_partition_wf],
+        workflows=[
+            ingest_build_wf,
+            ingest_confirm_wf,
+            ingest_decompose_wf,
+            ingest_partition_wf,
+            public_cache_sweep_wf,
+        ],
         lifespan=worker_lifespan,
     )
     worker.start()


### PR DESCRIPTION
## Summary

The standalone `worker-ingest` entry point (`__main__.py`) only registered 2 of 5 workflows:
- `ingest_confirm_wf`
- `ingest_partition_wf`

**Missing** (only registered in `worker-all` dev mode):
- `ingest_decompose_wf` — Phase 1 decomposition, dispatched by "Extract & Analyze"
- `ingest_build_wf` — Phase 2 node building
- `public_cache_sweep_wf` — public graph cache maintenance

This caused all decompose and build dispatches to silently queue forever in Hatchet with no consumer picking them up in production.

## Test plan

- [x] Pre-commit hooks pass (lint, format, typecheck)
- [ ] Deploy and verify decompose workflow runs on the ingest worker
- [ ] Verify build workflow also runs after decompose completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)