### PR TITLE
refactor(kt-providers): DOI as post-fetch enrichment layer

### DIFF
--- a/libs/kt-config/src/kt_config/settings.py
+++ b/libs/kt-config/src/kt_config/settings.py
@@ -381,6 +381,7 @@ _register(
         "fetch_flaresolverr_timeout": "flaresolverr_timeout",
         "fetch_host_overrides": "host_overrides",
         "fetch_provider_public_overrides": "provider_public_overrides",
+        "fetch_doi_enrichment": "doi_enrichment",
         "fetch_host_pref_ttl_seconds": "host_pref_ttl_seconds",
         "crossref_email": "crossref_email",
         "unpaywall_email": "unpaywall_email",
@@ -639,6 +640,12 @@ class Settings(BaseSettings):
     # Unpaywall *requires* an email parameter on every request.
     crossref_email: str = ""
     unpaywall_email: str = ""
+
+    # Post-fetch DOI enrichment via Crossref/Unpaywall.  When enabled, the
+    # fetch registry runs a post-fetch hook that queries Crossref for
+    # canonical metadata whenever a fetched page from a known publisher host
+    # contains a DOI.  Disable to skip the extra API roundtrip.
+    fetch_doi_enrichment: bool = True
 
     # TTL for the Redis-backed learned-host-preference cache.
     fetch_host_pref_ttl_seconds: int = 60 * 60 * 24 * 30  # 30 days

--- a/libs/kt-providers/src/kt_providers/fetch/__init__.py
+++ b/libs/kt-providers/src/kt_providers/fetch/__init__.py
@@ -9,6 +9,7 @@ for the DI helper that wires it from settings.
 
 from kt_providers.fetch.base import ContentFetcherProvider
 from kt_providers.fetch.builder import build_fetch_registry
+from kt_providers.fetch.doi_enricher import DoiEnricher
 from kt_providers.fetch.file_data_store import FileDataStore
 from kt_providers.fetch.host_pref import (
     HostPreferenceStore,
@@ -32,6 +33,7 @@ __all__ = [
     "ALLOWED_SCHEMES",
     "MIN_EXTRACTED_LENGTH",
     "ContentFetcherProvider",
+    "DoiEnricher",
     "FetchAttempt",
     "FetchProviderRegistry",
     "FetchResult",

--- a/libs/kt-providers/src/kt_providers/fetch/builder.py
+++ b/libs/kt-providers/src/kt_providers/fetch/builder.py
@@ -124,10 +124,24 @@ def build_fetch_registry(
     else:
         pref_store = None
 
+    # Post-fetch DOI enrichment — queries Crossref/Unpaywall after a
+    # provider successfully fetches a page from a known publisher host.
+    from collections.abc import Awaitable, Callable
+
+    from kt_providers.fetch.types import FetchResult
+
+    post_fetch_hooks: list[Callable[[str, FetchResult], Awaitable[FetchResult]]] = []
+    if getattr(settings, "fetch_doi_enrichment", True):
+        from kt_providers.fetch.doi_enricher import DoiEnricher
+
+        enricher = DoiEnricher(timeout=settings.full_text_fetch_timeout)
+        post_fetch_hooks.append(enricher.enrich)
+
     return FetchProviderRegistry(
         providers=providers,
         chain=chain,
         host_overrides=host_overrides,
         host_pref_store=pref_store,
         url_validator=validate_fetch_url,
+        post_fetch_hooks=post_fetch_hooks,
     )

--- a/libs/kt-providers/src/kt_providers/fetch/doi_enricher.py
+++ b/libs/kt-providers/src/kt_providers/fetch/doi_enricher.py
@@ -1,0 +1,342 @@
+"""Post-fetch DOI enrichment via Crossref and Unpaywall.
+
+This module is the **resolution layer** for academic content.  It runs
+*after* a successful page fetch (curl_cffi, httpx, flaresolverr, etc.)
+and checks whether the fetched page belongs to a known academic publisher
+and contains a DOI.  When a DOI is found it:
+
+1. Queries Crossref for canonical scholarly metadata (title, authors,
+   abstract, journal, publication date).
+2. Queries Unpaywall for an open-access PDF link.
+3. If an OA PDF exists, downloads it and upgrades the ``FetchResult``
+   content with the full text.
+4. Merges Crossref metadata fields into ``html_metadata`` so downstream
+   consumers (multigraph cache, ingest pipeline) can use them.
+
+The enricher is wired into ``FetchProviderRegistry`` as a post-fetch hook
+by ``build_fetch_registry``.  It is **not** a ``ContentFetcherProvider`` --
+it enhances results rather than competing in the fetch chain.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from urllib.parse import urlparse
+
+import httpx
+
+from kt_config.settings import get_settings
+from kt_providers.fetch.canonical import _doi_from_url
+from kt_providers.fetch.extract import classify_content_type, extract_pdf
+from kt_providers.fetch.types import FetchAttempt, FetchResult
+from kt_providers.fetch.url_safety import UnsafeUrlError, validate_fetch_url
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Known academic publisher hosts where DOI enrichment is worthwhile.
+# Anything else is skipped so we don't waste a Crossref roundtrip on a
+# random blog post.
+# ---------------------------------------------------------------------------
+PUBLISHER_HOSTS: frozenset[str] = frozenset(
+    {
+        "cell.com",
+        "www.cell.com",
+        "sciencedirect.com",
+        "www.sciencedirect.com",
+        "linkinghub.elsevier.com",
+        "nature.com",
+        "www.nature.com",
+        "link.springer.com",
+        "springer.com",
+        "onlinelibrary.wiley.com",
+        "wiley.com",
+        "tandfonline.com",
+        "www.tandfonline.com",
+        "journals.sagepub.com",
+        "academic.oup.com",
+        "ieeexplore.ieee.org",
+        "dl.acm.org",
+        "jstor.org",
+        "www.jstor.org",
+        "pubmed.ncbi.nlm.nih.gov",
+        "www.ncbi.nlm.nih.gov",
+        "pmc.ncbi.nlm.nih.gov",
+        "biorxiv.org",
+        "www.biorxiv.org",
+        "medrxiv.org",
+        "www.medrxiv.org",
+    }
+)
+
+CROSSREF_API = "https://api.crossref.org/works/{doi}"
+UNPAYWALL_API = "https://api.unpaywall.org/v2/{doi}"
+
+
+class DoiEnricher:
+    """Post-fetch DOI enrichment via Crossref and Unpaywall.
+
+    This class is used as a post-fetch hook on :class:`FetchProviderRegistry`.
+    Its :meth:`enrich` method signature matches the hook protocol::
+
+        async def enrich(uri: str, result: FetchResult) -> FetchResult
+    """
+
+    def __init__(self, timeout: float = 10.0) -> None:
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    async def _client_(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            ua = get_settings().fetch_user_agent
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(self._timeout),
+                follow_redirects=True,
+                headers={"User-Agent": ua, "Accept": "application/json"},
+            )
+        return self._client
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def enrich(self, uri: str, result: FetchResult) -> FetchResult:
+        """Attempt DOI-based enrichment on a successful ``FetchResult``.
+
+        Returns the original *result* unmodified when:
+
+        - The host is not a known publisher.
+        - No DOI can be extracted from ``html_metadata`` or the URL.
+        - Crossref lookup fails or returns sparse metadata.
+
+        Otherwise merges Crossref metadata into ``html_metadata`` and
+        optionally upgrades ``content`` with OA PDF full text.
+        """
+        host = urlparse(uri).netloc.lower()
+        if host not in PUBLISHER_HOSTS:
+            return result
+
+        doi = self._extract_doi(uri, result)
+        if doi is None:
+            return result
+
+        t0 = time.perf_counter()
+
+        try:
+            metadata = await self._fetch_crossref(doi)
+        except Exception as e:
+            logger.debug("DOI enrichment: Crossref failed for %s: %s", doi, e)
+            result.attempts.append(
+                FetchAttempt("doi_enricher", success=False, error=f"crossref: {e}", elapsed_ms=_ms(t0))
+            )
+            return result
+
+        if metadata is None:
+            result.attempts.append(
+                FetchAttempt("doi_enricher", success=False, error=f"DOI {doi} not in Crossref", elapsed_ms=_ms(t0))
+            )
+            return result
+
+        # Merge Crossref metadata into html_metadata.
+        meta = dict(result.html_metadata or {})
+        meta["doi"] = doi
+        title_value = metadata.get("title")
+        if isinstance(title_value, list) and title_value:
+            meta["title"] = str(title_value[0])
+        elif isinstance(title_value, str):
+            meta["title"] = title_value
+        publisher = metadata.get("publisher")
+        if isinstance(publisher, str):
+            meta["publisher"] = publisher
+        meta["enriched_by"] = "crossref"
+
+        # Best-effort Unpaywall OA PDF lookup.
+        oa_url: str | None = None
+        try:
+            oa_url = await self._fetch_unpaywall_oa(doi)
+        except Exception:
+            logger.debug("DOI enrichment: Unpaywall failed for %s", doi, exc_info=True)
+
+        meta["oa_pdf_url"] = oa_url
+        result.html_metadata = meta
+
+        # If we have an OA PDF, try to upgrade the content with full text.
+        if oa_url:
+            crossref_body = format_metadata(metadata)
+            upgraded = await self._try_fetch_pdf(uri, oa_url, crossref_body, meta)
+            if upgraded is not None:
+                # Preserve the original provider_id and attempts — just
+                # upgrade content, content_type, and PDF metadata.
+                result.content = upgraded.content
+                result.content_type = upgraded.content_type
+                result.page_count = upgraded.page_count
+                result.pdf_metadata = upgraded.pdf_metadata
+                result.html_metadata = upgraded.html_metadata
+
+        result.attempts.append(FetchAttempt("doi_enricher", success=True, error=None, elapsed_ms=_ms(t0)))
+        return result
+
+    # ------------------------------------------------------------------
+    # DOI extraction
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_doi(uri: str, result: FetchResult) -> str | None:
+        """Extract DOI from the fetch result metadata or the URL."""
+        if result.html_metadata:
+            meta_doi = result.html_metadata.get("doi")
+            if meta_doi and isinstance(meta_doi, str) and meta_doi.strip():
+                return meta_doi.strip()
+        return _doi_from_url(uri)
+
+    # ------------------------------------------------------------------
+    # Crossref / Unpaywall
+    # ------------------------------------------------------------------
+
+    async def _fetch_crossref(self, doi: str) -> dict[str, object] | None:
+        client = await self._client_()
+        settings = get_settings()
+        headers = {}
+        email = getattr(settings, "crossref_email", None)
+        if email:
+            headers["User-Agent"] = f"{settings.fetch_user_agent} (mailto:{email})"
+        response = await client.get(CROSSREF_API.format(doi=doi), headers=headers or None)
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        data = response.json()
+        message = data.get("message")
+        return message if isinstance(message, dict) else None
+
+    async def _fetch_unpaywall_oa(self, doi: str) -> str | None:
+        settings = get_settings()
+        email = getattr(settings, "unpaywall_email", None) or getattr(settings, "crossref_email", None)
+        if not email:
+            return None
+        client = await self._client_()
+        response = await client.get(UNPAYWALL_API.format(doi=doi), params={"email": email})
+        if response.status_code != 200:
+            return None
+        data = response.json()
+        best = data.get("best_oa_location") or {}
+        url = best.get("url_for_pdf") or best.get("url")
+        if not url:
+            return None
+        url_str = str(url)
+        try:
+            await validate_fetch_url(url_str)
+        except UnsafeUrlError as e:
+            logger.warning(
+                "rejecting unsafe Unpaywall PDF url for DOI %s: %s (%s)",
+                doi,
+                url_str,
+                e,
+            )
+            return None
+        return url_str
+
+    async def _try_fetch_pdf(
+        self,
+        uri: str,
+        oa_url: str,
+        metadata_body: str,
+        meta_out: dict[str, str | None],
+    ) -> FetchResult | None:
+        """Download an OA PDF and extract full text, returning None on failure."""
+        try:
+            client = await self._client_()
+            response = await client.get(oa_url, headers={"Accept": "application/pdf, */*"})
+        except Exception:
+            logger.debug("OA PDF download failed for %s", oa_url, exc_info=True)
+            return None
+
+        if response.status_code >= 400:
+            logger.debug("OA PDF returned %s for %s", response.status_code, oa_url)
+            return None
+
+        ct = response.headers.get("content-type", "")
+        if classify_content_type(ct) != "pdf":
+            logger.debug("OA URL returned non-PDF content-type %s for %s", ct, oa_url)
+            return None
+
+        pdf_result = extract_pdf(uri, response.content, ct)
+        if not pdf_result.success:
+            logger.debug("PDF extraction failed for %s: %s", oa_url, pdf_result.error)
+            return None
+
+        combined = f"{metadata_body}\n\n---\n\n{pdf_result.content}"
+        return FetchResult(
+            uri=uri,
+            content=combined,
+            content_type="application/pdf",
+            page_count=pdf_result.page_count,
+            pdf_metadata=pdf_result.pdf_metadata,
+            html_metadata=meta_out,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+
+# ------------------------------------------------------------------
+# Shared utilities
+# ------------------------------------------------------------------
+
+
+def format_metadata(message: dict[str, object]) -> str:
+    """Render a Crossref ``message`` payload as a plain-text body."""
+    parts: list[str] = []
+
+    title = message.get("title")
+    if isinstance(title, list) and title:
+        parts.append(f"Title: {title[0]}")
+    elif isinstance(title, str):
+        parts.append(f"Title: {title}")
+
+    authors = message.get("author")
+    if isinstance(authors, list) and authors:
+        names = [
+            " ".join(filter(None, [a.get("given"), a.get("family")]))  # type: ignore[union-attr]
+            for a in authors
+            if isinstance(a, dict)
+        ]
+        names = [n for n in names if n]
+        if names:
+            parts.append(f"Authors: {', '.join(names)}")
+
+    pub = message.get("publisher")
+    if pub:
+        parts.append(f"Publisher: {pub}")
+
+    container = message.get("container-title")
+    if isinstance(container, list) and container:
+        parts.append(f"Journal: {container[0]}")
+
+    issued = message.get("issued") or {}
+    date_parts = (issued.get("date-parts") or [[]])[0] if isinstance(issued, dict) else []
+    if date_parts:
+        parts.append(f"Published: {'-'.join(str(p) for p in date_parts)}")
+
+    abstract = message.get("abstract")
+    if isinstance(abstract, str) and abstract:
+        clean = re.sub(r"<[^>]+>", "", abstract).strip()
+        if clean:
+            parts.append(f"\nAbstract:\n{clean}")
+
+    doi = message.get("DOI")
+    if doi:
+        parts.append(f"\nDOI: {doi}")
+
+    return "\n".join(parts)
+
+
+def _ms(t0: float) -> int:
+    return int((time.perf_counter() - t0) * 1000)

--- a/libs/kt-providers/src/kt_providers/fetch/doi_provider.py
+++ b/libs/kt-providers/src/kt_providers/fetch/doi_provider.py
@@ -1,134 +1,51 @@
-"""DOI-aware shortcut provider for academic publishers.
+"""DOI-direct provider for ``doi.org`` / ``dx.doi.org`` URLs.
 
-Many academic publisher domains (cell.com, sciencedirect.com, nature.com,
-springer.com, wiley.com, …) sit behind aggressive WAFs that block plain HTTP
-clients **and** also expose canonical machine-readable identifiers (DOIs)
-plus open metadata APIs that don't bot-block at all.
-
-This provider:
-1. Recognises a publisher URL.
-2. Extracts the DOI either from the URL path or by fetching the landing page
-   and parsing `<meta name="citation_doi">`.
-3. Queries Crossref for canonical metadata (title, authors, abstract, …).
-4. Optionally queries Unpaywall for an open-access PDF link and follows it.
-
-For an Elsevier article like the one in the original bug report
-(`https://www.cell.com/molecular-cell/fulltext/S1097-2765(23)00605-6`) this
-sidesteps the entire scraping problem — the abstract + structured metadata
-come from Crossref, and if an OA PDF exists Unpaywall hands us a direct URL
-that the rest of the chain can fetch unblocked.
-
-Both Crossref and Unpaywall are free public APIs but ask for a contact
-email in the User-Agent (Crossref: "polite pool"; Unpaywall: required).
-Wire those via `crossref_email` / `unpaywall_email` settings.
+When a user submits a ``doi.org`` link the DOI is embedded in the URL path,
+so we can go straight to Crossref/Unpaywall without fetching a landing page.
+This provider handles **only** those two hosts; all other academic publisher
+URLs are fetched by the normal chain (curl_cffi, httpx, flaresolverr) and
+then enriched by the :class:`~kt_providers.fetch.doi_enricher.DoiEnricher`
+post-fetch hook.
 """
 
 from __future__ import annotations
 
 import logging
-import re
 from urllib.parse import urlparse
 
-import httpx
-
-from kt_config.settings import get_settings
 from kt_providers.fetch.base import ContentFetcherProvider
-from kt_providers.fetch.canonical import DOI_REGEX
-from kt_providers.fetch.extract import (
-    classify_content_type,
-    extract_html_metadata,
-    extract_pdf,
-)
+from kt_providers.fetch.doi_enricher import DoiEnricher, format_metadata
 from kt_providers.fetch.types import MIN_EXTRACTED_LENGTH, FetchResult
-from kt_providers.fetch.url_safety import UnsafeUrlError, validate_fetch_url
 
 logger = logging.getLogger(__name__)
 
-# Hosts where the DOI shortcut is known to be useful.  Anything else falls
-# through immediately so we don't waste a Crossref roundtrip on, say, a
-# random blog post.
-PUBLISHER_HOSTS: frozenset[str] = frozenset(
-    {
-        "cell.com",
-        "www.cell.com",
-        "sciencedirect.com",
-        "www.sciencedirect.com",
-        "linkinghub.elsevier.com",
-        "nature.com",
-        "www.nature.com",
-        "link.springer.com",
-        "springer.com",
-        "onlinelibrary.wiley.com",
-        "wiley.com",
-        "tandfonline.com",
-        "www.tandfonline.com",
-        "journals.sagepub.com",
-        "academic.oup.com",
-        "ieeexplore.ieee.org",
-        "dl.acm.org",
-        "jstor.org",
-        "www.jstor.org",
-        "pubmed.ncbi.nlm.nih.gov",
-        "www.ncbi.nlm.nih.gov",
-        "pmc.ncbi.nlm.nih.gov",
-        "biorxiv.org",
-        "www.biorxiv.org",
-        "medrxiv.org",
-        "www.medrxiv.org",
-        "doi.org",
-        "dx.doi.org",
-    }
-)
-
-# DOI regex is shared with the canonicalization helpers in
-# ``kt_providers.fetch.canonical`` so the pattern can never drift.  The
-# citation_doi meta-tag scrape now lives in ``extract_html_metadata``
-# (used by every fetcher), so the landing-page fallback below routes
-# through it instead of carrying its own copy of the regex.
-_DOI_RE = DOI_REGEX
-
-CROSSREF_API = "https://api.crossref.org/works/{doi}"
-UNPAYWALL_API = "https://api.unpaywall.org/v2/{doi}"
+_DOI_ORG_HOSTS = frozenset({"doi.org", "dx.doi.org", "www.doi.org"})
 
 
 class DoiContentFetcher(ContentFetcherProvider):
-    """Fetcher that resolves academic URLs via Crossref/Unpaywall."""
+    """Fetcher that resolves ``doi.org`` URLs via Crossref/Unpaywall."""
 
     def __init__(self, timeout: float = 10.0) -> None:
-        self._timeout = timeout
-        self._client: httpx.AsyncClient | None = None
+        self._enricher = DoiEnricher(timeout=timeout)
 
     @property
     def provider_id(self) -> str:
         return "doi"
 
     async def is_available(self) -> bool:
-        # Always available — uses public APIs.  Individual fetches no-op
-        # for non-publisher hosts.
         return True
-
-    async def _client_(self) -> httpx.AsyncClient:
-        if self._client is None or self._client.is_closed:
-            ua = get_settings().fetch_user_agent
-            self._client = httpx.AsyncClient(
-                timeout=httpx.Timeout(self._timeout),
-                follow_redirects=True,
-                headers={"User-Agent": ua, "Accept": "application/json"},
-            )
-        return self._client
 
     async def fetch(self, uri: str) -> FetchResult:
         host = urlparse(uri).netloc.lower()
-        if host not in PUBLISHER_HOSTS:
-            # Not an academic URL — let a downstream provider handle it.
-            return FetchResult(uri=uri, error="not a known publisher host")
+        if host not in _DOI_ORG_HOSTS:
+            return FetchResult(uri=uri, error="not a doi.org URL")
 
-        doi = await self._extract_doi(uri)
-        if doi is None:
-            return FetchResult(uri=uri, error="no DOI found for URL")
+        doi = urlparse(uri).path.lstrip("/")
+        if not doi:
+            return FetchResult(uri=uri, error="empty DOI path")
 
         try:
-            metadata = await self._fetch_crossref(doi)
+            metadata = await self._enricher._fetch_crossref(doi)
         except Exception as e:
             logger.debug("Crossref fetch failed for %s: %s", doi, e)
             return FetchResult(uri=uri, error=f"crossref error: {e}")
@@ -136,7 +53,7 @@ class DoiContentFetcher(ContentFetcherProvider):
         if metadata is None:
             return FetchResult(uri=uri, error=f"DOI {doi} not in Crossref")
 
-        body = _format_metadata(metadata)
+        body = format_metadata(metadata)
         if not body or len(body) < MIN_EXTRACTED_LENGTH:
             return FetchResult(
                 uri=uri,
@@ -147,7 +64,7 @@ class DoiContentFetcher(ContentFetcherProvider):
         # Best-effort: try to enrich with full-text from an Unpaywall OA PDF.
         oa_url = None
         try:
-            oa_url = await self._fetch_unpaywall_oa(doi)
+            oa_url = await self._enricher._fetch_unpaywall_oa(doi)
         except Exception:
             logger.debug("Unpaywall lookup failed for %s", doi, exc_info=True)
 
@@ -163,7 +80,7 @@ class DoiContentFetcher(ContentFetcherProvider):
 
         # If we have an OA PDF URL, download and extract full text.
         if oa_url:
-            pdf_result = await self._try_fetch_pdf(uri, oa_url, body, meta_out)
+            pdf_result = await self._enricher._try_fetch_pdf(uri, oa_url, body, meta_out)
             if pdf_result is not None:
                 return pdf_result
 
@@ -174,179 +91,5 @@ class DoiContentFetcher(ContentFetcherProvider):
             html_metadata=meta_out,
         )
 
-    async def _try_fetch_pdf(
-        self,
-        uri: str,
-        oa_url: str,
-        metadata_body: str,
-        meta_out: dict[str, str | None],
-    ) -> FetchResult | None:
-        """Download an OA PDF and extract full text, returning None on failure."""
-        try:
-            client = await self._client_()
-            response = await client.get(oa_url, headers={"Accept": "application/pdf, */*"})
-        except Exception:
-            logger.debug("OA PDF download failed for %s", oa_url, exc_info=True)
-            return None
-
-        if response.status_code >= 400:
-            logger.debug("OA PDF returned %s for %s", response.status_code, oa_url)
-            return None
-
-        ct = response.headers.get("content-type", "")
-        if classify_content_type(ct) != "pdf":
-            logger.debug("OA URL returned non-PDF content-type %s for %s", ct, oa_url)
-            return None
-
-        pdf_result = extract_pdf(uri, response.content, ct)
-        if not pdf_result.success:
-            logger.debug("PDF extraction failed for %s: %s", oa_url, pdf_result.error)
-            return None
-
-        # Combine Crossref metadata header with extracted PDF text.
-        combined = f"{metadata_body}\n\n---\n\n{pdf_result.content}"
-        return FetchResult(
-            uri=uri,
-            content=combined,
-            content_type="application/pdf",
-            page_count=pdf_result.page_count,
-            pdf_metadata=pdf_result.pdf_metadata,
-            html_metadata=meta_out,
-        )
-
-    async def _extract_doi(self, uri: str) -> str | None:
-        # 1. doi.org/<doi> → trivial extract from the path.
-        parsed = urlparse(uri)
-        if parsed.netloc.lower() in ("doi.org", "dx.doi.org"):
-            return parsed.path.lstrip("/") or None
-
-        # 2. Try to find a DOI in the URL itself (some publisher URLs include it).
-        m = _DOI_RE.search(uri)
-        if m:
-            return m.group(1).rstrip(".)")
-
-        # 3. Fall back to fetching the landing page.  We share
-        # ``extract_html_metadata`` with every other HTML fetcher so the
-        # citation_doi scrape lives in exactly one place; if no meta tag
-        # is present, scan the body for a bare DOI substring as a final
-        # safety net.
-        try:
-            client = await self._client_()
-            response = await client.get(uri)
-        except Exception as e:
-            logger.debug("DOI landing-page fetch failed for %s: %s", uri, e)
-            return None
-
-        if response.status_code >= 400:
-            return None
-
-        body = response.text or ""
-        meta = extract_html_metadata(body)
-        if meta and meta.get("doi"):
-            return meta["doi"]
-
-        m = _DOI_RE.search(body)
-        if m:
-            return m.group(1).rstrip(".)")
-        return None
-
-    async def _fetch_crossref(self, doi: str) -> dict[str, object] | None:
-        client = await self._client_()
-        settings = get_settings()
-        headers = {}
-        email = getattr(settings, "crossref_email", None)
-        if email:
-            headers["User-Agent"] = f"{settings.fetch_user_agent} (mailto:{email})"
-        response = await client.get(CROSSREF_API.format(doi=doi), headers=headers or None)
-        if response.status_code == 404:
-            return None
-        response.raise_for_status()
-        data = response.json()
-        message = data.get("message")
-        return message if isinstance(message, dict) else None
-
-    async def _fetch_unpaywall_oa(self, doi: str) -> str | None:
-        settings = get_settings()
-        email = getattr(settings, "unpaywall_email", None) or getattr(settings, "crossref_email", None)
-        if not email:
-            # Unpaywall requires an email; skip silently if not configured.
-            return None
-        client = await self._client_()
-        response = await client.get(UNPAYWALL_API.format(doi=doi), params={"email": email})
-        if response.status_code != 200:
-            return None
-        data = response.json()
-        best = data.get("best_oa_location") or {}
-        url = best.get("url_for_pdf") or best.get("url")
-        if not url:
-            return None
-        url_str = str(url)
-        # Defense-in-depth: Unpaywall is third-party JSON.  We hand the
-        # resulting URL back to the registry / pipeline, and a future
-        # consumer might fetch it without re-checking.  Run it through
-        # the same SSRF guard so a poisoned Unpaywall response cannot
-        # smuggle a private/loopback URL into our system.
-        try:
-            await validate_fetch_url(url_str)
-        except UnsafeUrlError as e:
-            logger.warning(
-                "rejecting unsafe Unpaywall PDF url for DOI %s: %s (%s)",
-                doi,
-                url_str,
-                e,
-            )
-            return None
-        return url_str
-
     async def close(self) -> None:
-        if self._client is not None and not self._client.is_closed:
-            await self._client.aclose()
-            self._client = None
-
-
-def _format_metadata(message: dict[str, object]) -> str:
-    """Render a Crossref `message` payload as a plain-text body."""
-    parts: list[str] = []
-
-    title = message.get("title")
-    if isinstance(title, list) and title:
-        parts.append(f"Title: {title[0]}")
-    elif isinstance(title, str):
-        parts.append(f"Title: {title}")
-
-    authors = message.get("author")
-    if isinstance(authors, list) and authors:
-        names = [
-            " ".join(filter(None, [a.get("given"), a.get("family")]))  # type: ignore[union-attr]
-            for a in authors
-            if isinstance(a, dict)
-        ]
-        names = [n for n in names if n]
-        if names:
-            parts.append(f"Authors: {', '.join(names)}")
-
-    publisher = message.get("publisher")
-    if publisher:
-        parts.append(f"Publisher: {publisher}")
-
-    container = message.get("container-title")
-    if isinstance(container, list) and container:
-        parts.append(f"Journal: {container[0]}")
-
-    issued = message.get("issued") or {}
-    date_parts = (issued.get("date-parts") or [[]])[0] if isinstance(issued, dict) else []
-    if date_parts:
-        parts.append(f"Published: {'-'.join(str(p) for p in date_parts)}")
-
-    abstract = message.get("abstract")
-    if isinstance(abstract, str) and abstract:
-        # Crossref abstracts are stored as JATS XML; strip tags crudely.
-        clean = re.sub(r"<[^>]+>", "", abstract).strip()
-        if clean:
-            parts.append(f"\nAbstract:\n{clean}")
-
-    doi = message.get("DOI")
-    if doi:
-        parts.append(f"\nDOI: {doi}")
-
-    return "\n".join(parts)
+        await self._enricher.close()

--- a/libs/kt-providers/src/kt_providers/fetch/registry.py
+++ b/libs/kt-providers/src/kt_providers/fetch/registry.py
@@ -49,6 +49,7 @@ class FetchProviderRegistry:
         host_overrides: dict[str, str] | None = None,
         host_pref_store: HostPreferenceStore | None = None,
         url_validator: UrlValidator | None = None,
+        post_fetch_hooks: list[Callable[[str, FetchResult], Awaitable[FetchResult]]] | None = None,
     ) -> None:
         """
         Args:
@@ -57,12 +58,18 @@ class FetchProviderRegistry:
                 — this is the test default; ``build_fetch_registry`` always
                 injects the real SSRF guard for production code paths.
                 A validator should raise ``UnsafeUrlError`` to reject a URL.
+            post_fetch_hooks: Optional list of async callables invoked
+                sequentially after a provider succeeds.  Each hook receives
+                ``(uri, result)`` and returns a (possibly enriched)
+                ``FetchResult``.  Exceptions are caught and logged so a
+                failing hook never breaks the fetch.
         """
         self._providers: dict[str, ContentFetcherProvider] = {p.provider_id: p for p in providers}
         self._chain: list[str] = list(chain)
         self._host_overrides: dict[str, str] = {k.lower(): v for k, v in (host_overrides or {}).items()}
         self._host_pref_store = host_pref_store
         self._url_validator = url_validator
+        self._post_fetch_hooks: list[Callable[[str, FetchResult], Awaitable[FetchResult]]] = post_fetch_hooks or []
 
     @property
     def chain(self) -> list[str]:
@@ -192,6 +199,14 @@ class FetchProviderRegistry:
                         await self._host_pref_store.record(host, pid)
                     except Exception:
                         logger.debug("host-pref record failed for %s", host, exc_info=True)
+
+                # Run post-fetch hooks (e.g. DOI enrichment).
+                for hook in self._post_fetch_hooks:
+                    try:
+                        result = await hook(uri, result)
+                    except Exception:
+                        logger.debug("post-fetch hook failed for %s", uri, exc_info=True)
+
                 return result
 
         # Every provider failed.  Return a synthetic failure with the audit
@@ -260,12 +275,19 @@ class FetchProviderRegistry:
         return list(await asyncio.gather(*tasks))
 
     async def close(self) -> None:
-        """Close every registered provider."""
+        """Close every registered provider and closeable post-fetch hooks."""
         for provider in self._providers.values():
             try:
                 await provider.close()
             except Exception:
                 logger.debug("provider %s close failed", provider.provider_id, exc_info=True)
+        for hook in self._post_fetch_hooks:
+            close_fn = getattr(hook, "close", None) or getattr(getattr(hook, "__self__", None), "close", None)
+            if close_fn is not None:
+                try:
+                    await close_fn()
+                except Exception:
+                    logger.debug("post-fetch hook close failed", exc_info=True)
 
 
 def _ms(t0: float) -> int:

--- a/libs/kt-providers/tests/fetch/test_doi_enricher.py
+++ b/libs/kt-providers/tests/fetch/test_doi_enricher.py
@@ -1,0 +1,277 @@
+"""Unit tests for the DoiEnricher post-fetch enrichment hook."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kt_providers.fetch.doi_enricher import DoiEnricher
+from kt_providers.fetch.types import FetchResult
+
+
+def _html_result(
+    uri: str = "https://www.cell.com/article/123",
+    doi: str | None = "10.1016/j.immuni.2006.07.008",
+) -> FetchResult:
+    """A successful FetchResult from curl_cffi with optional citation_doi."""
+    meta = {"title": "Page Title"}
+    if doi:
+        meta["doi"] = doi
+    return FetchResult(
+        uri=uri,
+        content="Full HTML content from the publisher. " * 20,
+        content_type="text/html",
+        html_metadata=meta,
+        attempts=[],
+    )
+
+
+def _crossref_message() -> dict[str, object]:
+    return {
+        "DOI": "10.1016/j.immuni.2006.07.008",
+        "title": ["Regulatory T cells in autoimmunity"],
+        "author": [{"given": "Shimon", "family": "Sakaguchi"}],
+        "publisher": "Elsevier",
+        "container-title": ["Immunity"],
+        "issued": {"date-parts": [[2006, 8]]},
+        "abstract": "<jats:p>Abstract from Crossref.</jats:p>",
+    }
+
+
+# ── Enrichment skipping ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skips_non_publisher_host():
+    enricher = DoiEnricher()
+    result = _html_result(uri="https://example.com/page", doi="10.1234/test")
+    enriched = await enricher.enrich("https://example.com/page", result)
+    assert enriched is result
+    assert enriched.html_metadata.get("enriched_by") is None  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_doi_in_metadata_or_url():
+    enricher = DoiEnricher()
+    result = _html_result(doi=None)
+    # URL also has no DOI pattern
+    enriched = await enricher.enrich("https://www.cell.com/article/S1074-7613(06)00309-8", result)
+    assert enriched is result
+    assert enriched.html_metadata.get("enriched_by") is None  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_skips_when_html_metadata_is_none():
+    enricher = DoiEnricher()
+    result = FetchResult(
+        uri="https://www.cell.com/x",
+        content="Hello world " * 20,
+        html_metadata=None,
+        attempts=[],
+    )
+    enriched = await enricher.enrich("https://www.cell.com/x", result)
+    assert enriched is result
+
+
+# ── Successful enrichment ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enriches_with_crossref_metadata(monkeypatch: pytest.MonkeyPatch):
+    enricher = DoiEnricher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return _crossref_message()
+
+    async def fake_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_unpaywall)
+
+    result = _html_result()
+    enriched = await enricher.enrich("https://www.cell.com/article/123", result)
+
+    assert enriched.html_metadata is not None
+    assert enriched.html_metadata["doi"] == "10.1016/j.immuni.2006.07.008"
+    assert enriched.html_metadata["title"] == "Regulatory T cells in autoimmunity"
+    assert enriched.html_metadata["publisher"] == "Elsevier"
+    assert enriched.html_metadata["enriched_by"] == "crossref"
+    assert enriched.html_metadata["oa_pdf_url"] is None
+    # Content should be unchanged (no OA PDF)
+    assert "Full HTML content" in (enriched.content or "")
+    # Audit trail should include enricher attempt
+    assert any(a.provider_id == "doi_enricher" and a.success for a in enriched.attempts)
+
+
+@pytest.mark.asyncio
+async def test_enriches_with_oa_pdf(monkeypatch: pytest.MonkeyPatch):
+    enricher = DoiEnricher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return _crossref_message()
+
+    async def fake_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return "https://europepmc.org/pdf/1234.pdf"
+
+    pdf_response = MagicMock()
+    pdf_response.status_code = 200
+    pdf_response.headers = {"content-type": "application/pdf"}
+    pdf_response.content = b"%PDF-bytes"
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=pdf_response)
+    client.is_closed = False
+
+    async def fake_client(self):  # type: ignore[no-untyped-def]
+        return client
+
+    def fake_extract_pdf(uri: str, pdf_bytes: bytes, ct: str) -> FetchResult:
+        return FetchResult(
+            uri=uri,
+            content="Extracted PDF full text. " * 10,
+            content_type="application/pdf",
+            page_count=8,
+            pdf_metadata={"title": "Paper"},
+        )
+
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiEnricher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_enricher.extract_pdf", fake_extract_pdf)
+
+    result = _html_result()
+    enriched = await enricher.enrich("https://www.cell.com/article/123", result)
+
+    assert enriched.content_type == "application/pdf"
+    assert enriched.page_count == 8
+    assert "Extracted PDF full text." in (enriched.content or "")
+    assert enriched.html_metadata is not None
+    assert enriched.html_metadata["oa_pdf_url"] == "https://europepmc.org/pdf/1234.pdf"
+
+
+@pytest.mark.asyncio
+async def test_extracts_doi_from_url_when_not_in_metadata(monkeypatch: pytest.MonkeyPatch):
+    """When html_metadata has no DOI but the URL contains one, enrichment still works."""
+    enricher = DoiEnricher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return {"DOI": doi, "title": ["Found via URL"], "publisher": "Pub"}
+
+    async def fake_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_unpaywall)
+
+    result = _html_result(
+        uri="https://link.springer.com/article/10.1007/s00125-024-06301-2",
+        doi=None,
+    )
+    enriched = await enricher.enrich("https://link.springer.com/article/10.1007/s00125-024-06301-2", result)
+    assert enriched.html_metadata is not None
+    assert enriched.html_metadata["doi"] == "10.1007/s00125-024-06301-2"
+    assert enriched.html_metadata["enriched_by"] == "crossref"
+
+
+# ── Failure handling ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_crossref_failure_returns_original(monkeypatch: pytest.MonkeyPatch):
+    enricher = DoiEnricher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        raise Exception("network error")
+
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+
+    result = _html_result()
+    enriched = await enricher.enrich("https://www.cell.com/article/123", result)
+
+    # Content unchanged
+    assert "Full HTML content" in (enriched.content or "")
+    # Failure recorded in attempts
+    assert any(
+        a.provider_id == "doi_enricher" and not a.success and "crossref" in (a.error or "") for a in enriched.attempts
+    )
+
+
+@pytest.mark.asyncio
+async def test_crossref_404_returns_original(monkeypatch: pytest.MonkeyPatch):
+    enricher = DoiEnricher()
+
+    async def fake_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return None  # DOI not found in Crossref
+
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+
+    result = _html_result()
+    enriched = await enricher.enrich("https://www.cell.com/article/123", result)
+
+    assert "Full HTML content" in (enriched.content or "")
+    assert any(a.provider_id == "doi_enricher" and not a.success for a in enriched.attempts)
+
+
+# ── Unpaywall SSRF protection ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unpaywall_safe_url_passed_through(monkeypatch: pytest.MonkeyPatch):
+    enricher = DoiEnricher()
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json = MagicMock(return_value={"best_oa_location": {"url_for_pdf": "https://arxiv.org/pdf/1234.pdf"}})
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    client.is_closed = False
+
+    async def fake_client(self):  # type: ignore[no-untyped-def]
+        return client
+
+    async def fake_validate(uri: str) -> None:
+        return None
+
+    monkeypatch.setattr(DoiEnricher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_enricher.validate_fetch_url", fake_validate)
+    monkeypatch.setattr(
+        "kt_providers.fetch.doi_enricher.get_settings",
+        lambda: MagicMock(unpaywall_email="me@example.com", crossref_email=None, fetch_user_agent="ua"),
+    )
+
+    url = await enricher._fetch_unpaywall_oa("10.1234/abc")
+    assert url == "https://arxiv.org/pdf/1234.pdf"
+
+
+@pytest.mark.asyncio
+async def test_unpaywall_poisoned_url_is_rejected(monkeypatch: pytest.MonkeyPatch):
+    from kt_providers.fetch.url_safety import UnsafeUrlError
+
+    enricher = DoiEnricher()
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json = MagicMock(return_value={"best_oa_location": {"url_for_pdf": "http://169.254.169.254/admin"}})
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    client.is_closed = False
+
+    async def fake_client(self):  # type: ignore[no-untyped-def]
+        return client
+
+    async def fake_validate(uri: str) -> None:
+        if "169.254" in uri:
+            raise UnsafeUrlError("metadata endpoint")
+        return None
+
+    monkeypatch.setattr(DoiEnricher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_enricher.validate_fetch_url", fake_validate)
+    monkeypatch.setattr(
+        "kt_providers.fetch.doi_enricher.get_settings",
+        lambda: MagicMock(unpaywall_email="me@example.com", crossref_email=None, fetch_user_agent="ua"),
+    )
+
+    url = await enricher._fetch_unpaywall_oa("10.1234/abc")
+    assert url is None

--- a/libs/kt-providers/tests/fetch/test_doi_provider.py
+++ b/libs/kt-providers/tests/fetch/test_doi_provider.py
@@ -1,4 +1,4 @@
-"""Unit tests for the DOI shortcut provider."""
+"""Unit tests for the DOI-direct provider (doi.org URLs only)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from kt_providers.fetch.doi_provider import DoiContentFetcher, _format_metadata
+from kt_providers.fetch.doi_enricher import DoiEnricher, format_metadata
+from kt_providers.fetch.doi_provider import DoiContentFetcher
 from kt_providers.fetch.types import FetchResult
 
 
@@ -18,49 +19,84 @@ async def test_provider_id_and_always_available():
 
 
 @pytest.mark.asyncio
-async def test_non_publisher_host_returns_immediately():
+async def test_non_doi_org_host_returns_immediately():
+    p = DoiContentFetcher()
+    result = await p.fetch("https://www.cell.com/some/article")
+    assert result.success is False
+    assert "doi.org" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_non_doi_org_host_example_com():
     p = DoiContentFetcher()
     result = await p.fetch("https://example.com/some/article")
     assert result.success is False
-    assert "publisher" in (result.error or "").lower()
+    assert "doi.org" in (result.error or "").lower()
 
 
 @pytest.mark.asyncio
 async def test_doi_org_url_extracts_doi_from_path(monkeypatch: pytest.MonkeyPatch):
     p = DoiContentFetcher()
 
-    crossref_payload = {
-        "message": {
-            "DOI": "10.1234/abcd",
-            "title": ["A great paper"],
-            "author": [{"given": "Ada", "family": "Lovelace"}],
-            "publisher": "Test Press",
-            "container-title": ["Journal of Tests"],
-            "issued": {"date-parts": [[2024, 5, 1]]},
-            "abstract": "<jats:p>This is the abstract content.</jats:p>",
-        }
+    crossref_message = {
+        "DOI": "10.1234/abcd",
+        "title": ["A great paper"],
+        "author": [{"given": "Ada", "family": "Lovelace"}],
+        "publisher": "Test Press",
+        "container-title": ["Journal of Tests"],
+        "issued": {"date-parts": [[2024, 5, 1]]},
+        "abstract": "<jats:p>This is the abstract content.</jats:p>",
     }
 
     async def fake_fetch_crossref(self, doi):  # type: ignore[no-untyped-def]
         assert doi == "10.1234/abcd"
-        return crossref_payload["message"]
+        return crossref_message
 
     async def fake_fetch_unpaywall(self, doi):  # type: ignore[no-untyped-def]
         return None
 
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_fetch_crossref)
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_fetch_unpaywall)
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_fetch_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_fetch_unpaywall)
 
     result = await p.fetch("https://doi.org/10.1234/abcd")
     assert result.success is True
-    assert result.provider_id is None  # registry sets this, not the provider
     assert "A great paper" in (result.content or "")
     assert "Ada Lovelace" in (result.content or "")
     assert "abstract content" in (result.content or "")
 
 
+@pytest.mark.asyncio
+async def test_dx_doi_org_also_handled(monkeypatch: pytest.MonkeyPatch):
+    p = DoiContentFetcher()
+
+    async def fake_fetch_crossref(self, doi):  # type: ignore[no-untyped-def]
+        return {
+            "DOI": doi,
+            "title": ["A paper with a sufficiently long title for testing"],
+            "publisher": "Publisher",
+            "abstract": "This is a test abstract with enough content to pass the minimum length check.",
+        }
+
+    async def fake_fetch_unpaywall(self, doi):  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_fetch_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_fetch_unpaywall)
+
+    result = await p.fetch("https://dx.doi.org/10.9999/xyz")
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_empty_doi_path_returns_error():
+    p = DoiContentFetcher()
+    result = await p.fetch("https://doi.org/")
+    assert result.success is False
+    assert "empty" in (result.error or "").lower()
+
+
 def test_format_metadata_strips_jats_xml():
-    body = _format_metadata(
+    body = format_metadata(
         {
             "title": ["Hello"],
             "DOI": "10.1/x",
@@ -70,93 +106,6 @@ def test_format_metadata_strips_jats_xml():
     assert "Hello" in body
     assert "plain text" in body
     assert "<jats" not in body
-
-
-@pytest.mark.asyncio
-async def test_unpaywall_url_passed_through_when_safe(monkeypatch: pytest.MonkeyPatch):
-    """A normal public Unpaywall URL is returned unchanged."""
-    p = DoiContentFetcher()
-
-    response = MagicMock()
-    response.status_code = 200
-    response.json = MagicMock(return_value={"best_oa_location": {"url_for_pdf": "https://arxiv.org/pdf/1234.pdf"}})
-    client = MagicMock()
-    client.get = AsyncMock(return_value=response)
-    client.is_closed = False
-
-    async def fake_client(self):  # type: ignore[no-untyped-def]
-        return client
-
-    async def fake_validate(uri: str) -> None:
-        # Pretend the URL safety check passed.
-        return None
-
-    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
-    monkeypatch.setattr("kt_providers.fetch.doi_provider.validate_fetch_url", fake_validate)
-    monkeypatch.setattr(
-        "kt_providers.fetch.doi_provider.get_settings",
-        lambda: MagicMock(unpaywall_email="me@example.com", crossref_email=None, fetch_user_agent="ua"),
-    )
-
-    url = await p._fetch_unpaywall_oa("10.1234/abc")
-    assert url == "https://arxiv.org/pdf/1234.pdf"
-
-
-@pytest.mark.asyncio
-async def test_unpaywall_poisoned_url_is_rejected(monkeypatch: pytest.MonkeyPatch):
-    """A poisoned Unpaywall response that returns a private/loopback URL
-    must be dropped — Unpaywall is third-party JSON and we cannot trust
-    its `url_for_pdf` to be safe to fetch."""
-    from kt_providers.fetch.url_safety import UnsafeUrlError
-
-    p = DoiContentFetcher()
-
-    response = MagicMock()
-    response.status_code = 200
-    response.json = MagicMock(return_value={"best_oa_location": {"url_for_pdf": "http://169.254.169.254/admin"}})
-    client = MagicMock()
-    client.get = AsyncMock(return_value=response)
-    client.is_closed = False
-
-    async def fake_client(self):  # type: ignore[no-untyped-def]
-        return client
-
-    async def fake_validate(uri: str) -> None:
-        if "169.254" in uri:
-            raise UnsafeUrlError("metadata endpoint")
-        return None
-
-    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
-    monkeypatch.setattr("kt_providers.fetch.doi_provider.validate_fetch_url", fake_validate)
-    monkeypatch.setattr(
-        "kt_providers.fetch.doi_provider.get_settings",
-        lambda: MagicMock(unpaywall_email="me@example.com", crossref_email=None, fetch_user_agent="ua"),
-    )
-
-    url = await p._fetch_unpaywall_oa("10.1234/abc")
-    assert url is None  # poisoned URL silently dropped
-
-
-@pytest.mark.asyncio
-async def test_extract_doi_from_meta_tag(monkeypatch: pytest.MonkeyPatch):
-    """When the DOI isn't in the URL, fall back to parsing citation_doi meta."""
-    p = DoiContentFetcher()
-
-    response = MagicMock()
-    response.status_code = 200
-    response.text = '<html><head><meta name="citation_doi" content="10.5555/found-doi"/></head></html>'
-
-    client = MagicMock()
-    client.get = AsyncMock(return_value=response)
-    client.is_closed = False
-
-    async def fake_client(self):  # type: ignore[no-untyped-def]
-        return client
-
-    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
-
-    doi = await p._extract_doi("https://www.cell.com/some/page")
-    assert doi == "10.5555/found-doi"
 
 
 # ── OA PDF download & extraction tests ──────────────────────────
@@ -205,21 +154,19 @@ async def test_doi_fetcher_downloads_oa_pdf(monkeypatch: pytest.MonkeyPatch):
             pdf_metadata={"title": "A great paper"},
         )
 
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_crossref)
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_unpaywall)
-    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
-    monkeypatch.setattr("kt_providers.fetch.doi_provider.extract_pdf", fake_extract_pdf)
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiEnricher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_enricher.extract_pdf", fake_extract_pdf)
 
     result = await p.fetch("https://doi.org/10.1234/abcd")
     assert result.success is True
     assert result.content_type == "application/pdf"
     assert result.page_count == 12
     assert result.pdf_metadata == {"title": "A great paper"}
-    # Should contain both metadata header and PDF text
     assert "A great paper" in (result.content or "")
     assert "Full paper text extracted from PDF." in (result.content or "")
     assert "---" in (result.content or "")
-    # html_metadata should still have DOI and OA URL
     assert result.html_metadata is not None
     assert result.html_metadata["doi"] == "10.1234/abcd"
     assert result.html_metadata["oa_pdf_url"] == "https://arxiv.org/pdf/1234.pdf"
@@ -243,9 +190,9 @@ async def test_doi_fetcher_falls_back_on_pdf_download_failure(monkeypatch: pytes
     async def fake_client(self):  # type: ignore[no-untyped-def]
         return client
 
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_crossref)
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_unpaywall)
-    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiEnricher, "_client_", fake_client)
 
     result = await p.fetch("https://doi.org/10.1234/abcd")
     assert result.success is True
@@ -281,10 +228,10 @@ async def test_doi_fetcher_falls_back_when_pdf_extraction_fails(monkeypatch: pyt
     def fake_extract_pdf(uri: str, pdf_bytes: bytes, ct: str) -> FetchResult:
         return FetchResult(uri=uri, error="corrupt PDF")
 
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_crossref", fake_crossref)
-    monkeypatch.setattr(DoiContentFetcher, "_fetch_unpaywall_oa", fake_unpaywall)
-    monkeypatch.setattr(DoiContentFetcher, "_client_", fake_client)
-    monkeypatch.setattr("kt_providers.fetch.doi_provider.extract_pdf", fake_extract_pdf)
+    monkeypatch.setattr(DoiEnricher, "_fetch_crossref", fake_crossref)
+    monkeypatch.setattr(DoiEnricher, "_fetch_unpaywall_oa", fake_unpaywall)
+    monkeypatch.setattr(DoiEnricher, "_client_", fake_client)
+    monkeypatch.setattr("kt_providers.fetch.doi_enricher.extract_pdf", fake_extract_pdf)
 
     result = await p.fetch("https://doi.org/10.1234/abcd")
     assert result.success is True

--- a/libs/kt-providers/tests/fetch/test_registry.py
+++ b/libs/kt-providers/tests/fetch/test_registry.py
@@ -291,3 +291,87 @@ async def test_stale_learned_preference_is_forgotten_on_total_failure():
     assert result.success is False
     # Learned preference should be cleared so we re-learn next time.
     assert await store.get("example.com") is None
+
+
+# ── Post-fetch hooks ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_fetch_hook_called_after_successful_fetch():
+    """A post-fetch hook receives the URI and result and can enrich it."""
+    hook_calls: list[tuple[str, FetchResult]] = []
+
+    async def hook(uri: str, result: FetchResult) -> FetchResult:
+        hook_calls.append((uri, result))
+        meta = dict(result.html_metadata or {})
+        meta["enriched"] = "yes"
+        result.html_metadata = meta
+        return result
+
+    p1 = FakeProvider("a", return_value=_success("a"))
+    reg = FetchProviderRegistry([p1], chain=["a"], post_fetch_hooks=[hook])
+    result = await reg.fetch("https://example.com")
+
+    assert result.success is True
+    assert len(hook_calls) == 1
+    assert hook_calls[0][0] == "https://example.com"
+    assert result.html_metadata is not None
+    assert result.html_metadata["enriched"] == "yes"
+
+
+@pytest.mark.asyncio
+async def test_post_fetch_hook_failure_does_not_break_result():
+    """If a hook raises, the result from the provider is still returned."""
+
+    async def bad_hook(uri: str, result: FetchResult) -> FetchResult:
+        raise RuntimeError("hook exploded")
+
+    p1 = FakeProvider("a", return_value=_success("a"))
+    reg = FetchProviderRegistry([p1], chain=["a"], post_fetch_hooks=[bad_hook])
+    result = await reg.fetch("https://example.com")
+
+    assert result.success is True
+    assert result.provider_id == "a"
+
+
+@pytest.mark.asyncio
+async def test_post_fetch_hooks_not_called_when_all_providers_fail():
+    """Hooks only run on success — they should not be called on total failure."""
+    hook_calls: list[str] = []
+
+    async def hook(uri: str, result: FetchResult) -> FetchResult:
+        hook_calls.append(uri)
+        return result
+
+    p1 = FakeProvider("a", return_value=_failure("a"))
+    reg = FetchProviderRegistry([p1], chain=["a"], post_fetch_hooks=[hook])
+    result = await reg.fetch("https://example.com")
+
+    assert result.success is False
+    assert hook_calls == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_post_fetch_hooks_run_sequentially():
+    """Multiple hooks run in order, each seeing the previous hook's result."""
+    order: list[str] = []
+
+    async def hook_a(uri: str, result: FetchResult) -> FetchResult:
+        order.append("a")
+        meta = dict(result.html_metadata or {})
+        meta["hook_a"] = "done"
+        result.html_metadata = meta
+        return result
+
+    async def hook_b(uri: str, result: FetchResult) -> FetchResult:
+        order.append("b")
+        # hook_b can see hook_a's enrichment
+        assert result.html_metadata is not None
+        assert result.html_metadata.get("hook_a") == "done"
+        return result
+
+    p1 = FakeProvider("a", return_value=_success("a"))
+    reg = FetchProviderRegistry([p1], chain=["a"], post_fetch_hooks=[hook_a, hook_b])
+    result = await reg.fetch("https://example.com")
+
+    assert order == ["a", "b"]


### PR DESCRIPTION
## Summary

- **New `DoiEnricher` class** — post-fetch hook that runs after any provider successfully fetches a page from a known academic publisher. Extracts DOI from `html_metadata` or URL, queries Crossref for canonical metadata, and optionally upgrades content with Unpaywall OA PDF full text.
- **Slimmed `DoiContentFetcher`** — now only handles `doi.org`/`dx.doi.org` URLs where the DOI is in the path. No longer attempts to fetch publisher landing pages with plain httpx (which fails on bot-blocking sites).
- **`FetchProviderRegistry` gains `post_fetch_hooks`** — generic extension point for post-fetch enrichment. Hooks run sequentially after a successful fetch; exceptions are caught and logged.
- **New `fetch_doi_enrichment` setting** (default `true`) — controls whether the enricher hook is wired into the registry.

### Problem

When ingesting publisher URLs like `cell.com/immunity/fulltext/S1074-7613(06)00309-8`:
1. DOI provider tried first — URL contains a PII (not a DOI), regex finds nothing
2. DOI provider's fallback fetches landing page with plain httpx — publisher returns 403
3. DOI provider gives up → chain falls through to curl_cffi which succeeds
4. curl_cffi finds `<meta name="citation_doi">` in HTML, but Crossref/Unpaywall enrichment never happened

### Fix

DOI is now a **resolution layer** (post-fetch enrichment) instead of a competing fetch provider. The fetch chain gets the content first, then the enricher checks for a DOI and queries Crossref/Unpaywall.

## Test plan

- [x] All 165 kt-providers tests pass (including 10 new enricher tests, 4 new registry hook tests)
- [x] All 35 kt-config tests pass
- [x] All 97 kt-graph tests pass
- [ ] CI pipelines green
- [ ] Manual: ingest a Cell.com URL and verify DOI is found + Crossref metadata appears in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)