### PR TITLE
fix(workers): content_fetcher → fetch_registry in AgentContext calls

### DIFF
--- a/services/worker-bottomup/src/kt_worker_bottomup/shared.py
+++ b/services/worker-bottomup/src/kt_worker_bottomup/shared.py
@@ -85,7 +85,7 @@ async def _build_agent_context(
         embedding_service=embedding_service,
         session=None,
         session_factory=resolved_sf,
-        content_fetcher=state.content_fetcher,
+        fetch_registry=state.fetch_registry,
         emit_event=emit_event,
         write_session_factory=resolved_write_sf,
         qdrant_client=state.qdrant_client,

--- a/services/worker-ingest/src/kt_worker_ingest/workflows/ingest.py
+++ b/services/worker-ingest/src/kt_worker_ingest/workflows/ingest.py
@@ -126,7 +126,7 @@ async def _build_agent_context(
         embedding_service=embedding_service,
         session=None,
         emit_event=emit_event,
-        content_fetcher=state.content_fetcher,
+        fetch_registry=state.fetch_registry,
         session_factory=resolved_sf,
         write_session_factory=resolved_write_sf,
         qdrant_client=state.qdrant_client,

--- a/services/worker-nodes/src/kt_worker_nodes/hatchet_pipeline.py
+++ b/services/worker-nodes/src/kt_worker_nodes/hatchet_pipeline.py
@@ -105,7 +105,7 @@ class HatchetPipeline:
             embedding_service=embedding_service,
             session=None,
             session_factory=resolved_sf,
-            content_fetcher=self._state.content_fetcher,  # type: ignore[arg-type]
+            fetch_registry=self._state.fetch_registry,  # type: ignore[arg-type]
             emit_event=emit_event,
             write_session_factory=resolved_write_sf,
             qdrant_client=self._state.qdrant_client,

--- a/services/worker-nodes/src/kt_worker_nodes/workflows/composite.py
+++ b/services/worker-nodes/src/kt_worker_nodes/workflows/composite.py
@@ -108,7 +108,7 @@ async def build_composite_task(input: BuildCompositeInput, ctx: Context) -> dict
             embedding_service=state.embedding_service,
             session=None,
             session_factory=state.session_factory,
-            content_fetcher=state.content_fetcher,
+            fetch_registry=state.fetch_registry,
             write_session_factory=state.write_session_factory,
             qdrant_client=state.qdrant_client,
         )
@@ -294,7 +294,7 @@ async def regenerate_composite_task(input: RegenerateCompositeInput, ctx: Contex
             embedding_service=state.embedding_service,
             session=None,
             session_factory=state.session_factory,
-            content_fetcher=state.content_fetcher,
+            fetch_registry=state.fetch_registry,
             write_session_factory=state.write_session_factory,
             qdrant_client=state.qdrant_client,
         )


### PR DESCRIPTION
## Summary

All worker services passed `content_fetcher=state.content_fetcher` when building `AgentContext`, but `WorkerState` has no `content_fetcher` attribute — it's called `fetch_registry`. Same on `AgentContext.__init__`. This caused an immediate `AttributeError` on any workflow that calls `_build_agent_context`.

**Fixed in 4 files across 3 workers:**
- `services/worker-ingest/src/kt_worker_ingest/workflows/ingest.py`
- `services/worker-bottomup/src/kt_worker_bottomup/shared.py`
- `services/worker-nodes/src/kt_worker_nodes/hatchet_pipeline.py`
- `services/worker-nodes/src/kt_worker_nodes/workflows/composite.py`

## Test plan

- [x] Pre-commit hooks pass
- [ ] Deploy and verify decompose workflow completes without AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)