### PR TITLE
fix(kt-config): add missing public_contribute_retry settings

### DIFF
--- a/libs/kt-config/src/kt_config/settings.py
+++ b/libs/kt-config/src/kt_config/settings.py
@@ -630,6 +630,10 @@ class Settings(BaseSettings):
     # this over time as compute budget allows more frequent refreshes.
     public_cache_refresh_after_days: int = 365
 
+    # Public-cache contribute sweeper (retries failed contribute-back rows).
+    public_contribute_retry_min_age_minutes: int = 15
+    public_contribute_retry_batch_size: int = 200
+
     # Crossref + Unpaywall contact emails (used by the DOI fetcher).
     # Crossref's "polite pool" gives configured users better rate limits;
     # Unpaywall *requires* an email parameter on every request.


### PR DESCRIPTION
## Summary

The `public_cache_sweeper` workflow references `public_contribute_retry_min_age_minutes` and `public_contribute_retry_batch_size` on `Settings`, but they were never added to the Settings class. Tests passed because they mock Settings with `SimpleNamespace`.

Added both with defaults matching the test fixtures (`min_age=15`, `batch_size=200`).

## Test plan

- [x] Pre-commit hooks pass
- [ ] Deploy and verify sweeper no longer crashes with AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)