### PR TITLE
feat(api,frontend): show nested Hatchet subtasks lazily on grow-graph

### DIFF
--- a/frontend/src/components/research/ResearchBuildProgress.tsx
+++ b/frontend/src/components/research/ResearchBuildProgress.tsx
@@ -8,10 +8,11 @@ import {
   XCircle,
   BarChart2,
   ExternalLink,
+  ChevronRight,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { api } from "@/lib/api";
+import { api, getTaskChildren } from "@/lib/api";
 import type {
   BottomUpProposedNode,
   PipelineTaskItem,
@@ -92,6 +93,116 @@ function statusIcon(status: NodeStatus) {
 }
 
 // ---------------------------------------------------------------------------
+// TaskRow — recursive, lazy-loaded
+// ---------------------------------------------------------------------------
+
+interface TaskRowProps {
+  task: PipelineTaskItem;
+  depth: number;
+  workflowRunId: string | null;
+  nodeType?: string;
+}
+
+function TaskRow({ task, depth, workflowRunId, nodeType }: TaskRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [children, setChildren] = useState<PipelineTaskItem[]>(task.children || []);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const hasChildren = task.has_children || children.length > 0;
+  const status = taskStatusToNode(task.status);
+
+  const toggle = async () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && children.length === 0 && task.has_children && workflowRunId && !loading) {
+      setLoading(true);
+      setError(false);
+      try {
+        const res = await getTaskChildren(workflowRunId, task.task_id);
+        setChildren(res.tasks);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/30 cursor-default"
+        style={{ paddingLeft: depth * 16 + 16 }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={toggle}
+            className="shrink-0 p-0.5 -ml-1 rounded hover:bg-muted"
+            aria-label={expanded ? "Collapse" : "Expand"}
+          >
+            <ChevronRight
+              className={`size-3.5 transition-transform ${expanded ? "rotate-90" : ""}`}
+            />
+          </button>
+        ) : (
+          <div className="size-3.5 shrink-0" />
+        )}
+        {statusIcon(status)}
+        <span className="flex-1 text-sm truncate">{task.display_name}</span>
+        {depth === 0 && nodeType && (
+          <Badge
+            variant="secondary"
+            className={`text-[10px] shrink-0 ${NODE_TYPE_COLORS[nodeType] || ""}`}
+          >
+            {nodeType}
+          </Badge>
+        )}
+        {hasChildren && children.length > 0 && (
+          <Badge variant="outline" className="text-[10px] shrink-0 tabular-nums">
+            {children.length}
+          </Badge>
+        )}
+        {task.duration_ms != null && (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {formatDuration(task.duration_ms)}
+          </span>
+        )}
+      </div>
+      {expanded && (
+        <>
+          {loading && (
+            <div
+              className="flex items-center gap-2 px-4 py-2 text-xs text-muted-foreground"
+              style={{ paddingLeft: (depth + 1) * 16 + 16 }}
+            >
+              <Loader2 className="size-3 animate-spin" /> Loading subtasks…
+            </div>
+          )}
+          {error && (
+            <div
+              className="px-4 py-2 text-xs text-red-500"
+              style={{ paddingLeft: (depth + 1) * 16 + 16 }}
+            >
+              Failed to load subtasks
+            </div>
+          )}
+          {children.map((child) => (
+            <TaskRow
+              key={child.task_id}
+              task={child}
+              depth={depth + 1}
+              workflowRunId={workflowRunId}
+            />
+          ))}
+        </>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -104,6 +215,7 @@ export function ResearchBuildProgress({
 }: ResearchBuildProgressProps) {
   const [overallStatus, setOverallStatus] = useState<"running" | "completed" | "failed">(initialStatus);
   const [tasks, setTasks] = useState<PipelineTaskItem[]>([]);
+  const [workflowRunId, setWorkflowRunId] = useState<string | null>(null);
   const [report, setReport] = useState<ResearchReportResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -116,6 +228,7 @@ export function ResearchBuildProgress({
         const progress = await api.conversations.getProgress(conversationId, messageId);
         if (cancelled) return;
         setTasks(progress.tasks);
+        setWorkflowRunId(progress.workflow_run_id);
         setIsLoading(false);
 
         if (progress.status === "completed") {
@@ -323,28 +436,35 @@ export function ResearchBuildProgress({
             <h4 className="text-sm font-medium">Nodes</h4>
           </div>
           <div className="divide-y">
-            {coreNodes.map((node, idx) => (
-              <div
-                key={idx}
-                className="flex items-center gap-3 px-4 py-3"
-              >
-                {statusIcon(node.status)}
-                <span className="flex-1 text-sm font-medium truncate">
-                  {node.name}
-                </span>
-                <Badge
-                  variant="secondary"
-                  className={`text-[10px] shrink-0 ${NODE_TYPE_COLORS[node.nodeType] || ""}`}
-                >
-                  {node.nodeType}
-                </Badge>
-                {node.durationMs != null && (
-                  <span className="text-xs tabular-nums text-muted-foreground">
-                    {formatDuration(node.durationMs)}
+            {coreNodes.map((node, idx) =>
+              node.taskItem ? (
+                <TaskRow
+                  key={node.taskItem.task_id}
+                  task={node.taskItem}
+                  depth={0}
+                  workflowRunId={workflowRunId}
+                  nodeType={node.nodeType}
+                />
+              ) : (
+                <div key={idx} className="flex items-center gap-3 px-4 py-3">
+                  {statusIcon(node.status)}
+                  <span className="flex-1 text-sm font-medium truncate">
+                    {node.name}
                   </span>
-                )}
-              </div>
-            ))}
+                  <Badge
+                    variant="secondary"
+                    className={`text-[10px] shrink-0 ${NODE_TYPE_COLORS[node.nodeType] || ""}`}
+                  >
+                    {node.nodeType}
+                  </Badge>
+                  {node.durationMs != null && (
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {formatDuration(node.durationMs)}
+                    </span>
+                  )}
+                </div>
+              )
+            )}
           </div>
         </div>
       )}
@@ -356,28 +476,33 @@ export function ResearchBuildProgress({
             <h4 className="text-sm font-medium">Perspectives</h4>
           </div>
           <div className="divide-y">
-            {perspectiveNodes.map((node, idx) => (
-              <div
-                key={idx}
-                className="flex items-center gap-3 px-4 py-2.5"
-              >
-                {statusIcon(node.status)}
-                <span className="flex-1 text-sm truncate">
-                  {node.name}
-                </span>
-                <Badge
-                  variant="secondary"
-                  className={`text-[10px] shrink-0 ${NODE_TYPE_COLORS.perspective}`}
-                >
-                  perspective
-                </Badge>
-                {node.durationMs != null && (
-                  <span className="text-xs tabular-nums text-muted-foreground">
-                    {formatDuration(node.durationMs)}
-                  </span>
-                )}
-              </div>
-            ))}
+            {perspectiveNodes.map((node, idx) =>
+              node.taskItem ? (
+                <TaskRow
+                  key={node.taskItem.task_id}
+                  task={node.taskItem}
+                  depth={0}
+                  workflowRunId={workflowRunId}
+                  nodeType="perspective"
+                />
+              ) : (
+                <div key={idx} className="flex items-center gap-3 px-4 py-2.5">
+                  {statusIcon(node.status)}
+                  <span className="flex-1 text-sm truncate">{node.name}</span>
+                  <Badge
+                    variant="secondary"
+                    className={`text-[10px] shrink-0 ${NODE_TYPE_COLORS.perspective}`}
+                  >
+                    perspective
+                  </Badge>
+                  {node.durationMs != null && (
+                    <span className="text-xs tabular-nums text-muted-foreground">
+                      {formatDuration(node.durationMs)}
+                    </span>
+                  )}
+                </div>
+              )
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -86,6 +86,7 @@ import type {
   SentenceFactLink,
   SynthesisNodeResponse,
   PipelineSnapshotResponse,
+  TaskChildrenResponse,
   GraphResponse,
   CreateGraphRequest,
   UpdateGraphRequest,
@@ -1307,6 +1308,12 @@ export async function createSuperSynthesis(data: CreateSuperSynthesisRequest) {
 export async function getWorkflowProgress(workflowRunId: string) {
   return graphRequest<PipelineSnapshotResponse>(
     `/workflows/${encodeURIComponent(workflowRunId)}/progress`
+  );
+}
+
+export async function getTaskChildren(workflowRunId: string, taskId: string) {
+  return graphRequest<TaskChildrenResponse>(
+    `/workflows/${encodeURIComponent(workflowRunId)}/tasks/${encodeURIComponent(taskId)}/children`
   );
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -914,7 +914,12 @@ export interface PipelineTaskItem {
   started_at: string | null;
   wave_number?: number | null; // Only set for explore_scope tasks
   node_type?: string | null; // "concept" | "entity" | "event" | "perspective" etc.
+  has_children: boolean;
   children: PipelineTaskItem[];
+}
+
+export interface TaskChildrenResponse {
+  tasks: PipelineTaskItem[];
 }
 
 export interface PipelineSnapshotResponse {
@@ -926,6 +931,7 @@ export interface PipelineSnapshotResponse {
 
 export interface ProgressResponse {
   message_id: string;
+  workflow_run_id: string | null;
   status: string; // "pending" | "running" | "completed" | "failed"
   content: string; // answer text (empty while running)
   error: string | null;

--- a/libs/kt-hatchet/src/kt_hatchet/client.py
+++ b/libs/kt-hatchet/src/kt_hatchet/client.py
@@ -65,12 +65,8 @@ async def list_child_runs(parent_task_external_id: str, since: object | None = N
         )
         return list(result.rows or [])
     except Exception as exc:
-        logger.warning(
-            "Failed to list child runs for task %s: %s", parent_task_external_id, exc
-        )
-        raise RuntimeError(
-            f"Failed to list child runs for task '{parent_task_external_id}': {exc}"
-        ) from exc
+        logger.warning("Failed to list child runs for task %s: %s", parent_task_external_id, exc)
+        raise RuntimeError(f"Failed to list child runs for task '{parent_task_external_id}': {exc}") from exc
 
 
 async def has_child_runs(parent_task_external_id: str, since: object | None = None) -> bool:
@@ -93,9 +89,7 @@ async def has_child_runs(parent_task_external_id: str, since: object | None = No
         )
         return bool(result.rows)
     except Exception as exc:
-        logger.debug(
-            "has_child_runs probe failed for %s: %s", parent_task_external_id, exc
-        )
+        logger.debug("has_child_runs probe failed for %s: %s", parent_task_external_id, exc)
         return False
 
 

--- a/libs/kt-hatchet/src/kt_hatchet/client.py
+++ b/libs/kt-hatchet/src/kt_hatchet/client.py
@@ -46,6 +46,59 @@ async def get_workflow_run_details(workflow_run_id: str) -> object:
         raise RuntimeError(f"Failed to fetch workflow run '{workflow_run_id}': {exc}") from exc
 
 
+async def list_child_runs(parent_task_external_id: str, since: object | None = None) -> list:
+    """List workflow runs spawned by the given parent task.
+
+    ``since`` is a ``datetime`` (tz-aware) used as the lower bound of the
+    Hatchet search window. Defaults to ``now - 1 day``.
+    """
+    import logging
+    from datetime import datetime, timedelta, timezone
+
+    logger = logging.getLogger(__name__)
+    h = get_hatchet()
+    since_dt = since or (datetime.now(tz=timezone.utc) - timedelta(days=1))
+    try:
+        result = await h.runs.aio_list(
+            parent_task_external_id=parent_task_external_id,
+            since=since_dt,
+        )
+        return list(result.rows or [])
+    except Exception as exc:
+        logger.warning(
+            "Failed to list child runs for task %s: %s", parent_task_external_id, exc
+        )
+        raise RuntimeError(
+            f"Failed to list child runs for task '{parent_task_external_id}': {exc}"
+        ) from exc
+
+
+async def has_child_runs(parent_task_external_id: str, since: object | None = None) -> bool:
+    """Quick probe: does this task have at least one spawned child workflow run?
+
+    Returns ``False`` on any Hatchet error rather than raising, so it's safe to
+    call on every task in a polling loop.
+    """
+    import logging
+    from datetime import datetime, timedelta, timezone
+
+    logger = logging.getLogger(__name__)
+    h = get_hatchet()
+    since_dt = since or (datetime.now(tz=timezone.utc) - timedelta(days=1))
+    try:
+        result = await h.runs.aio_list(
+            parent_task_external_id=parent_task_external_id,
+            since=since_dt,
+            limit=1,
+        )
+        return bool(result.rows)
+    except Exception as exc:
+        logger.debug(
+            "has_child_runs probe failed for %s: %s", parent_task_external_id, exc
+        )
+        return False
+
+
 def _ensure_dict(input: dict | object) -> dict:
     """Coerce *input* to a plain dict.
 

--- a/libs/kt-hatchet/src/kt_hatchet/progress.py
+++ b/libs/kt-hatchet/src/kt_hatchet/progress.py
@@ -11,13 +11,18 @@ libs never import from services.
 
 from __future__ import annotations
 
+import asyncio
+from datetime import datetime
 from typing import Any
 
 
-def map_task_summary(task: Any) -> dict[str, Any]:
+def map_task_summary(task: Any, *, has_children: bool = False) -> dict[str, Any]:
     """Map a Hatchet ``V1TaskSummary`` to a ``PipelineTaskItem``-shaped dict.
 
-    The dict keys match the ``PipelineTaskItem`` Pydantic model fields.
+    ``has_children`` is set by callers that have probed for spawned child
+    workflow runs separately (``V1TaskSummary.children`` is typically empty
+    from ``aio_get``; spawned child workflow runs must be discovered via
+    ``runs.aio_list(parent_task_external_id=...)``).
     """
     status_str: str = task.status.value  # e.g. "COMPLETED", "RUNNING"
     if status_str == "COMPLETED":
@@ -28,7 +33,7 @@ def map_task_summary(task: Any) -> dict[str, Any]:
         started_at = task.started_at.isoformat()
 
     children: list[dict[str, Any]] = []
-    if task.children:
+    if getattr(task, "children", None):
         children = [map_task_summary(c) for c in task.children]
 
     return {
@@ -37,10 +42,58 @@ def map_task_summary(task: Any) -> dict[str, Any]:
         "status": status_str,
         "duration_ms": task.duration,
         "started_at": started_at,
+        "has_children": has_children or bool(children),
         "children": children,
         "wave_number": None,
         "node_type": None,
     }
+
+
+async def annotate_has_children(
+    items: list[dict[str, Any]], *, since: datetime | None = None
+) -> list[dict[str, Any]]:
+    """Probe each item's ``task_id`` for spawned child workflow runs in parallel.
+
+    Mutates ``has_children`` in place and returns the same list.
+    """
+    from kt_hatchet.client import has_child_runs
+
+    async def _probe(item: dict[str, Any]) -> None:
+        if item.get("has_children"):
+            return
+        item["has_children"] = await has_child_runs(item["task_id"], since=since)
+
+    if items:
+        await asyncio.gather(*(_probe(i) for i in items))
+    return items
+
+
+async def fetch_child_task_items(
+    parent_task_id: str, *, since: datetime | None = None
+) -> list[dict[str, Any]]:
+    """Fetch direct children of a task as ``PipelineTaskItem``-shaped dicts.
+
+    Lists spawned child workflow runs via ``list_child_runs``, then for each
+    calls ``aio_get`` to pull its tasks, mapping each to a dict. Populates
+    ``has_children`` on every returned item via a parallel probe.
+    """
+    from kt_hatchet.client import get_workflow_run_details, list_child_runs
+
+    runs = await list_child_runs(parent_task_id, since=since)
+
+    async def _fetch_run(run: Any) -> list[dict[str, Any]]:
+        run_id = run.metadata.id
+        try:
+            details = await get_workflow_run_details(run_id)
+        except Exception:
+            return []
+        tasks = getattr(details, "tasks", []) or []
+        return [map_task_summary(t) for t in tasks]
+
+    nested = await asyncio.gather(*(_fetch_run(r) for r in runs))
+    items: list[dict[str, Any]] = [t for group in nested for t in group]
+    await annotate_has_children(items, since=since)
+    return items
 
 
 def map_run_status(details: Any) -> str:

--- a/libs/kt-hatchet/src/kt_hatchet/progress.py
+++ b/libs/kt-hatchet/src/kt_hatchet/progress.py
@@ -49,9 +49,7 @@ def map_task_summary(task: Any, *, has_children: bool = False) -> dict[str, Any]
     }
 
 
-async def annotate_has_children(
-    items: list[dict[str, Any]], *, since: datetime | None = None
-) -> list[dict[str, Any]]:
+async def annotate_has_children(items: list[dict[str, Any]], *, since: datetime | None = None) -> list[dict[str, Any]]:
     """Probe each item's ``task_id`` for spawned child workflow runs in parallel.
 
     Mutates ``has_children`` in place and returns the same list.
@@ -68,9 +66,7 @@ async def annotate_has_children(
     return items
 
 
-async def fetch_child_task_items(
-    parent_task_id: str, *, since: datetime | None = None
-) -> list[dict[str, Any]]:
+async def fetch_child_task_items(parent_task_id: str, *, since: datetime | None = None) -> list[dict[str, Any]]:
     """Fetch direct children of a task as ``PipelineTaskItem``-shaped dicts.
 
     Lists spawned child workflow runs via ``list_child_runs``, then for each

--- a/libs/kt-hatchet/tests/test_progress.py
+++ b/libs/kt-hatchet/tests/test_progress.py
@@ -6,7 +6,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from kt_hatchet.progress import map_run_error, map_run_status, map_task_summary
+from kt_hatchet.progress import (
+    annotate_has_children,
+    fetch_child_task_items,
+    map_run_error,
+    map_run_status,
+    map_task_summary,
+)
 
 
 def _make_status(value: str) -> SimpleNamespace:
@@ -153,3 +159,60 @@ class TestMapRunError:
     def test_with_error(self) -> None:
         details = _make_details(error_message="task timed out")
         assert map_run_error(details) == "task timed out"
+
+
+# ---------------------------------------------------------------------------
+# annotate_has_children / fetch_child_task_items
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotateHasChildren:
+    @pytest.mark.asyncio
+    async def test_probes_in_parallel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        async def fake_has(parent_id: str, since: object | None = None) -> bool:
+            calls.append(parent_id)
+            return parent_id == "yes"
+
+        monkeypatch.setattr("kt_hatchet.client.has_child_runs", fake_has)
+
+        items = [
+            {"task_id": "yes", "has_children": False},
+            {"task_id": "no", "has_children": False},
+            {"task_id": "skip", "has_children": True},
+        ]
+        await annotate_has_children(items)
+        assert items[0]["has_children"] is True
+        assert items[1]["has_children"] is False
+        assert items[2]["has_children"] is True  # already set, not re-probed
+        assert "skip" not in calls
+
+
+class TestFetchChildTaskItems:
+    @pytest.mark.asyncio
+    async def test_lists_and_fetches_runs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run_row = SimpleNamespace(metadata=SimpleNamespace(id="child-run-1"))
+        child_task = _make_task(task_external_id="ct-1", display_name="node_create")
+        details = SimpleNamespace(tasks=[child_task])
+
+        async def fake_list(parent_id: str, since: object | None = None) -> list:
+            assert parent_id == "root-task"
+            return [run_row]
+
+        async def fake_get(run_id: str) -> object:
+            assert run_id == "child-run-1"
+            return details
+
+        async def fake_has(task_id: str, since: object | None = None) -> bool:
+            return task_id == "ct-1"
+
+        monkeypatch.setattr("kt_hatchet.client.list_child_runs", fake_list)
+        monkeypatch.setattr("kt_hatchet.client.get_workflow_run_details", fake_get)
+        monkeypatch.setattr("kt_hatchet.client.has_child_runs", fake_has)
+
+        items = await fetch_child_task_items("root-task")
+        assert len(items) == 1
+        assert items[0]["task_id"] == "ct-1"
+        assert items[0]["display_name"] == "node_create"
+        assert items[0]["has_children"] is True

--- a/services/api/src/kt_api/progress.py
+++ b/services/api/src/kt_api/progress.py
@@ -18,6 +18,7 @@ from kt_api.schemas import (
     PipelineTaskItem,
     ProgressResponse,
     ResearchReportResponse,
+    TaskChildrenResponse,
 )
 from kt_db.repositories.conversations import ConversationRepository
 from kt_db.repositories.research_reports import ResearchReportRepository
@@ -27,12 +28,31 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1", tags=["progress"])
 
 
-def _build_task_items(details: object) -> list[PipelineTaskItem]:
-    """Convert Hatchet V1WorkflowRunDetails.tasks to PipelineTaskItem list."""
-    from kt_hatchet.progress import map_task_summary
+def _run_since(details: object) -> object | None:
+    """Extract a safe ``since`` datetime from run details for child-run listing."""
+    from datetime import timedelta
+
+    created = getattr(getattr(details, "run", None), "created_at", None)
+    if created is None:
+        return None
+    try:
+        return created - timedelta(hours=1)
+    except Exception:
+        return None
+
+
+async def _build_task_items(details: object) -> list[PipelineTaskItem]:
+    """Convert Hatchet V1WorkflowRunDetails.tasks to PipelineTaskItem list.
+
+    Probes every top-level task for spawned child workflow runs so the UI can
+    render a chevron without a second roundtrip.
+    """
+    from kt_hatchet.progress import annotate_has_children, map_task_summary
 
     tasks: list = getattr(details, "tasks", []) or []
-    return [PipelineTaskItem(**map_task_summary(t)) for t in tasks]
+    items = [map_task_summary(t) for t in tasks]
+    await annotate_has_children(items, since=_run_since(details))
+    return [PipelineTaskItem(**i) for i in items]
 
 
 @router.get(
@@ -69,7 +89,7 @@ async def get_message_progress(
             details = await get_workflow_run_details(msg.workflow_run_id)
             status = map_run_status(details)
             error = error or map_run_error(details)
-            task_items = _build_task_items(details)
+            task_items = await _build_task_items(details)
         except RuntimeError:
             logger.debug(
                 "Hatchet unavailable for run %s, falling back to DB status",
@@ -78,6 +98,7 @@ async def get_message_progress(
 
     return ProgressResponse(
         message_id=str(msg.id),
+        workflow_run_id=msg.workflow_run_id,
         status=status,
         content=msg.content or "",
         error=error,
@@ -148,10 +169,43 @@ async def get_workflow_progress(
             message_id="",
             workflow_run_id=workflow_run_id,
             status=map_run_status(details),
-            tasks=_build_task_items(details),
+            tasks=await _build_task_items(details),
         )
     except RuntimeError:
         raise HTTPException(
             status_code=502,
             detail="Unable to fetch workflow status from Hatchet",
         )
+
+
+@router.get(
+    "/workflows/{workflow_run_id}/tasks/{task_id}/children",
+    response_model=TaskChildrenResponse,
+)
+async def get_task_children(
+    workflow_run_id: str,
+    task_id: str,
+) -> TaskChildrenResponse:
+    """Lazy-fetch direct children of a Hatchet task.
+
+    Lists spawned child workflow runs whose parent_task_external_id matches
+    ``task_id``, then returns their root tasks. Each returned item is itself
+    probed for grandchildren (``has_children``) so the UI can recurse.
+    """
+    from kt_hatchet.client import get_workflow_run_details
+    from kt_hatchet.progress import fetch_child_task_items
+
+    since = None
+    try:
+        details = await get_workflow_run_details(workflow_run_id)
+        since = _run_since(details)
+    except RuntimeError:
+        pass  # Fall back to default (now - 1 day) inside list_child_runs.
+
+    try:
+        items = await fetch_child_task_items(task_id, since=since)
+    except RuntimeError as exc:
+        logger.warning("fetch_child_task_items failed for %s: %s", task_id, exc)
+        raise HTTPException(status_code=502, detail="Unable to fetch task children")
+
+    return TaskChildrenResponse(tasks=[PipelineTaskItem(**i) for i in items])

--- a/services/api/src/kt_api/schemas.py
+++ b/services/api/src/kt_api/schemas.py
@@ -577,10 +577,17 @@ class PipelineTaskItem(BaseModel):
     started_at: str | None = None  # ISO 8601
     wave_number: int | None = None  # Only set for explore_scope tasks
     node_type: str | None = None  # "concept" | "entity" | "event" | "perspective" etc.
+    has_children: bool = False
     children: list["PipelineTaskItem"] = Field(default_factory=list)
 
 
 PipelineTaskItem.model_rebuild()
+
+
+class TaskChildrenResponse(BaseModel):
+    """Children of a single Hatchet task (spawned child workflow runs)."""
+
+    tasks: list[PipelineTaskItem] = Field(default_factory=list)
 
 
 class PipelineSnapshotResponse(BaseModel):
@@ -604,6 +611,7 @@ class ProgressResponse(BaseModel):
     """
 
     message_id: str
+    workflow_run_id: str | None = None
     status: str  # "pending" | "running" | "completed" | "failed"
     content: str  # answer text (empty while running)
     error: str | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -1663,7 +1663,7 @@ wheels = [
 
 [[package]]
 name = "knowledge-tree-workspace"
-version = "0.50.1"
+version = "0.50.8"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- Backend: new `GET /workflows/{run_id}/tasks/{task_id}/children` endpoint that lazy-fetches spawned child workflow runs via `runs.aio_list(parent_task_external_id)` + `runs.aio_get`; progress response now carries `has_children` on each task (parallel probe) and `workflow_run_id` on the message progress payload.
- Frontend: recursive `TaskRow` component in `ResearchBuildProgress` — collapsed by default, lazy-loads direct children on first expand, caches afterwards, shows a count badge once loaded.
- Fixes grow-graph view where only the root Hatchet task (e.g. `handle_decompose-*`) showed because spawned child workflow runs live in separate Hatchet runs that `runs.aio_get(root_run_id)` does not return.

## Test plan
- [x] `uv run pytest libs/kt-hatchet/tests/test_progress.py -x` (new tests for `annotate_has_children` and `fetch_child_task_items`)
- [x] `uv run pytest services/api/tests/ -x --ignore=tests/integration`
- [x] `pnpm lint && pnpm type-check && pnpm test`
- [ ] Manual: start `just up-all` + `pnpm dev`, trigger a web research or file ingest on `/grow-graph`, verify root row shows chevron, expanding lazy-loads subtasks, leaves show none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)